### PR TITLE
Declare test-only functionality as test-only

### DIFF
--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -34,102 +34,6 @@ pub struct ArangesCU {
     pub aranges: Vec<(u64, u64)>,
 }
 
-fn parse_aranges_cu(data: &[u8]) -> Result<(ArangesCU, usize), Error> {
-    if data.len() < 12 {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
-            "invalid arange header (too small)",
-        ));
-    }
-    let len = decode_uword(data);
-    let version = decode_uhalf(&data[4..]);
-    let offset = decode_uword(&data[6..]);
-    let addr_sz = data[10];
-    let _seg_sz = data[11];
-
-    if data.len() < (len + 4) as usize {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
-            "data is broken (too small)",
-        ));
-    }
-
-    // Size of the header
-    let mut pos = 12;
-
-    // Padding to align with the size of addresses on the target system.
-    pos += addr_sz as usize - 1;
-    pos -= pos % addr_sz as usize;
-
-    let mut aranges = Vec::<(u64, u64)>::new();
-    match addr_sz {
-        4 => {
-            while pos < (len + 4 - 8) as usize {
-                let start = decode_uword(&data[pos..]);
-                pos += 4;
-                let size = decode_uword(&data[pos..]);
-                pos += 4;
-
-                if start == 0 && size == 0 {
-                    break;
-                }
-                aranges.push((start as u64, size as u64));
-            }
-        }
-        8 => {
-            while pos < (len + 4 - 16) as usize {
-                let start = decode_udword(&data[pos..]);
-                pos += 8;
-                let size = decode_udword(&data[pos..]);
-                pos += 8;
-
-                if start == 0 && size == 0 {
-                    break;
-                }
-                aranges.push((start, size));
-            }
-        }
-        _ => {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                format!(
-                    "unsupported address size {} ver {} off 0x{:x}",
-                    addr_sz, version, offset
-                ),
-            ));
-        }
-    }
-
-    Ok((
-        ArangesCU {
-            debug_line_off: offset as usize,
-            aranges,
-        },
-        len as usize + 4,
-    ))
-}
-
-fn parse_aranges_elf_parser(parser: &Elf64Parser) -> Result<Vec<ArangesCU>, Error> {
-    let debug_aranges_idx = parser.find_section(".debug_aranges")?;
-
-    let raw_data = parser.read_section_raw(debug_aranges_idx)?;
-
-    let mut pos = 0;
-    let mut acus = Vec::<ArangesCU>::new();
-    while pos < raw_data.len() {
-        let (acu, bytes) = parse_aranges_cu(&raw_data[pos..])?;
-        acus.push(acu);
-        pos += bytes;
-    }
-
-    Ok(acus)
-}
-
-pub fn parse_aranges_elf(filename: &str) -> Result<Vec<ArangesCU>, Error> {
-    let parser = Elf64Parser::open(filename)?;
-    parse_aranges_elf_parser(&parser)
-}
-
 #[repr(packed)]
 struct DebugLinePrologueV2 {
     total_length: u32,
@@ -796,12 +700,6 @@ fn parse_debug_line_elf_parser(
     Ok(all_cus)
 }
 
-#[allow(dead_code)]
-fn parse_debug_line_elf(filename: &str) -> Result<Vec<DebugLineCU>, Error> {
-    let parser = Elf64Parser::open(filename)?;
-    parse_debug_line_elf_parser(&parser, &[])
-}
-
 /// DwarfResolver provide abilities to query DWARF information of binaries.
 pub struct DwarfResolver {
     parser: Rc<Elf64Parser>,
@@ -1328,6 +1226,107 @@ mod tests {
     use test::Bencher;
 
     use crate::tools::{decode_shalf, decode_sword};
+
+    fn parse_debug_line_elf(filename: &str) -> Result<Vec<DebugLineCU>, Error> {
+        let parser = Elf64Parser::open(filename)?;
+        parse_debug_line_elf_parser(&parser, &[])
+    }
+
+    fn parse_aranges_cu(data: &[u8]) -> Result<(ArangesCU, usize), Error> {
+        if data.len() < 12 {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "invalid arange header (too small)",
+            ));
+        }
+        let len = decode_uword(data);
+        let version = decode_uhalf(&data[4..]);
+        let offset = decode_uword(&data[6..]);
+        let addr_sz = data[10];
+        let _seg_sz = data[11];
+
+        if data.len() < (len + 4) as usize {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "data is broken (too small)",
+            ));
+        }
+
+        // Size of the header
+        let mut pos = 12;
+
+        // Padding to align with the size of addresses on the target system.
+        pos += addr_sz as usize - 1;
+        pos -= pos % addr_sz as usize;
+
+        let mut aranges = Vec::<(u64, u64)>::new();
+        match addr_sz {
+            4 => {
+                while pos < (len + 4 - 8) as usize {
+                    let start = decode_uword(&data[pos..]);
+                    pos += 4;
+                    let size = decode_uword(&data[pos..]);
+                    pos += 4;
+
+                    if start == 0 && size == 0 {
+                        break;
+                    }
+                    aranges.push((start as u64, size as u64));
+                }
+            }
+            8 => {
+                while pos < (len + 4 - 16) as usize {
+                    let start = decode_udword(&data[pos..]);
+                    pos += 8;
+                    let size = decode_udword(&data[pos..]);
+                    pos += 8;
+
+                    if start == 0 && size == 0 {
+                        break;
+                    }
+                    aranges.push((start, size));
+                }
+            }
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::Unsupported,
+                    format!(
+                        "unsupported address size {} ver {} off 0x{:x}",
+                        addr_sz, version, offset
+                    ),
+                ));
+            }
+        }
+
+        Ok((
+            ArangesCU {
+                debug_line_off: offset as usize,
+                aranges,
+            },
+            len as usize + 4,
+        ))
+    }
+
+    fn parse_aranges_elf_parser(parser: &Elf64Parser) -> Result<Vec<ArangesCU>, Error> {
+        let debug_aranges_idx = parser.find_section(".debug_aranges")?;
+
+        let raw_data = parser.read_section_raw(debug_aranges_idx)?;
+
+        let mut pos = 0;
+        let mut acus = Vec::<ArangesCU>::new();
+        while pos < raw_data.len() {
+            let (acu, bytes) = parse_aranges_cu(&raw_data[pos..])?;
+            acus.push(acu);
+            pos += bytes;
+        }
+
+        Ok(acus)
+    }
+
+    fn parse_aranges_elf(filename: &str) -> Result<Vec<ArangesCU>, Error> {
+        let parser = Elf64Parser::open(filename)?;
+        parse_aranges_elf_parser(&parser)
+    }
 
     #[test]
     fn test_decode_leb128() {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -743,7 +743,8 @@ impl Elf64Parser {
         Ok(me.symtab.as_ref().unwrap().len())
     }
 
-    pub fn get_symbol(&self, idx: usize) -> Result<&Elf64_Sym, Error> {
+    #[cfg(test)]
+    fn get_symbol(&self, idx: usize) -> Result<&Elf64_Sym, Error> {
         self.ensure_symtab()?;
 
         let me = self.backobj.as_ptr();
@@ -757,7 +758,8 @@ impl Elf64Parser {
         Ok(unsafe { &(*me).symtab_origin.as_mut().unwrap()[idx] })
     }
 
-    pub fn get_symbol_name(&self, idx: usize) -> Result<&str, Error> {
+    #[cfg(test)]
+    fn get_symbol_name(&self, idx: usize) -> Result<&str, Error> {
         let sym = self.get_symbol(idx)?;
 
         let me = self.backobj.as_ptr();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -221,6 +221,7 @@ pub fn decode_uhalf(data: &[u8]) -> u16 {
     (data[0] as u16) | ((data[1] as u16) << 8)
 }
 
+#[cfg(test)]
 #[inline(always)]
 pub fn decode_shalf(data: &[u8]) -> i16 {
     let uh = decode_uhalf(data);
@@ -236,7 +237,7 @@ pub fn decode_uword(data: &[u8]) -> u32 {
     (data[0] as u32) | ((data[1] as u32) << 8) | ((data[2] as u32) << 16) | ((data[3] as u32) << 24)
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 #[inline(always)]
 pub fn decode_sword(data: &[u8]) -> i32 {
     let uw = decode_uword(data);


### PR DESCRIPTION
If functionality is only used by tests we should declare it as such. Marking it as dead will cause it to longer around in the code base forever, even if not referenced anywhere.

Signed-off-by: Daniel Müller <deso@posteo.net>