### PR TITLE
Remove unused Symbol type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -781,12 +781,6 @@ impl ResolverMap {
     }
 }
 
-#[allow(dead_code)]
-struct Symbol {
-    pub name: String,
-    pub addr: u64,
-}
-
 /// Switches in the features of BlazeSymbolizer.
 ///
 /// Passing variants of this `enum` to [`BlazeSymbolizer::new_opt()`]


### PR DESCRIPTION
The Symbol type is unused. Remove it.

Signed-off-by: Daniel Müller <deso@posteo.net>