### PR TITLE
fix build on MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib", "staticlib"]
 nix = "0.24"
 regex = "1.6"
 crossbeam-channel = "0.5"
+libc = "0.2.137"
 
 [build-dependencies]
 cbindgen = "0.24"

--- a/src/elf_cache.rs
+++ b/src/elf_cache.rs
@@ -58,10 +58,10 @@ struct ElfCacheEntry {
 
     file_name: String,
 
-    dev: u64,
-    inode: u64,
-    size: i64,
-    mtime_sec: i64,
+    dev: libc::dev_t,
+    inode: libc::ino_t,
+    size: libc::off_t,
+    mtime_sec: libc::time_t,
     mtime_nsec: i64,
     backend: ElfBackend,
 }


### PR DESCRIPTION
Currently running `cargo check` on a MacOS produces the following errors:
```
error[E0308]: mismatched types
  --> src/elf_cache.rs:93:18
   |
93 |             dev: stat.st_dev,
   |                  ^^^^^^^^^^^ expected `u64`, found `i32`

error[E0308]: mismatched types
   --> src/elf_cache.rs:107:24
    |
107 |         stat.st_dev == self.dev
    |                        ^^^^^^^^ expected `i32`, found `u64`
    |
help: you can convert a `u64` to an `i32` and panic if the converted value doesn't fit
    |
107 |         stat.st_dev == self.dev.try_into().unwrap()
    |                                ++++++++++++++++++++

For more information about this error, try `rustc --explain E0308`.
error: could not compile `blazesym` due to 2 previous errors
```

This PR fixes them by adding casts and allows for a clean build.