### PR TITLE
Remove the order check of CU start addresses.

### DIFF
--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -891,19 +891,6 @@ impl DwarfResolver {
         }
         addr_to_dlcu.sort_by_key(|v| v.0);
 
-        #[cfg(debug_assertions)]
-        for i in 1..addr_to_dlcu.len() {
-            if addr_to_dlcu[i].0 <= addr_to_dlcu[i - 1].0 {
-                panic!(
-                    "CU's start address should be in strict order: [{}] 0x{:x} [{}] 0x{:x}",
-                    i - 1,
-                    addr_to_dlcu[i - 1].0,
-                    i,
-                    addr_to_dlcu[i].0
-                );
-            }
-        }
-
         Ok(DwarfResolver {
             parser,
             debug_line_cus,


### PR DESCRIPTION
Issue #8 raises the issue that the debug build will crash for checking the order of CU start addresses.  However, this check is not valid anymore since we sort the list of CUs.  In the future, we will support returning multiple symbols and line numbers.  So, this check is either unnecessary or too strict.

Signed-off-by: Kui-Feng Lee <kuifeng@fb.com>