### PR TITLE
Fix that ElfResolver returned extra unnecessary symbols.

### DIFF
--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -1032,9 +1032,11 @@ impl DwarfResolver {
         if let SymbolType::Variable = opts.sym_type {
             return Err(Error::new(ErrorKind::Unsupported, "Not implemented"));
         }
-        let r = self.parser.find_address(name, opts);
-        if r.is_ok() {
-            return r;
+        let elf_r = self.parser.find_address(name, opts)?;
+        if !elf_r.is_empty() {
+            // Since it is found from symtab, symtab should be
+            // complete and DWARF shouldn't provide more information.
+            return Ok(elf_r);
         }
 
         self.ensure_debug_info_syms()?;

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -672,6 +672,14 @@ impl Elf64Parser {
 
                 let mut found = vec![];
                 for idx in idx..str2symtab.len() {
+                    let name_visit = unsafe {
+                        CStr::from_ptr(&strtab[str2symtab[idx].0] as *const u8 as *const i8)
+                            .to_str()
+                            .unwrap()
+                    };
+                    if !name_visit.eq(name) {
+                        break;
+                    }
                     let sym_i = str2symtab[idx].1;
                     let sym_ref = &me.symtab.as_ref().unwrap()[sym_i];
                     if !sym_ref.is_undef() {
@@ -902,7 +910,8 @@ mod tests {
             obj_file_name: false,
             sym_type: SymbolType::Unknown,
         };
-        let addr_r = parser.find_address(sym_name, &opts);
-        assert!(addr_r.unwrap().iter().any(|x| x.address == addr));
+        let addr_r = parser.find_address(sym_name, &opts).unwrap();
+        assert_eq!(addr_r.len(), 1);
+        assert!(addr_r.iter().any(|x| x.address == addr));
     }
 }


### PR DESCRIPTION
The changes of returning multiple symbols didn't stop properly.  It causes returning additional unwanted symbols.  By checking symbol names, it will stop properly to get a correct list of symbols.

Signed-off-by: Kui-Feng Lee <kuifeng@fb.com>