### PR TITLE
Remove dwarf_perf feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ cbindgen = "0.24"
 
 [features]
 cheader = []
-# Show performance numbers of DWARF parser.
-dwarf_perf = []
 # Enable code paths requiring a nightly toolchain. This feature is only meant to
 # be used for testing and benchmarking purposes, not for the core library, which
 # is expected to work on stable.

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -11,9 +11,6 @@ use std::iter::Iterator;
 use std::mem;
 use std::rc::Rc;
 
-#[cfg(feature = "dwarf_perf")]
-use std::time::Instant;
-
 #[cfg(test)]
 use std::env;
 
@@ -1222,9 +1219,6 @@ fn debug_info_parse_symbols<'a>(
     let str_sect_idx = parser.find_section(".debug_str")?;
     let str_data = parser.read_section_raw_cache(str_sect_idx)?;
 
-    #[cfg(feature = "dwarf_perf")]
-    let now = Instant::now();
-
     let mut syms = Vec::<DWSymInfo>::new();
 
     if nthreads > 1 {
@@ -1311,12 +1305,6 @@ fn debug_info_parse_symbols<'a>(
             }
         }
     }
-    #[cfg(feature = "dwarf_perf")]
-    println!(
-        "debug_info_parse_symbols elapse {} us",
-        now.elapsed().as_micros()
-    );
-
     Ok(syms)
 }
 


### PR DESCRIPTION
As per the discussion over in
https://github.com/libbpf/blazesym/pull/25, now that we have a benchmark covering the DWARF parsing code path, we can stop relying on the dwarf_perf feature. Remove it.

Signed-off-by: Daniel Müller <deso@posteo.net>