### PR TITLE
Fix pointer casts

### DIFF
--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -977,7 +977,7 @@ fn parse_die_subprogram<'a>(
                 }
                 name_str = Some(match value {
                     debug_info::AttrValue::Unsigned(str_off) => unsafe {
-                        CStr::from_ptr(str_data[str_off as usize..].as_ptr() as *const i8)
+                        CStr::from_ptr(str_data[str_off as usize..].as_ptr().cast())
                             .to_str()
                             .map_err(|_e| {
                                 Error::new(

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -285,8 +285,7 @@ impl ElfParser {
         }
 
         // Sort in the dictionary order
-        str2symtab
-            .sort_by_key(|&x| unsafe { CStr::from_ptr(&strtab[x.0] as *const u8 as *const i8) });
+        str2symtab.sort_by_key(|&x| unsafe { CStr::from_ptr(strtab[x.0..].as_ptr().cast()) });
 
         me.str2symtab = Some(str2symtab);
 
@@ -447,7 +446,7 @@ impl ElfParser {
         let strtab = me.strtab.as_ref().unwrap();
         let r = str2symtab.binary_search_by_key(&name.to_string(), |&x| {
             String::from(
-                unsafe { CStr::from_ptr(&strtab[x.0] as *const u8 as *const i8) }
+                unsafe { CStr::from_ptr(strtab[x.0..].as_ptr().cast()) }
                     .to_str()
                     .unwrap(),
             )
@@ -458,7 +457,7 @@ impl ElfParser {
                 let mut idx = str2sym_i;
                 while idx > 0 {
                     let name_seek = unsafe {
-                        CStr::from_ptr(&strtab[str2symtab[idx].0] as *const u8 as *const i8)
+                        CStr::from_ptr(strtab[str2symtab[idx].0..].as_ptr().cast())
                             .to_str()
                             .unwrap()
                     };
@@ -472,7 +471,7 @@ impl ElfParser {
                 let mut found = vec![];
                 for idx in idx..str2symtab.len() {
                     let name_visit = unsafe {
-                        CStr::from_ptr(&strtab[str2symtab[idx].0] as *const u8 as *const i8)
+                        CStr::from_ptr(strtab[str2symtab[idx].0..].as_ptr().cast())
                             .to_str()
                             .unwrap()
                     };
@@ -515,7 +514,7 @@ impl ElfParser {
         let mut syms = vec![];
         for (str_off, sym_i) in str2symtab {
             let sname = unsafe {
-                CStr::from_ptr(&strtab[*str_off] as *const u8 as *const i8)
+                CStr::from_ptr(strtab[*str_off..].as_ptr().cast())
                     .to_str()
                     .unwrap()
             };

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -230,7 +230,7 @@ impl<'a> GsymContext<'a> {
         // SAFETY: the lifetime of `CStr` can live as long as `self`.
         // The returned reference can also live as long as `self`.
         unsafe {
-            CStr::from_ptr(self.str_tab[off..].as_ptr() as *const i8)
+            CStr::from_ptr(self.str_tab[off..].as_ptr().cast())
                 .to_str()
                 .ok()
         }


### PR DESCRIPTION
Our pointer casts assume char to signed, which isn't guaranteed:
>    --> src/elf/parser.rs:475:40
>     |
> 475 |                         CStr::from_ptr(&strtab[str2symtab[idx].0] as *const u8 as *const i8)
>     |                         -------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
>     |                         |
>     |                         arguments to this function are incorrect
>     |
>     = note: expected raw pointer `*const u8`
>                found raw pointer `*const i8`

Fix them.