### PR TITLE
Use BlazeSymbolizer in addr2ln.

### DIFF
--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -1,6 +1,6 @@
 extern crate blazesym;
 
-use blazesym::dwarf::DwarfResolver;
+use blazesym::{BlazeSymbolizer, SymbolSrcCfg};
 use std::env;
 
 fn show_usage() {
@@ -18,6 +18,11 @@ fn main() {
 
     let bin_name = &args[1];
     let mut addr_str = &args[2][..];
+    let sym_srcs = [SymbolSrcCfg::Elf {
+        file_name: bin_name.clone(),
+        base_address: 0x0,
+    }];
+    let resolver = BlazeSymbolizer::new().unwrap();
 
     if &addr_str[0..2] == "0x" {
         // Remove prefixed 0x
@@ -25,9 +30,13 @@ fn main() {
     }
     let addr = u64::from_str_radix(addr_str, 16).unwrap();
 
-    let resolver = DwarfResolver::open_for_addresses(bin_name, &[addr]).unwrap();
-    if let Some((dir, file, line)) = resolver.find_line(addr) {
-        println!("0x{:x} @ {}/{}:{}", addr, dir, file, line);
+    let results = resolver.symbolize(&sym_srcs, &[addr]);
+    if results.len() == 1 && results[0].len() > 0 {
+        let result = &results[0][0];
+        println!(
+            "0x{:x} @ {} {}:{}",
+            addr, result.symbol, result.path, result.line_no
+        );
     } else {
         println!("0x{:x} is not found", addr);
     }


### PR DESCRIPTION
Use BlazeSymbolizer instead of DwarfResolver.  DwarfResolver is an
internal API.
