### PR TITLE
Accept slices instead of vectors

### DIFF
--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -794,7 +794,7 @@ pub unsafe extern "C" fn blazesym_find_address_regex_opt(
     let pattern = unsafe { CStr::from_ptr(pattern) };
     let features = unsafe { convert_find_addr_features(features, num_features) };
     let syms =
-        { symbolizer.find_address_regex_opt(&sym_srcs_rs, pattern.to_str().unwrap(), features) };
+        { symbolizer.find_address_regex_opt(&sym_srcs_rs, pattern.to_str().unwrap(), &features) };
 
     if syms.is_none() {
         return ptr::null_mut();
@@ -892,7 +892,7 @@ pub unsafe extern "C" fn blazesym_find_addresses_opt(
         for name in names_cstr.iter().take(name_cnt) {
             names_r.push(name.to_str().unwrap());
         }
-        symbolizer.find_addresses_opt(&sym_srcs_rs, &names_r, features)
+        symbolizer.find_addresses_opt(&sym_srcs_rs, &names_r, &features)
     };
 
     unsafe { convert_syms_list_to_c(syms) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,7 +701,7 @@ impl BlazeSymbolizer {
         })
     }
 
-    fn find_addr_features_context(features: Vec<FindAddrFeature>) -> FindAddrOpts {
+    fn find_addr_features_context(features: &[FindAddrFeature]) -> FindAddrOpts {
         let mut opts = FindAddrOpts {
             offset_in_file: false,
             obj_file_name: false,
@@ -710,13 +710,13 @@ impl BlazeSymbolizer {
         for f in features {
             match f {
                 FindAddrFeature::OffsetInFile(enable) => {
-                    opts.offset_in_file = enable;
+                    opts.offset_in_file = *enable;
                 }
                 FindAddrFeature::ObjFileName(enable) => {
-                    opts.obj_file_name = enable;
+                    opts.obj_file_name = *enable;
                 }
                 FindAddrFeature::SymbolType(sym_type) => {
-                    opts.sym_type = sym_type;
+                    opts.sym_type = *sym_type;
                 }
                 _ => {
                     todo!();
@@ -742,7 +742,7 @@ impl BlazeSymbolizer {
         &self,
         sym_srcs: &[SymbolSrcCfg],
         pattern: &str,
-        features: Vec<FindAddrFeature>,
+        features: &[FindAddrFeature],
     ) -> Option<Vec<SymbolInfo>> {
         let ctx = Self::find_addr_features_context(features);
 
@@ -786,7 +786,7 @@ impl BlazeSymbolizer {
         sym_srcs: &[SymbolSrcCfg],
         pattern: &str,
     ) -> Option<Vec<SymbolInfo>> {
-        self.find_address_regex_opt(sym_srcs, pattern, vec![])
+        self.find_address_regex_opt(sym_srcs, pattern, &[])
     }
 
     /// Find the addresses of a list of symbol names.
@@ -805,7 +805,7 @@ impl BlazeSymbolizer {
         &self,
         sym_srcs: &[SymbolSrcCfg],
         names: &[&str],
-        features: Vec<FindAddrFeature>,
+        features: &[FindAddrFeature],
     ) -> Vec<Vec<SymbolInfo>> {
         let ctx = Self::find_addr_features_context(features);
 
@@ -852,7 +852,7 @@ impl BlazeSymbolizer {
         sym_srcs: &[SymbolSrcCfg],
         names: &[&str],
     ) -> Vec<Vec<SymbolInfo>> {
-        self.find_addresses_opt(sym_srcs, names, vec![])
+        self.find_addresses_opt(sym_srcs, names, &[])
     }
 
     /// Symbolize a list of addresses.


### PR DESCRIPTION
It is bad practiced to accept a Vec object in a function that does not actually need to consume it. Work with slices instead.