### PR TITLE
Fix the linking parameters order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ BlazeSym.  Refer to the “Build” section to generate `"blazesym.h"`.
 You also need the following arguments to link against BlazeSym.
 
 ```text
-	-lrt -ldl -lpthread -lm libblazesym.a
+	libblazesym.a -lrt -ldl -lpthread -lm
 ```
 
 You may want to link a shared library, i.e., `libblazesym.so`.


### PR DESCRIPTION
Issue #7 mentioned about link errors about the order of parameters sugguested in the README. libblazesym.a should go first before its dependencies.

Signed-off-by: Kui-Feng Lee <kuifeng@fb.com>