### PR TITLE
Enable test file generation when building tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         override: true
     - name: Build ${{ matrix.profile }}
       run: |
-        cargo build --profile=${{ matrix.profile }} --features=dont-generate-test-files --features=${{ matrix.features }} --lib --tests --examples
+        cargo build --profile=${{ matrix.profile }} --features=${{ matrix.features }} --lib
   test-coverage:
     name: Test and coverage
     runs-on: ubuntu-22.04
@@ -71,7 +71,7 @@ jobs:
       with:
         toolchain: nightly
         override: true
-    - run: cargo bench --features=dont-generate-test-files --features=nightly
+    - run: cargo bench --features=nightly,dont-generate-test-files
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest
@@ -105,4 +105,4 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: cargo doc --features=dont-generate-test-files --no-deps
+      - run: cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2021"
 name = "blazesym"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
-[package.metadata.docs.rs]
-features = ["dont-generate-test-files"]
-
 [dependencies]
 nix = "0.24"
 regex = "1.6"
 crossbeam-channel = "0.5"
 libc = "0.2.137"
+
+[dev-dependencies]
+blazesym = {path = ".", features = ["generate-test-files"]}
 
 [build-dependencies]
 anyhow = "1.0.68"
@@ -28,9 +28,11 @@ cbindgen = {version = "0.24", optional = true}
 
 [features]
 cheader = ["cbindgen"]
-# Enable this feature to opt out of the generation of test files. That may be
-# useful when certain utilities are not installed or when there is no intention
-# to run tests.
+# Enable this feature to opt in to the generation of test files. Having test
+# files created is necessary for running tests.
+generate-test-files = []
+# Disable generation of test files. This feature takes preference over
+# `generate-test-files`.
 dont-generate-test-files = []
 # Enable code paths requiring a nightly toolchain. This feature is only meant to
 # be used for testing and benchmarking purposes, not for the core library, which

--- a/build.rs
+++ b/build.rs
@@ -134,7 +134,7 @@ fn build_test_bins(crate_root: &Path) {
 fn main() {
     let crate_dir = env!("CARGO_MANIFEST_DIR");
 
-    if !cfg!(feature = "dont-generate-test-files") {
+    if cfg!(feature = "generate-test-files") && !cfg!(feature = "dont-generate-test-files") {
         build_test_bins(crate_dir.as_ref());
     }
 


### PR DESCRIPTION
Cargo build scripts can't distinguish between building the "core" library and building tests. For that reason, we decided to make test file generation opt-out.
It turns out there actually is a way to approximate the desired behavior of building test files when testing very closely and it is outlined in the corresponding upstream feature request:
https://github.com/rust-lang/cargo/issues/2911
Basically, we declare blazesym as a dev-dependency of itself with the feature in question enabled.
With this change we do just that for the newly introduced generate-test-files feature. That means test file generation is now opt-in for regular builds, unless tests or examples are also build, in which case it will default to being enabled. For that reason, we keep the dont-generate-test-files feature around to allow for opting out of that (unlikely to be needed often, but for instance useful for linting the entire crate including tests and examples in CI without needing llvm-gsymutil, for example).