### PR TITLE
Remove more unused code or declare it test only

### DIFF
--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -21,15 +21,10 @@ use std::thread;
 
 use regex::Regex;
 
-#[allow(non_upper_case_globals)]
+#[allow(non_upper_case_globals, unused)]
 mod constants;
 #[allow(non_upper_case_globals)]
 mod debug_info;
-
-pub struct ArangesCU {
-    pub debug_line_off: usize,
-    pub aranges: Vec<(u64, u64)>,
-}
 
 #[repr(C, packed)]
 struct DebugLinePrologueV2 {
@@ -749,7 +744,8 @@ impl DwarfResolver {
     /// from the given file.  If the instance will be used for long
     /// running, you would want to load all data into memory to have
     /// the ability of handling all possible addresses.
-    pub fn open_for_addresses(
+    #[cfg(test)]
+    fn open_for_addresses(
         filename: &str,
         addresses: &[u64],
         line_number_info: bool,
@@ -768,7 +764,8 @@ impl DwarfResolver {
     ///
     /// `filename` is the name of an ELF binary/or shared object that
     /// has .debug_line section.
-    pub fn open(
+    #[cfg(test)]
+    fn open(
         filename: &str,
         debug_line_info: bool,
         debug_info_symbols: bool,
@@ -802,7 +799,8 @@ impl DwarfResolver {
     ///
     /// This function is pretty much the same as `find_line_as_ref()`
     /// except returning a copies of `String` instead of `&str`.
-    pub fn find_line(&self, address: u64) -> Option<(String, String, usize)> {
+    #[cfg(test)]
+    fn find_line(&self, address: u64) -> Option<(String, String, usize)> {
         let (dir, file, line_no) = self.find_line_as_ref(address)?;
         Some((String::from(dir), String::from(file), line_no))
     }
@@ -1214,6 +1212,12 @@ mod tests {
     fn parse_debug_line_elf(filename: &str) -> Result<Vec<DebugLineCU>, Error> {
         let parser = Elf64Parser::open(filename)?;
         parse_debug_line_elf_parser(&parser, &[])
+    }
+
+    #[allow(unused)]
+    struct ArangesCU {
+        debug_line_off: usize,
+        aranges: Vec<(u64, u64)>,
     }
 
     fn parse_aranges_cu(data: &[u8]) -> Result<(ArangesCU, usize), Error> {

--- a/src/dwarf/debug_info.rs
+++ b/src/dwarf/debug_info.rs
@@ -33,6 +33,7 @@ fn decode_3bytes_usigned(data: &[u8]) -> u32 {
     data[0] as u32 | ((data[1] as u32) << 8) | ((data[2] as u32) << 16)
 }
 
+#[allow(unused)]
 pub struct UnknownHeader {
     init_length: usize,
     bits64: bool,
@@ -41,6 +42,7 @@ pub struct UnknownHeader {
     hdr_size: usize,
 }
 
+#[allow(unused)]
 pub struct CUHeaderV5 {
     init_length: usize,
     bits64: bool,
@@ -51,6 +53,7 @@ pub struct CUHeaderV5 {
     hdr_size: usize,
 }
 
+#[allow(unused)]
 pub struct CUHeaderV4 {
     init_length: usize,
     bits64: bool,
@@ -194,7 +197,6 @@ fn parse_abbrev_attr(data: &[u8]) -> Option<(u8, u8, u128, usize)> {
 
 #[derive(Clone)]
 pub enum AttrValue<'a> {
-    Signed(i64),
     Signed128(i128),
     Unsigned(u64),
     Unsigned128(u128),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -893,40 +893,6 @@ impl BlazeSymbolizer {
         })
     }
 
-    #[allow(dead_code)]
-    fn find_address(
-        &self,
-        sym_srcs: &[SymbolSrcCfg],
-        name: &str,
-        opts: &FindAddrOpts,
-    ) -> Option<Vec<SymbolInfo>> {
-        let resolver_map = ResolverMap::new(sym_srcs, &self.cache_holder).ok()?;
-        let mut found = vec![];
-        for (_, resolver) in resolver_map.resolvers {
-            if let Some(mut syms) = resolver.find_address(name, opts) {
-                for sym in &mut syms {
-                    if opts.offset_in_file {
-                        if let Some(off) = resolver.addr_file_off(sym.address) {
-                            sym.file_offset = off;
-                        }
-                    }
-                    if opts.obj_file_name {
-                        sym.obj_file_name = Some(resolver.get_obj_file_name().to_path_buf());
-                    }
-                }
-                found.append(&mut syms);
-            }
-        }
-        Some(found)
-    }
-
-    #[allow(dead_code)]
-    fn find_line_info(&self, sym_srcs: &[SymbolSrcCfg], addr: u64) -> Option<AddressLineInfo> {
-        let resolver_map = ResolverMap::new(sym_srcs, &self.cache_holder).ok()?;
-        let resolver = resolver_map.find_resolver(addr)?;
-        resolver.find_line_info(addr)
-    }
-
     fn find_addr_features_context(features: Vec<FindAddrFeature>) -> FindAddrOpts {
         let mut opts = FindAddrOpts {
             offset_in_file: false,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -256,14 +256,3 @@ pub fn decode_sword(data: &[u8]) -> i32 {
 pub fn decode_udword(data: &[u8]) -> u64 {
     decode_uword(data) as u64 | ((decode_uword(&data[4..]) as u64) << 32)
 }
-
-#[allow(dead_code)]
-#[inline(always)]
-pub fn decode_swdord(data: &[u8]) -> i64 {
-    let udw = decode_udword(data);
-    if udw >= 0x8000000000000000 {
-        ((udw as i128) - 0x10000000000000000) as i64
-    } else {
-        udw as i64
-    }
-}


### PR DESCRIPTION
Remove more unused code or declare it test only so that we can eventually remove global allowance of the `dead_code` lint. If we need some of the removed functionality we can always get it back from version control, as discussed in person.

Signed-off-by: Daniel Müller <deso@posteo.net>