### PR TITLE
Fix clippy reported issues

### DIFF
--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -39,6 +39,6 @@ fn main() {
             addr, result.symbol, result.path, result.line_no
         );
     } else {
-        println!("0x{:x} is not found", addr);
+        println!("0x{addr:x} is not found");
     }
 }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let pid = args[1].parse::<u32>().unwrap();
     let mut addr_str = &args[2][..];
-    println!("PID: {}", pid);
+    println!("PID: {pid}");
 
     if addr_str.len() > 2 && &addr_str[0..2] == "0x" {
         // Remove prefixed 0x
@@ -49,6 +49,6 @@ fn main() {
             line_no
         );
     } else {
-        println!("0x{:x} is not found", addr);
+        println!("0x{addr:x} is not found");
     }
 }

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -238,7 +238,7 @@ fn parse_debug_line_cu(
         let version = v2.version;
         return Err(Error::new(
             ErrorKind::Unsupported,
-            format!("Support DWARF version 2 & 4 (version: {})", version),
+            format!("Support DWARF version 2 & 4 (version: {version})"),
         ));
     }
 
@@ -401,10 +401,7 @@ fn run_debug_line_stmt(
                 if insn_size < 1 {
                     return Err(Error::new(
                         ErrorKind::InvalidData,
-                        format!(
-                            "invalid extended opcode (ip=0x{:x}, insn_size=0x{:x}",
-                            ip, insn_size
-                        ),
+                        format!("invalid extended opcode (ip=0x{ip:x}, insn_size=0x{insn_size:x}"),
                     ));
                 }
                 let ext_opcode = stmts[ip + 1 + bytes as usize];
@@ -427,7 +424,7 @@ fn run_debug_line_stmt(
                         }
                         _ => Err(Error::new(
                             ErrorKind::Unsupported,
-                            format!("unsupported address size ({})", insn_size),
+                            format!("unsupported address size ({insn_size})"),
                         )),
                     },
                     DW_LINE_DEFINE_FILE => Err(Error::new(
@@ -457,15 +454,14 @@ fn run_debug_line_stmt(
                     _ => Err(Error::new(
                         ErrorKind::Unsupported,
                         format!(
-                            "invalid extended opcode (ip=0x{:x}, ext_opcode=0x{:x})",
-                            ip, ext_opcode
+                            "invalid extended opcode (ip=0x{ip:x}, ext_opcode=0x{ext_opcode:x})"
                         ),
                     )),
                 }
             } else {
                 Err(Error::new(
                     ErrorKind::InvalidData,
-                    format!("invalid extended opcode (ip=0x{:x})", ip),
+                    format!("invalid extended opcode (ip=0x{ip:x})"),
                 ))
             }
         }
@@ -1280,10 +1276,7 @@ mod tests {
             _ => {
                 return Err(Error::new(
                     ErrorKind::Unsupported,
-                    format!(
-                        "unsupported address size {} ver {} off 0x{:x}",
-                        addr_sz, version, offset
-                    ),
+                    format!("unsupported address size {addr_sz} ver {version} off 0x{offset:x}"),
                 ));
             }
         }
@@ -1378,7 +1371,7 @@ mod tests {
         let result = run_debug_line_stmts(&stmts, &prologue, &[]);
         if result.is_err() {
             let e = result.as_ref().err().unwrap();
-            println!("result {:?}", e);
+            println!("result {e:?}");
         }
         assert!(result.is_ok());
         let matrix = result.unwrap();
@@ -1438,7 +1431,7 @@ mod tests {
         let result = run_debug_line_stmts(&stmts, &prologue, &[]);
         if result.is_err() {
             let e = result.as_ref().err().unwrap();
-            println!("result {:?}", e);
+            println!("result {e:?}");
         }
         assert!(result.is_ok());
         let matrix = result.unwrap();
@@ -1492,7 +1485,7 @@ mod tests {
         let line_info = resolver.find_line(addr);
         assert!(line_info.is_some());
         let (dir_ret, file_ret, line_ret) = line_info.unwrap();
-        println!("{}/{} {}", dir_ret, file_ret, line_ret);
+        println!("{dir_ret}/{file_ret} {line_ret}");
         assert_eq!(dir, dir_ret);
         assert_eq!(file, file_ret);
         assert_eq!(line, line_ret);

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -572,7 +572,7 @@ impl Elf64Parser {
         }
         Err(Error::new(
             ErrorKind::NotFound,
-            format!("Does not found the give section: {}", name),
+            format!("Does not found the give section: {name}"),
         ))
     }
 
@@ -854,7 +854,7 @@ mod tests {
 
         let (sym_name, addr) = parser.pick_symtab_addr();
 
-        println!("{}", sym_name);
+        println!("{sym_name}");
         let opts = FindAddrOpts {
             offset_in_file: false,
             obj_file_name: false,

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -349,7 +349,7 @@ mod tests {
         let mut addr_tab = Vec::<u8>::new();
         addr_tab.resize(TEST_SIZE * 4, 0);
 
-        let mut values: Vec<u32> = (0_u32..(TEST_SIZE as u32)).into_iter().collect();
+        let mut values: Vec<u32> = (0_u32..(TEST_SIZE as u32)).collect();
 
         let copy_to_addr_tab = |values: &[u32], addr_tab: &mut Vec<u8>| {
             addr_tab.clear();
@@ -362,7 +362,7 @@ mod tests {
         // ascending order and `< TEST_SIZE * 2`.
         let gen_values = |values: &mut [u32]| {
             let mut carry_out = TEST_SIZE as u32 * 2;
-            for i in (0..values.len()).into_iter().rev() {
+            for i in (0..values.len()).rev() {
                 values[i] += 1;
                 if values[i] >= carry_out {
                     carry_out -= 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,7 +741,7 @@ impl ResolverMap {
                         let dirs = [Path::new("/boot/"), Path::new("/usr/lib/debug/boot/")];
                         let mut i = 0;
                         let kernel_image = loop {
-                            let path = dirs[i].join(format!("{}{}", basename, release));
+                            let path = dirs[i].join(format!("{basename}{release}"));
                             if stat(&path).is_ok() {
                                 break path;
                             }
@@ -767,7 +767,7 @@ impl ResolverMap {
                         Self::build_resolvers_proc_maps(pid, &mut resolvers, cache_holder)
                     {
                         #[cfg(debug_assertions)]
-                        eprintln!("Fail to load symbols for the process {}: {:?}", pid, _e);
+                        eprintln!("Fail to load symbols for the process {pid}: {_e:?}");
                     }
                 }
                 SymbolSrcCfg::Gsym {
@@ -1581,7 +1581,7 @@ pub unsafe extern "C" fn blazesym_symbolize(
 
     if results.is_empty() {
         #[cfg(debug_assertions)]
-        eprintln!("Empty result while request for {}", addr_cnt);
+        eprintln!("Empty result while request for {addr_cnt}");
         return ptr::null();
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -129,7 +129,7 @@ pub fn parse_maps(pid: u32) -> Result<Vec<LinuxMapsEntry>, Error> {
     let file_name = if pid == 0 {
         String::from("/proc/self/maps")
     } else {
-        format!("/proc/{}/maps", pid)
+        format!("/proc/{pid}/maps")
     };
     let file = fs::File::open(file_name)?;
     let mut reader = BufReader::new(file);
@@ -138,7 +138,7 @@ pub fn parse_maps(pid: u32) -> Result<Vec<LinuxMapsEntry>, Error> {
         r"^([0-9a-f]+)-([0-9a-f]+) ([rwxp\\-]+) ([0-9a-f]+) [0-9a-f]+:[0-9a-f]+ [0-9]+ *((/[^/]+)+)$",
     );
     if re_ptn.is_err() {
-        println!("{:?}", re_ptn);
+        println!("{re_ptn:?}");
         return Err(Error::new(ErrorKind::InvalidData, "Failed to build regex"));
     }
     let re_ptn = re_ptn.unwrap();
@@ -162,10 +162,7 @@ pub fn parse_maps(pid: u32) -> Result<Vec<LinuxMapsEntry>, Error> {
             let mut path_str = path.to_string();
             if let Some(pos) = path.rfind(" (deleted)") {
                 if pos == path.len() - " (deleted)".len() {
-                    path_str = format!(
-                        "/proc/{}/map_files/{:x}-{:x}",
-                        pid, loaded_address, end_address
-                    );
+                    path_str = format!("/proc/{pid}/map_files/{loaded_address:x}-{end_address:x}");
                 }
             }
 


### PR DESCRIPTION
With Rust 1.67 clippy warns about us not inlining some variables in format strings in some locations. Follow the suggestions and fix some other issues flagged by newer versions of clippy.

Signed-off-by: Daniel Müller <deso@posteo.net>