### PR TITLE
Make cbindgen dependency optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,18 @@ env:
 
 jobs:
   build:
-    name: Build [${{ matrix.rust }}, ${{ matrix.profile }}]
+    name: Build [${{ matrix.rust }}, ${{ matrix.profile }}, features=${{ matrix.features }}]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         rust: [1.63.0, stable]
         profile: [dev, release]
+        features: ['']
+        include:
+          - rust: stable
+            profile: dev
+            features: cheader
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
@@ -25,7 +30,7 @@ jobs:
         override: true
     - name: Build ${{ matrix.profile }}
       run: |
-        cargo build --profile=${{ matrix.profile }} --lib --tests --examples
+        cargo build --profile=${{ matrix.profile }} --features=${{ matrix.features }} --lib --tests --examples
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ crossbeam-channel = "0.5"
 libc = "0.2.137"
 
 [build-dependencies]
-cbindgen = "0.24"
+cbindgen = {version = "0.24", optional = true}
 
 [features]
-cheader = []
+cheader = ["cbindgen"]
 # Enable code paths requiring a nightly toolchain. This feature is only meant to
 # be used for testing and benchmarking purposes, not for the core library, which
 # is expected to work on stable.

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate cbindgen;
-
 #[cfg(feature = "cheader")]
 use std::env;
 #[cfg(feature = "cheader")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 // trace to function names and their locations in the
 // source code.
 #![doc = include_str!("../README.md")]
-#![allow(dead_code, clippy::let_and_return)]
+#![allow(dead_code, clippy::let_and_return, clippy::let_unit_value)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(feature = "nightly", feature(test))]
 


### PR DESCRIPTION
The `cbindgen` dependency pulls in a swath of transitive dependencies. Currently, everybody compiling the crate pays the price of compiling all of them, while the dependency is really only used when generating C headers.
With this change we pull in the dependency only when generating C headers, eliminating that work when it is unnecessary.

Signed-off-by: Daniel Müller <deso@posteo.net>