### PR TITLE
Parse the line table of GSYM files.

### DIFF
--- a/src/gsym.rs
+++ b/src/gsym.rs
@@ -5,10 +5,13 @@ use std::path::{Path, PathBuf};
 
 use super::{AddressLineInfo, FindAddrOpts, SymResolver, SymbolInfo};
 
+mod linetab;
 mod parser;
 mod types;
 
-use parser::{find_address, GsymContext};
+use linetab::{line_table_row_from, run_op, RunResult};
+use parser::{find_address, parse_address_data, parse_line_table_header, GsymContext};
+use types::InfoTypeLineTableInfo;
 
 /// The symbol resolver for the GSYM format.
 pub struct GsymResolver {
@@ -74,6 +77,93 @@ impl SymResolver for GsymResolver {
         None
     }
 
+    /// Finds the source code location for a given address.
+    ///
+    /// This function takes in an address and returns the file path,
+    /// line number and column of the line in the source code where
+    /// the address corresponds to. If it doesn't find any match it
+    /// returns None.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - A 64-bit unsigned integer representing the address to find the source code location for.
+    ///
+    /// # Returns
+    ///
+    /// `Some(AddressLineInfo)` if the location is found, otherwise `None`.
+    ///
+    fn find_line_info(&self, addr: u64) -> Option<AddressLineInfo> {
+        let addr = addr - self.loaded_address;
+        let idx = find_address(&self.ctx, addr);
+        let symaddr = self.ctx.addr_at(idx);
+        if addr < symaddr {
+            return None;
+        }
+        let addrinfo = self.ctx.addr_info(idx);
+        if addr >= (symaddr + addrinfo.size as u64) {
+            return None;
+        }
+
+        let addrdatas = parse_address_data(addrinfo.data);
+        for adr_ent in addrdatas {
+            if adr_ent.typ != InfoTypeLineTableInfo {
+                continue;
+            }
+            // Continue to execute all GSYM line table operations
+            // until the end of the buffer is reached or a row
+            // containing addr is located.
+            let (lntab_hdr, hdr_bytes) = parse_line_table_header(adr_ent.data).ok()?;
+            let ops = &adr_ent.data[hdr_bytes..];
+            let mut lntab_row = line_table_row_from(&lntab_hdr, symaddr);
+            let mut last_lntab_row = lntab_row.clone();
+            let mut row_cnt = 0;
+            let mut pc = 0;
+            while pc < ops.len() {
+                match run_op(&mut lntab_row, &lntab_hdr, ops, pc) {
+                    RunResult::Ok(bytes) => {
+                        pc += bytes;
+                    }
+                    RunResult::NewRow(bytes) => {
+                        pc += bytes;
+                        row_cnt += 1;
+                        if addr < lntab_row.address {
+                            if row_cnt == 1 {
+                                // The address is lower than the first row.
+                                return None;
+                            }
+                            // Rollback to the last row.
+                            lntab_row = last_lntab_row;
+                            break;
+                        }
+                        last_lntab_row = lntab_row.clone();
+                    }
+                    RunResult::End | RunResult::Err => {
+                        break;
+                    }
+                }
+            }
+
+            if row_cnt == 0 {
+                continue;
+            }
+
+            let finfo = self.ctx.file_info(lntab_row.file_idx as usize);
+            let dirname = self.ctx.get_str(finfo.directory as usize);
+            let filename = self.ctx.get_str(finfo.filename as usize);
+            let path = Path::new(dirname)
+                .join(filename)
+                .to_str()
+                .unwrap()
+                .to_string();
+            return Some(AddressLineInfo {
+                path,
+                line_no: lntab_row.file_line as usize,
+                column: 0,
+            });
+        }
+        None
+    }
+
     fn addr_file_off(&self, _addr: u64) -> Option<u64> {
         // Unavailable
         None
@@ -83,11 +173,37 @@ impl SymResolver for GsymResolver {
         &self.file_name
     }
 
-    fn find_line_info(&self, _addr: u64) -> Option<AddressLineInfo> {
-        None
-    }
-
     fn repr(&self) -> String {
         format!("GSYM {:?}", self.file_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_find_line_info() {
+        let args: Vec<String> = env::args().collect();
+        let bin_name = &args[0];
+        let test_gsym = Path::new(bin_name)
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("data")
+            .join("test.gsym");
+        let resolver = GsymResolver::new(test_gsym, 0).unwrap();
+
+        let linfo = resolver.find_line_info(0x0000000002000001);
+        assert!(linfo.is_some());
+        let linfo = linfo.unwrap();
+        assert_eq!(linfo.line_no, 49);
+        assert!(linfo.path.ends_with("gsym-example.c"));
     }
 }

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -1,0 +1,119 @@
+//! Opcode runner of GSYM line table.
+//!
+//! See <https://github.com/YtnbFirewings/gsym>
+use super::types::{LineTableHeader, LineTableRow};
+use crate::tools::{decode_leb128, decode_leb128_s};
+
+const DBG_END_SEQUENCE: u8 = 0x00; // End of the line table
+const DBG_SET_FILE: u8 = 0x01; // Set LineTableRow.file_idx, don't push a row
+const DBG_ADVANCE_PC: u8 = 0x02; // Increment LineTableRow.address, and push a row
+const DBG_ADVANCE_LINE: u8 = 0x03; // Set LineTableRow.file_line, don't push a row
+const DBG_FIRST_SPECIAL: u8 = 0x04; // All special opcodes push a row.
+
+pub enum RunResult {
+    /// Run the operator successfully.
+    Ok(usize),
+    /// This operator creates a new row.
+    NewRow(usize),
+    /// The end of the program (the operator stream.)
+    End,
+    /// Fails to run the operator at the position.
+    Err,
+}
+
+/// Create a LineTableRow to use as the states of a line table virtual
+/// machine.
+///
+/// The returned LineTableRow can be passed to [`run_op()`] as `ctx`.
+///
+/// # Arguments
+///
+/// * `lthdr` - is a LineTableHeader returned by [`parse_line_table_header()`].
+/// * `symaddr` - the address of the symbol that `lthdr` belongs to.
+pub fn line_table_row_from(lthdr: &LineTableHeader, symaddr: u64) -> LineTableRow {
+    LineTableRow {
+        address: symaddr,
+        file_idx: 1,
+        file_line: lthdr.first_line,
+    }
+}
+
+/// Run a GSYM line table operator/instruction in the buffer.
+///
+/// # Arguments
+///
+/// * `ctx` - a line table row to present the current states of the
+///           virtual machine.  [`line_table_row_from()`] can create a
+///           LineTableRow to keep the states of a virtual machine.
+/// * `ltbl_hdr` - is a LineTableHeader.
+/// * `ops` - is the buffer of the operators following the
+///           LineTableHeader in a GSYM file.
+/// * `pc` - is the program counter of the virtual machine.
+///
+/// Return a RunResult. `Ok()` and `NewRow()`will return the size of
+/// this instruction.  So, the caller should adjust the value of `pc`
+/// according to the value returned.
+#[inline]
+pub fn run_op(
+    ctx: &mut LineTableRow,
+    ltbl_hdr: &LineTableHeader,
+    ops: &[u8],
+    pc: usize,
+) -> RunResult {
+    let mut off = pc;
+    let op = ops[off];
+    off += 1;
+    match op {
+        DBG_END_SEQUENCE => RunResult::End,
+        DBG_SET_FILE => {
+            if let Some((f, bytes)) = decode_leb128(&ops[off..]) {
+                off += bytes as usize;
+                ctx.file_idx = f as u32;
+                RunResult::Ok(off - pc)
+            } else {
+                RunResult::Err
+            }
+        }
+        DBG_ADVANCE_PC => {
+            if let Some((adv, bytes)) = decode_leb128(&ops[off..]) {
+                off += bytes as usize;
+                ctx.address += adv;
+                RunResult::NewRow(off - pc)
+            } else {
+                RunResult::Err
+            }
+        }
+        DBG_ADVANCE_LINE => {
+            if let Some((adv, bytes)) = decode_leb128_s(&ops[off..]) {
+                off += bytes as usize;
+                ctx.file_line = (ctx.file_line as i64 + adv) as u32;
+                RunResult::Ok(off - pc)
+            } else {
+                RunResult::Err
+            }
+        }
+        // Special operators.
+        //
+        // All operators that have a value greater than or equal to
+        // DBG_FIRST_SPECIAL are considered special operators. These
+        // operators change both the line number and address of the
+        // virtual machine and emit a new row.
+        _ => {
+            let adjusted = (op - DBG_FIRST_SPECIAL) as i64;
+            // The range of line number delta is from min_delta to
+            // max_delta, including max_delta.
+            let range = ltbl_hdr.max_delta - ltbl_hdr.min_delta + 1;
+            let line_delta = ltbl_hdr.min_delta + (adjusted % range);
+            let addr_delta = adjusted / range;
+
+            let file_line = ctx.file_line as i32 + line_delta as i32;
+            if file_line < 1 {
+                return RunResult::Err;
+            }
+
+            ctx.file_line = file_line as u32;
+            ctx.address = (ctx.address as i64 + addr_delta) as u64;
+            RunResult::NewRow(off - pc)
+        }
+    }
+}

--- a/src/gsym/types.rs
+++ b/src/gsym/types.rs
@@ -14,6 +14,12 @@ pub struct Header {
     pub uuid: [u8; 20],
 }
 
+#[allow(dead_code)]
+pub struct FileInfo {
+    pub directory: u32,
+    pub filename: u32,
+}
+
 pub struct AddressInfo<'a> {
     pub size: u32,
     pub name: u32,
@@ -26,6 +32,25 @@ pub struct AddressData<'a> {
     pub typ: u32,
     pub length: u32,
     pub data: &'a [u8],
+}
+
+#[derive(Clone)]
+pub struct LineTableRow {
+    pub address: u64,
+    pub file_idx: u32,
+    pub file_line: u32,
+}
+
+pub struct LineTableHeader {
+    /// `min_data` & `max_delta` together is used to set the range and
+    /// encoding of line delta in special operator.  Line delta is the
+    /// number of lines that a line table row is different from the
+    /// previous row.
+    ///
+    /// See `Special operators` in lintab.rs.
+    pub min_delta: i64,
+    pub max_delta: i64,
+    pub first_line: u32,
 }
 
 #[allow(non_upper_case_globals)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2200,6 +2200,7 @@ mod tests {
         for syms in syms_lst {
             for sym in syms {
                 assert_eq!(sym.symbol, "factorial");
+                assert!(sym.path.ends_with("gsym-example.c"));
                 cnt += 1;
             }
         }


### PR DESCRIPTION
The line table of GSYM file provide a way to translate an address to the file name and the line number of its source code if there is.

Signed-off-by: Kui-Feng Lee <kuifeng@fb.com>