### PR TITLE
Use `PathBuf`/`Path` instead of `String`/`str` for representing paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ argument passed to [`BlazeSymbolizer::symbolize()`].
 
 ```rust,ignore,compile_fail
 	let sym_srcs = [SymbolSrcCfg::Kernel {
-		kallsyms: Some("/proc/kallsyms".to_string()),
-		kernel_image: Some("/boot/vmlinux-xxxxx".to_string()),
+		kallsyms: Some(PathBuf::from("/proc/kallsyms")),
+		kernel_image: Some(PathBuf::from("/boot/vmlinux-xxxxx")),
 	}];
 ```
 
@@ -112,9 +112,9 @@ potential directories; for instance, `"/boot/"` and `"/usr/lib/debug/boot/"`.
 You can still provide a list of ELF files and their base addresses if necessary.
 
 ```rust,ignore,compile_fail
-	let sym_srcs = [SymbolSrcCfg::Elf { file_name: String::from("/lib/libc.so.xxx"),
+	let sym_srcs = [SymbolSrcCfg::Elf { file_name: PathBuf::from("/lib/libc.so.xxx"),
 	                                    base_address: 0x1f005d },
-	                SymbolSrcCfg::Elf { fie_name: String::from("/path/to/my/binary"),
+	                SymbolSrcCfg::Elf { fie_name: PathBuf::from("/path/to/my/binary"),
 	                                    base_address: 0x77777 },
 	                ......
 	];

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -2,6 +2,7 @@ extern crate blazesym;
 
 use blazesym::{BlazeSymbolizer, SymbolSrcCfg};
 use std::env;
+use std::path;
 
 fn show_usage() {
     let args: Vec<String> = env::args().collect();
@@ -19,7 +20,7 @@ fn main() {
     let bin_name = &args[1];
     let mut addr_str = &args[2][..];
     let sym_srcs = [SymbolSrcCfg::Elf {
-        file_name: bin_name.clone(),
+        file_name: path::PathBuf::from(bin_name),
         base_address: 0x0,
     }];
     let resolver = BlazeSymbolizer::new().unwrap();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,6 +1,7 @@
 use std::ffi::CStr;
 use std::fs;
 use std::io::{BufRead, BufReader, Error, ErrorKind};
+use std::path::PathBuf;
 
 use regex::Regex;
 
@@ -119,7 +120,7 @@ pub struct LinuxMapsEntry {
     pub end_address: u64,
     pub mode: u8,
     pub offset: u64,
-    pub path: String,
+    pub path: PathBuf,
 }
 
 #[allow(dead_code)]
@@ -173,7 +174,7 @@ pub fn parse_maps(pid: u32) -> Result<Vec<LinuxMapsEntry>, Error> {
                 end_address,
                 mode,
                 offset,
-                path: path_str,
+                path: PathBuf::from(path_str),
             };
             entries.push(entry);
         }


### PR DESCRIPTION
This change switches the library over to using `PathBuf`/`Path` instead of `String`/`str` for representing paths. Strings are overly strong in their assertions, in that they enforce UTF-8 encoding, which is not necessarily required for paths. It's also the correct thing to do, as it allows us to use native path manipulations. The conversion is fairly straight forward and mechanical. It's also pretty much fully compiler checked (modulo, perhaps, unsafe portions using pointer dances).

Signed-off-by: Daniel Müller <deso@posteo.net>