### PR TITLE
Use memory mapping and zero-copy parsing

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
 blank_lines_upper_bound = 2
+trailing_semicolon = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,11 @@ name = "blazesym"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [dependencies]
-nix = "0.24"
-regex = "1.6"
 crossbeam-channel = "0.5"
 libc = "0.2.137"
+memmap = "0.7"
+nix = "0.24"
+regex = "1.6"
 
 [dev-dependencies]
 blazesym = {path = ".", features = ["generate-test-files"]}

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -14,7 +14,7 @@ fn main() {
 
     if args.len() != 3 {
         show_usage();
-        return;
+        return
     }
 
     let bin_name = &args[1];

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -15,7 +15,7 @@ fn main() {
 
     if args.len() != 3 {
         show_usage();
-        return;
+        return
     }
 
     let pid = args[1].parse::<u32>().unwrap();

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -269,9 +269,7 @@ unsafe fn symbolsrccfg_to_rust(cfg: *const sym_src_cfg, cfg_len: u32) -> Option<
 pub unsafe extern "C" fn blazesym_new() -> *mut blazesym {
     let symbolizer = match BlazeSymbolizer::new() {
         Ok(s) => s,
-        Err(_) => {
-            return ptr::null_mut();
-        }
+        Err(_) => return ptr::null_mut(),
     };
     let symbolizer_box = Box::new(symbolizer);
     let c_box = Box::new(blazesym {
@@ -315,9 +313,7 @@ pub unsafe extern "C" fn blazesym_new_opts(
 
     let symbolizer = match BlazeSymbolizer::new_opt(&features_r) {
         Ok(s) => s,
-        Err(_) => {
-            return ptr::null_mut();
-        }
+        Err(_) => return ptr::null_mut(),
     };
     let symbolizer_box = Box::new(symbolizer);
     let c_box = Box::new(blazesym {
@@ -362,7 +358,7 @@ unsafe fn convert_symbolizedresults_to_c(
     let raw_buf_with_sz =
         unsafe { alloc(Layout::from_size_align(buf_size + mem::size_of::<u64>(), 8).unwrap()) };
     if raw_buf_with_sz.is_null() {
-        return ptr::null();
+        return ptr::null()
     }
 
     // prepend an u64 to keep the size of the buffer.
@@ -445,7 +441,7 @@ pub unsafe extern "C" fn blazesym_symbolize(
         } else {
             #[cfg(debug_assertions)]
             eprintln!("Fail to transform configurations of symbolizer from C to Rust");
-            return ptr::null_mut();
+            return ptr::null_mut()
         };
 
     let symbolizer = unsafe { &*(*symbolizer).symbolizer };
@@ -458,7 +454,7 @@ pub unsafe extern "C" fn blazesym_symbolize(
     if results.is_empty() {
         #[cfg(debug_assertions)]
         eprintln!("Empty result while request for {addr_cnt}");
-        return ptr::null();
+        return ptr::null()
     }
 
     unsafe { convert_symbolizedresults_to_c(results) }
@@ -475,7 +471,7 @@ pub unsafe extern "C" fn blazesym_result_free(results: *const blazesym_result) {
     if results.is_null() {
         #[cfg(debug_assertions)]
         eprintln!("blazesym_result_free(null)");
-        return;
+        return
     }
 
     let raw_buf_with_sz = unsafe { (results as *mut u8).offset(-(mem::size_of::<u64>() as isize)) };
@@ -786,7 +782,7 @@ pub unsafe extern "C" fn blazesym_find_address_regex_opt(
         } else {
             #[cfg(debug_assertions)]
             eprintln!("Fail to transform configurations of symbolizer from C to Rust");
-            return ptr::null_mut();
+            return ptr::null_mut()
         };
 
     let symbolizer = unsafe { &*(*symbolizer).symbolizer };
@@ -797,7 +793,7 @@ pub unsafe extern "C" fn blazesym_find_address_regex_opt(
         { symbolizer.find_address_regex_opt(&sym_srcs_rs, pattern.to_str().unwrap(), &features) };
 
     if syms.is_none() {
-        return ptr::null_mut();
+        return ptr::null_mut()
     }
 
     unsafe { convert_syms_to_c(syms.unwrap()) }
@@ -837,7 +833,7 @@ pub unsafe extern "C" fn blazesym_syms_free(syms: *const blazesym_sym_info) {
     if syms.is_null() {
         #[cfg(debug_assertions)]
         eprintln!("blazesym_sym_info_free(null)");
-        return;
+        return
     }
 
     let raw_buf_with_sz = unsafe { (syms as *mut u8).offset(-(mem::size_of::<u64>() as isize)) };
@@ -875,7 +871,7 @@ pub unsafe extern "C" fn blazesym_find_addresses_opt(
         } else {
             #[cfg(debug_assertions)]
             eprintln!("Fail to transform configurations of symbolizer from C to Rust");
-            return ptr::null_mut();
+            return ptr::null_mut()
         };
 
     let symbolizer = unsafe { &*(*symbolizer).symbolizer };
@@ -938,7 +934,7 @@ pub unsafe extern "C" fn blazesym_syms_list_free(syms_list: *const *const blazes
     if syms_list.is_null() {
         #[cfg(debug_assertions)]
         eprintln!("blazesym_syms_list_free(null)");
-        return;
+        return
     }
 
     let raw_buf_with_sz =

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -112,7 +112,7 @@ impl DebugLineCU {
         let states = &self.matrix[idx];
         if states.end_sequence {
             // This is the first byte after the last instruction
-            return None;
+            return None
         }
 
         self.stringify_row(idx)
@@ -158,7 +158,7 @@ fn parse_debug_line_dirs(data: &mut &[u8]) -> Result<Vec<String>, Error> {
         // If the first byte is 0 we reached the end. In our case that
         // maps to an empty NUL terminated string.
         if string.is_empty() {
-            break Ok(strs);
+            break Ok(strs)
         }
         strs.push(string.to_string());
     }
@@ -182,7 +182,7 @@ fn parse_debug_line_files(data: &mut &[u8]) -> Result<Vec<DebugLineFileInfo>, Er
         // If the first byte is 0 we reached the end. In our case that
         // maps to an empty NUL terminated string.
         if name.is_empty() {
-            break Ok(strs);
+            break Ok(strs)
         }
 
         let (dir_idx, _bytes) = data
@@ -220,7 +220,7 @@ fn parse_debug_line_cu(data: &mut &[u8], addresses: &[u64]) -> Result<DebugLineC
         return Err(Error::new(
             ErrorKind::Unsupported,
             format!("encountered unsupported DWARF version: {version}"),
-        ));
+        ))
     }
 
     let (prologue, prologue_size) = if v2.version == 4 {
@@ -374,7 +374,7 @@ fn run_debug_line_stmt(
                     return Err(Error::new(
                         ErrorKind::InvalidData,
                         format!("invalid extended opcode (ip=0x{ip:x}, insn_size=0x{insn_size:x}"),
-                    ));
+                    ))
                 }
                 let ext_opcode = stmts[ip + 1 + bytes as usize];
                 match ext_opcode {
@@ -566,7 +566,7 @@ fn run_debug_line_stmts(
                                     }
                                     matrix.push(states_cur.clone());
                                     pushed = true;
-                                    break;
+                                    break
                                 }
                             }
                             last_ip_pushed = pushed;
@@ -584,9 +584,7 @@ fn run_debug_line_stmts(
                     force_no_emit = false;
                 }
             }
-            Err(e) => {
-                return Err(e);
-            }
+            Err(e) => return Err(e),
         }
     }
 
@@ -618,7 +616,7 @@ fn parse_debug_line_elf_parser(
         remain_sz -= prologue.total_length as usize + 4;
 
         if debug_line_cu.matrix.is_empty() {
-            continue;
+            continue
         }
 
         if !addresses.is_empty() {
@@ -640,7 +638,7 @@ fn parse_debug_line_elf_parser(
             all_cus.push(debug_line_cu);
 
             if not_found.is_empty() {
-                return Ok(all_cus);
+                return Ok(all_cus)
             }
         } else {
             all_cus.push(debug_line_cu);
@@ -651,7 +649,7 @@ fn parse_debug_line_elf_parser(
         return Err(Error::new(
             ErrorKind::InvalidData,
             "encountered remaining garbage data at the end",
-        ));
+        ))
     }
 
     Ok(all_cus)
@@ -687,7 +685,7 @@ impl DwarfResolver {
         let mut addr_to_dlcu = Vec::with_capacity(debug_line_cus.len());
         for (idx, dlcu) in debug_line_cus.iter().enumerate() {
             if dlcu.matrix.is_empty() {
-                continue;
+                continue
             }
             let first_addr = dlcu.matrix[0].address;
             addr_to_dlcu.push((first_addr, idx as u32));
@@ -781,7 +779,7 @@ impl DwarfResolver {
         if self.enable_debug_info_syms {
             let mut dis_ref = self.debug_info_syms.borrow_mut();
             if dis_ref.is_some() {
-                return Ok(());
+                return Ok(())
             }
             let mut debug_info_syms = debug_info_parse_symbols(&self.parser, None, 1)?;
             debug_info_syms.sort_by_key(|v: &DWSymInfo| -> &str { v.name });
@@ -798,13 +796,13 @@ impl DwarfResolver {
     /// * `opts` - is the context giving additional parameters.
     pub fn find_address(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymbolInfo>, Error> {
         if let SymbolType::Variable = opts.sym_type {
-            return Err(Error::new(ErrorKind::Unsupported, "Not implemented"));
+            return Err(Error::new(ErrorKind::Unsupported, "Not implemented"))
         }
         let elf_r = self.parser.find_address(name, opts)?;
         if !elf_r.is_empty() {
             // Since it is found from symtab, symtab should be
             // complete and DWARF shouldn't provide more information.
-            return Ok(elf_r);
+            return Ok(elf_r)
         }
 
         self.ensure_debug_info_syms()?;
@@ -813,9 +811,7 @@ impl DwarfResolver {
         let mut idx =
             match debug_info_syms.binary_search_by_key(&name.to_string(), |v| v.name.to_string()) {
                 Ok(idx) => idx,
-                _ => {
-                    return Ok(vec![]);
-                }
+                _ => return Ok(vec![]),
             };
         while idx > 0 && debug_info_syms[idx].name.eq(name) {
             idx -= 1;
@@ -857,18 +853,18 @@ impl DwarfResolver {
         opts: &FindAddrOpts,
     ) -> Result<Vec<SymbolInfo>, Error> {
         if let SymbolType::Variable = opts.sym_type {
-            return Err(Error::new(ErrorKind::Unsupported, "Not implemented"));
+            return Err(Error::new(ErrorKind::Unsupported, "Not implemented"))
         }
         let r = self.parser.find_address_regex(pattern, opts)?;
         if !r.is_empty() {
-            return Ok(r);
+            return Ok(r)
         }
 
         self.ensure_debug_info_syms()?;
 
         let dis_ref = self.debug_info_syms.borrow();
         if dis_ref.is_none() {
-            return Ok(vec![]);
+            return Ok(vec![])
         }
         let debug_info_syms = dis_ref.as_ref().unwrap();
         let mut syms = vec![];
@@ -916,9 +912,9 @@ fn find_die_sibling(die: &mut debug_info::DIE<'_>) -> Option<usize> {
     for (name, _form, _opt, value) in die {
         if name == constants::DW_AT_sibling {
             if let debug_info::AttrValue::Unsigned(off) = value {
-                return Some(off as usize);
+                return Some(off as usize)
             }
-            return None;
+            return None
         }
     }
     None
@@ -948,7 +944,7 @@ fn parse_die_subprogram<'a>(
         match name {
             constants::DW_AT_linkage_name | constants::DW_AT_name => {
                 if name_str.is_some() {
-                    continue;
+                    continue
                 }
                 name_str = Some(match value {
                     debug_info::AttrValue::Unsigned(str_off) => unsafe {
@@ -966,7 +962,7 @@ fn parse_die_subprogram<'a>(
                         return Err(Error::new(
                             ErrorKind::InvalidData,
                             "fail to parse DW_AT_linkage_name {}",
-                        ));
+                        ))
                     }
                 });
             }
@@ -978,7 +974,7 @@ fn parse_die_subprogram<'a>(
                     return Err(Error::new(
                         ErrorKind::InvalidData,
                         "fail to parse DW_AT_lo_pc",
-                    ));
+                    ))
                 }
             },
             constants::DW_AT_hi_pc => match value {
@@ -989,7 +985,7 @@ fn parse_die_subprogram<'a>(
                     return Err(Error::new(
                         ErrorKind::InvalidData,
                         "fail to parse DW_AT_lo_pc",
-                    ));
+                    ))
                 }
             },
             _ => {}
@@ -1023,7 +1019,7 @@ fn debug_info_parse_symbols_cu<'a>(
 ) {
     while let Some(mut die) = dieiter.next() {
         if die.tag == 0 || die.tag == constants::DW_TAG_namespace {
-            continue;
+            continue
         }
 
         assert!(die.abbrev.is_some());
@@ -1031,13 +1027,13 @@ fn debug_info_parse_symbols_cu<'a>(
             if die.abbrev.unwrap().has_children {
                 if let Some(sibling_off) = find_die_sibling(&mut die) {
                     dieiter.seek_to_sibling(sibling_off);
-                    continue;
+                    continue
                 }
                 // Skip this DIE quickly, or the iterator will
                 // recalculate the size of the DIE.
                 die.exhaust().unwrap();
             }
-            continue;
+            continue
         }
 
         if let Ok(Some(syminfo)) = parse_die_subprogram(&mut die, str_data) {
@@ -1125,12 +1121,12 @@ fn debug_info_parse_symbols<'a>(
 
                 if let Ok(result) = result_rx.try_recv() {
                     if let DIParseResult::Stop = result {
-                        break;
+                        break
                     } else {
                         return Err(Error::new(
                             ErrorKind::UnexpectedEof,
                             "Receive an unexpected result",
-                        ));
+                        ))
                     }
                 }
             }
@@ -1155,7 +1151,7 @@ fn debug_info_parse_symbols<'a>(
                 debug_info_parse_symbols_cu(dieiter, str_data, &mut syms);
                 for sym in &syms[saved_sz..] {
                     if !cond(sym) {
-                        break 'outer;
+                        break 'outer
                     }
                 }
             }
@@ -1189,7 +1185,7 @@ mod tests {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "invalid arange header (too small)",
-            ));
+            ))
         }
         let len = decode_uword(data);
         let version = decode_uhalf(&data[4..]);
@@ -1201,7 +1197,7 @@ mod tests {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "data is broken (too small)",
-            ));
+            ))
         }
 
         // Size of the header
@@ -1221,7 +1217,7 @@ mod tests {
                     pos += 4;
 
                     if start == 0 && size == 0 {
-                        break;
+                        break
                     }
                     aranges.push((start as u64, size as u64));
                 }
@@ -1234,7 +1230,7 @@ mod tests {
                     pos += 8;
 
                     if start == 0 && size == 0 {
-                        break;
+                        break
                     }
                     aranges.push((start, size));
                 }
@@ -1243,7 +1239,7 @@ mod tests {
                 return Err(Error::new(
                     ErrorKind::Unsupported,
                     format!("unsupported address size {addr_sz} ver {version} off 0x{offset:x}"),
-                ));
+                ))
             }
         }
 

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -1074,12 +1074,12 @@ fn debug_info_parse_symbols<'a>(
     nthreads: usize,
 ) -> Result<Vec<DWSymInfo<'a>>, Error> {
     let info_sect_idx = parser.find_section(".debug_info")?;
-    let info_data = parser.read_section_raw_cache(info_sect_idx)?;
+    let info_data = parser.section_data(info_sect_idx)?;
     let abbrev_sect_idx = parser.find_section(".debug_abbrev")?;
-    let abbrev_data = parser.read_section_raw_cache(abbrev_sect_idx)?;
+    let abbrev_data = parser.section_data(abbrev_sect_idx)?;
     let units = debug_info::UnitIter::new(info_data, abbrev_data);
     let str_sect_idx = parser.find_section(".debug_str")?;
-    let str_data = parser.read_section_raw_cache(str_sect_idx)?;
+    let str_data = parser.section_data(str_sect_idx)?;
 
     let mut syms = Vec::<DWSymInfo>::new();
 

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -248,16 +248,15 @@ fn parse_debug_line_cu(parser: &ElfParser, addresses: &[u64]) -> Result<DebugLin
     };
 
     let to_read = prologue.total_length as usize + 4 - prologue_sz;
-    let data_buf = &mut buf;
-    if to_read <= data_buf.capacity() {
+    if to_read <= buf.capacity() {
         // Gain better performance by skipping initialization.
-        unsafe { data_buf.set_len(to_read) };
+        unsafe { buf.set_len(to_read) };
     } else {
-        data_buf.resize(to_read, 0);
+        buf.resize(to_read, 0);
     }
-    let () = parser.read_raw(data_buf.as_mut_slice())?;
+    let () = parser.read_raw(buf.as_mut_slice())?;
 
-    let data = &mut &data_buf[0..];
+    let data = &mut &buf[0..];
     let std_op_num = (prologue.opcode_base - 1) as usize;
     let std_op_lengths = data
         .read_slice(std_op_num)

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -211,7 +211,7 @@ fn parse_debug_line_cu(
     let buf = reused_buf;
 
     buf.resize(prologue_sz, 0);
-    unsafe { parser.read_raw(buf.as_mut_slice()) }?;
+    let () = parser.read_raw(buf.as_mut_slice())?;
     let prologue_raw = buf.as_mut_ptr() as *mut DebugLinePrologueV2;
     // SAFETY: `prologue_raw` is valid for reads and `DebugLinePrologueV2` is
     //         comprised only of objects that are valid for any bit pattern.
@@ -229,7 +229,7 @@ fn parse_debug_line_cu(
         // Upgrade to V4.
         // V4 has more fields to read.
         buf.resize(prologue_v4_sz, 0);
-        unsafe { parser.read_raw(&mut buf.as_mut_slice()[prologue_sz..]) }?;
+        let () = parser.read_raw(&mut buf.as_mut_slice()[prologue_sz..])?;
         let prologue_raw = buf.as_mut_ptr() as *mut DebugLinePrologue;
         // SAFETY: `prologue_raw` is valid for reads and `DebugLinePrologue` is
         //         comprised only of objects that are valid for any bit pattern.
@@ -260,7 +260,7 @@ fn parse_debug_line_cu(
     } else {
         data_buf.resize(to_read, 0);
     }
-    unsafe { parser.read_raw(data_buf.as_mut_slice())? };
+    let () = parser.read_raw(data_buf.as_mut_slice())?;
 
     let data = &mut &data_buf[0..];
     let std_op_num = (prologue.opcode_base - 1) as usize;

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -248,12 +248,7 @@ fn parse_debug_line_cu(parser: &ElfParser, addresses: &[u64]) -> Result<DebugLin
     };
 
     let to_read = prologue.total_length as usize + 4 - prologue_sz;
-    if to_read <= buf.capacity() {
-        // Gain better performance by skipping initialization.
-        unsafe { buf.set_len(to_read) };
-    } else {
-        buf.resize(to_read, 0);
-    }
+    let () = buf.resize(to_read, 0);
     let () = parser.read_raw(buf.as_mut_slice())?;
 
     let data = &mut &buf[0..];

--- a/src/dwarf/debug_info.rs
+++ b/src/dwarf/debug_info.rs
@@ -151,7 +151,7 @@ fn parse_abbrev(data: &[u8]) -> Option<(Abbrev, usize)> {
                 parsed_attrs: vec![],
             },
             1,
-        ));
+        ))
     }
 
     let mut pos = bytes as usize;
@@ -166,10 +166,10 @@ fn parse_abbrev(data: &[u8]) -> Option<(Abbrev, usize)> {
             pos += bytes;
             parsed_attrs.push(AbbrevAttr { name, form, opt });
             if form == 0 {
-                break;
+                break
             }
         } else {
-            break;
+            break
         }
     }
 
@@ -392,7 +392,7 @@ fn parse_cu_abbrevs(data: &[u8]) -> Option<(Vec<Abbrev>, usize)> {
         let (abbrev, bytes) = parse_abbrev(&data[pos..])?;
         pos += bytes;
         if abbrev.abbrev_code == 0x0 {
-            return Some((abbrevs, pos));
+            return Some((abbrevs, pos))
         }
         abbrevs.push(abbrev);
     }
@@ -408,7 +408,7 @@ fn parse_cu_abbrevs(data: &[u8]) -> Option<(Vec<Abbrev>, usize)> {
 /// * `data` - is the data from the `.debug_info` section.
 fn parse_unit_header(data: &[u8]) -> Option<UnitHeader> {
     if data.len() < 4 {
-        return None;
+        return None
     }
 
     let mut pos = 0;
@@ -418,14 +418,14 @@ fn parse_unit_header(data: &[u8]) -> Option<UnitHeader> {
     let bits64 = init_length == 0xffffffff;
     if bits64 {
         if (pos + 8) > data.len() {
-            return None;
+            return None
         }
         init_length = decode_udword(&data[pos..]) as usize;
         pos += 8;
     }
 
     if (pos + 2) > data.len() {
-        return None;
+        return None
     }
     let version = decode_uhalf(&data[pos..]);
     pos += 2;
@@ -433,14 +433,14 @@ fn parse_unit_header(data: &[u8]) -> Option<UnitHeader> {
     if version == 0x4 {
         let debug_abbrev_offset: u64 = if bits64 {
             if (pos + 8) > data.len() {
-                return None;
+                return None
             }
             let v = decode_udword(&data[pos..]);
             pos += 8;
             v
         } else {
             if (pos + 4) > data.len() {
-                return None;
+                return None
             }
             let v = decode_uword(&data[pos..]);
             pos += 4;
@@ -455,11 +455,11 @@ fn parse_unit_header(data: &[u8]) -> Option<UnitHeader> {
             debug_abbrev_offset,
             address_size,
             hdr_size: pos,
-        }));
+        }))
     }
 
     if (pos + 1) > data.len() {
-        return None;
+        return None
     }
     let unit_type = data[pos];
     pos += 1;
@@ -467,21 +467,21 @@ fn parse_unit_header(data: &[u8]) -> Option<UnitHeader> {
     match unit_type {
         DW_UT_compile => {
             if (pos + 1) > data.len() {
-                return None;
+                return None
             }
             let address_size = data[pos];
             pos += 1;
 
             let debug_abbrev_offset: u64 = if bits64 {
                 if (pos + 8) > data.len() {
-                    return None;
+                    return None
                 }
                 let v = decode_udword(&data[pos..]);
                 pos += 8;
                 v
             } else {
                 if (pos + 4) > data.len() {
-                    return None;
+                    return None
                 }
                 let v = decode_uword(&data[pos..]);
                 pos += 4;
@@ -531,7 +531,7 @@ impl<'a> DIE<'a> {
         let abbrev_attrs = self.abbrev_attrs;
 
         if self.done {
-            return Ok(());
+            return Ok(())
         }
 
         while self.abbrev_attrs_idx < abbrev_attrs.len() {
@@ -539,7 +539,7 @@ impl<'a> DIE<'a> {
             self.abbrev_attrs_idx += 1;
 
             if attr.form == 0 {
-                continue;
+                continue
             }
             let (_value, bytes) = extract_attr_value(
                 &self.data[self.reading_offset..],
@@ -565,7 +565,7 @@ impl<'a> Iterator for DIE<'a> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
-            return None;
+            return None
         }
         self.abbrev?;
 
@@ -580,7 +580,7 @@ impl<'a> Iterator for DIE<'a> {
             if form == 0 {
                 self.dieiter.die_finish_reading(self.reading_offset);
                 self.done = true;
-                return None;
+                return None
             }
 
             let (value, bytes) = extract_attr_value(
@@ -634,7 +634,7 @@ impl<'a> DIEIter<'a> {
         let abbrev = self.abbrev.unwrap();
         for attr in abbrev.all_attrs() {
             if attr.form == 0 {
-                continue;
+                continue
             }
             let (_value, bytes) = extract_attr_value(
                 &self.data[self.off..],
@@ -660,7 +660,7 @@ impl<'a> Iterator for DIEIter<'a> {
             self.exhaust_die().unwrap();
         }
         if self.done {
-            return None;
+            return None
         }
 
         let (abbrev_idx, bytes) = decode_leb128_128(&self.data[self.off..])?;

--- a/src/dwarf/debug_info.rs
+++ b/src/dwarf/debug_info.rs
@@ -844,7 +844,7 @@ mod tests {
         let info_idx = elfparser.find_section(".debug_info").unwrap();
         let info = elfparser.read_section_raw(info_idx).unwrap();
 
-        let iter = UnitIter::new(&info, &abbrev);
+        let iter = UnitIter::new(info, abbrev);
         let mut cnt = 0;
         let mut die_cnt = 0;
         let mut attr_cnt = 0;

--- a/src/dwarf/debug_info.rs
+++ b/src/dwarf/debug_info.rs
@@ -112,9 +112,9 @@ pub struct AbbrevAttr {
 
 /// An abbreviation.
 ///
-/// An abbrivation describes the format of a DIE.  it comprises a list
+/// An abbreviation describes the format of a DIE. It comprises a list
 /// of specifications that describe the names and the formats of
-/// attributes.  A DIE will be formated in the way described by it's
+/// attributes. A DIE will be formatted in the way described by it's
 /// abbreviation.
 pub struct Abbrev {
     /// The index to the abbreviation table.
@@ -348,7 +348,7 @@ fn extract_attr_value_impl<'data>(
 /// Extract the value of an attribute from a data buffer.
 ///
 /// This function works with [`parse_abbrev_attr()`], that parse the
-/// attribute specifications of DIEs delcared in the abbreviation
+/// attribute specifications of DIEs declared in the abbreviation
 /// table in the .debug_abbrev section, by using the result of
 /// [`parse_abbrev_attr()`] to parse the value of an attribute of a
 /// DIE.

--- a/src/elf/cache.rs
+++ b/src/elf/cache.rs
@@ -250,7 +250,7 @@ impl _ElfCache {
             let stat = fstat(file.as_raw_fd())?;
 
             if ent.is_valid(&stat) {
-                return Ok(ent.get_backend());
+                return Ok(ent.get_backend())
             }
 
             // Purge the entry and load it from the filesystem.

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -600,7 +600,7 @@ impl ElfParser {
     /// of the backed file.  However, this function doesn't promise to
     /// not cross the boundary of the section.  The caller should take
     /// care about it.
-    pub unsafe fn read_raw(&self, buf: &mut [u8]) -> Result<(), Error> {
+    pub fn read_raw(&self, buf: &mut [u8]) -> Result<(), Error> {
         self.file.borrow_mut().read_exact(buf)?;
         Ok(())
     }

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -90,7 +90,7 @@ impl<'mmap> Cache<'mmap> {
 
     fn ensure_ehdr(&mut self) -> Result<&'mmap Elf64_Ehdr, Error> {
         if let Some(ehdr) = self.ehdr {
-            return Ok(ehdr);
+            return Ok(ehdr)
         }
 
         let mut elf_data = self.elf_data;
@@ -102,7 +102,7 @@ impl<'mmap> Cache<'mmap> {
             && ehdr.e_ident[2] == b'L'
             && ehdr.e_ident[3] == b'F')
         {
-            return Err(Error::new(ErrorKind::InvalidData, "e_ident is wrong"));
+            return Err(Error::new(ErrorKind::InvalidData, "e_ident is wrong"))
         }
         self.ehdr = Some(ehdr);
         Ok(ehdr)
@@ -110,7 +110,7 @@ impl<'mmap> Cache<'mmap> {
 
     fn ensure_shdrs(&mut self) -> Result<&'mmap [Elf64_Shdr], Error> {
         if let Some(shdrs) = self.shdrs {
-            return Ok(shdrs);
+            return Ok(shdrs)
         }
 
         let ehdr = self.ensure_ehdr()?;
@@ -126,7 +126,7 @@ impl<'mmap> Cache<'mmap> {
 
     fn ensure_phdrs(&mut self) -> Result<&'mmap [Elf64_Phdr], Error> {
         if let Some(phdrs) = self.phdrs {
-            return Ok(phdrs);
+            return Ok(phdrs)
         }
 
         let ehdr = self.ensure_ehdr()?;
@@ -142,7 +142,7 @@ impl<'mmap> Cache<'mmap> {
 
     fn ensure_shstrtab(&mut self) -> Result<&'mmap [u8], Error> {
         if let Some(shstrtab) = self.shstrtab {
-            return Ok(shstrtab);
+            return Ok(shstrtab)
         }
 
         let ehdr = self.ensure_ehdr()?;
@@ -216,7 +216,7 @@ impl<'mmap> Cache<'mmap> {
         let ehdr = self.ensure_ehdr()?;
         for i in 0..ehdr.e_shnum.into() {
             if self.section_name(i)? == name {
-                return Ok(i);
+                return Ok(i)
             }
         }
         Err(Error::new(
@@ -230,7 +230,7 @@ impl<'mmap> Cache<'mmap> {
     //       effectively prevent us from doing so.
     fn ensure_symtab(&mut self) -> Result<(), Error> {
         if self.symtab.is_some() {
-            return Ok(());
+            return Ok(())
         }
 
         let idx = if let Ok(idx) = self.find_section(".symtab") {
@@ -244,7 +244,7 @@ impl<'mmap> Cache<'mmap> {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "size of symbol table section is invalid",
-            ));
+            ))
         }
 
         let count = symtab.len() / mem::size_of::<Elf64_Sym>();
@@ -266,7 +266,7 @@ impl<'mmap> Cache<'mmap> {
 
     fn ensure_strtab(&mut self) -> Result<&'mmap [u8], Error> {
         if let Some(strtab) = self.strtab {
-            return Ok(strtab);
+            return Ok(strtab)
         }
 
         let idx = if let Ok(idx) = self.find_section(".strtab") {
@@ -300,10 +300,7 @@ impl<'mmap> Cache<'mmap> {
                 let name = strtab
                     .get(sym.st_name as usize..)
                     .ok_or_else(|| {
-                        Error::new(
-                            ErrorKind::InvalidInput,
-                            "string table index out of bounds",
-                        )
+                        Error::new(ErrorKind::InvalidInput, "string table index out of bounds")
                     })?
                     .read_cstr()
                     .ok_or_else(|| {
@@ -313,9 +310,7 @@ impl<'mmap> Cache<'mmap> {
                         )
                     })?
                     .to_str()
-                    .map_err(|_| {
-                        Error::new(ErrorKind::InvalidInput, "invalid symbol name")
-                    })?;
+                    .map_err(|_| Error::new(ErrorKind::InvalidInput, "invalid symbol name"))?;
                 Ok((name, i))
             })
             .collect::<Result<Vec<_>, Error>>()?;
@@ -424,7 +419,7 @@ impl ElfParser {
             return Err(Error::new(
                 ErrorKind::NotFound,
                 "Does not found a symbol for the given address",
-            ));
+            ))
         }
         let idx = idx_r.unwrap();
 
@@ -435,7 +430,7 @@ impl ElfParser {
 
     pub fn find_address(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymbolInfo>, Error> {
         if let SymbolType::Variable = opts.sym_type {
-            return Err(Error::new(ErrorKind::Unsupported, "Not implemented"));
+            return Err(Error::new(ErrorKind::Unsupported, "Not implemented"))
         }
 
         let mut cache = self.cache.borrow_mut();
@@ -457,7 +452,7 @@ impl ElfParser {
                     let name_seek = str2symtab[idx].0;
                     if !name_seek.eq(name) {
                         idx += 1;
-                        break;
+                        break
                     }
                     idx -= 1;
                 }
@@ -465,7 +460,7 @@ impl ElfParser {
                 let mut found = vec![];
                 for (name_visit, sym_i) in str2symtab.iter().skip(idx) {
                     if !(*name_visit).eq(name) {
-                        break;
+                        break
                     }
                     let sym_ref = &symtab[*sym_i];
                     if sym_ref.st_shndx != SHN_UNDEF {
@@ -490,7 +485,7 @@ impl ElfParser {
         opts: &FindAddrOpts,
     ) -> Result<Vec<SymbolInfo>, Error> {
         if let SymbolType::Variable = opts.sym_type {
-            return Err(Error::new(ErrorKind::Unsupported, "Not implemented"));
+            return Err(Error::new(ErrorKind::Unsupported, "Not implemented"))
         }
 
 

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -6,6 +6,8 @@ use std::mem;
 #[cfg(test)]
 use std::path::Path;
 
+use memmap::Mmap;
+
 use regex::Regex;
 
 use crate::util::{extract_string, search_address_opt_key};
@@ -103,15 +105,20 @@ struct Cache {
 /// A parser for ELF64 files.
 #[derive(Debug)]
 pub struct ElfParser {
+    /// The file representing the ELF object to be parsed.
     file: File,
+    /// The memory mapped file.
+    mmap: Mmap,
     /// A cache for relevant parts of the ELF file.
     cache: RefCell<Cache>,
 }
 
 impl ElfParser {
     pub fn open_file(file: File) -> Result<ElfParser, Error> {
+        let mmap = unsafe { Mmap::map(&file) }?;
         let parser = ElfParser {
             file,
+            mmap,
             cache: RefCell::new(Cache::default()),
         };
         Ok(parser)

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -51,8 +51,7 @@ struct Cache<'mmap> {
     shstrtab: Option<&'mmap [u8]>,
     /// The cached ELF program headers.
     phdrs: Option<&'mmap [Elf64_Phdr]>,
-    symtab: Option<Vec<Elf64_Sym>>,        // in address order
-    symtab_origin: Option<Vec<Elf64_Sym>>, // The copy in the same order as the file
+    symtab: Option<Vec<Elf64_Sym>>, // in address order
     strtab: Option<Vec<u8>>,
     str2symtab: Option<Vec<(usize, usize)>>, // strtab offset to symtab in the dictionary order
 }
@@ -67,7 +66,6 @@ impl<'mmap> Cache<'mmap> {
             shstrtab: None,
             phdrs: None,
             symtab: None,
-            symtab_origin: None,
             strtab: None,
             str2symtab: None,
         }
@@ -263,12 +261,10 @@ impl ElfParser {
             symtab_raw.leak();
             Vec::from_raw_parts(symtab_ptr, cnt, cnt)
         };
-        let origin = symtab.clone();
         symtab.sort_by_key(|x| x.st_value);
 
         let mut cache = self.cache.borrow_mut();
         cache.symtab = Some(symtab);
-        cache.symtab_origin = Some(origin);
 
         Ok(())
     }

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -57,10 +57,10 @@ impl ElfResolver {
         if e_type == ET_DYN || e_type == ET_EXEC {
             for phdr in phdrs {
                 if phdr.p_type != PT_LOAD {
-                    continue;
+                    continue
                 }
                 if (phdr.p_flags & PF_X) != PF_X {
-                    continue;
+                    continue
                 }
                 let end_at = phdr.p_vaddr + phdr.p_memsz;
                 if max_addr < end_at {
@@ -72,7 +72,7 @@ impl ElfResolver {
                 }
             }
         } else {
-            return Err(Error::new(ErrorKind::InvalidData, "unknown e_type"));
+            return Err(Error::new(ErrorKind::InvalidData, "unknown e_type"))
         }
 
         let loaded_address = if e_type == ET_EXEC {
@@ -112,7 +112,7 @@ impl SymResolver for ElfResolver {
         let parser = if let Some(parser) = self.get_parser() {
             parser
         } else {
-            return vec![];
+            return vec![]
         };
 
         match parser.find_symbol(off, STT_FUNC) {
@@ -141,7 +141,7 @@ impl SymResolver for ElfResolver {
             ElfBackend::Elf(parser) => parser.find_address_regex(pattern, opts),
         };
         if syms.is_err() {
-            return None;
+            return None
         }
         let mut syms = syms.unwrap();
         for sym in &mut syms {

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -15,6 +15,8 @@ unsafe impl crate::util::Pod for Elf64_Ehdr {}
 unsafe impl crate::util::Pod for Elf64_Phdr {}
 // SAFETY: `Elf64_Shdr` is valid for any bit pattern.
 unsafe impl crate::util::Pod for Elf64_Shdr {}
+// SAFETY: `Elf64_Sym` is valid for any bit pattern.
+unsafe impl crate::util::Pod for Elf64_Sym {}
 
 pub use libc::ET_CORE;
 pub use libc::ET_DYN;

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -11,6 +11,8 @@ pub use libc::Elf64_Xword;
 
 // SAFETY: `Elf64_Ehdr` is valid for any bit pattern.
 unsafe impl crate::util::Pod for Elf64_Ehdr {}
+// SAFETY: `Elf64_Shdr` is valid for any bit pattern.
+unsafe impl crate::util::Pod for Elf64_Shdr {}
 
 pub use libc::ET_CORE;
 pub use libc::ET_DYN;

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -1,4 +1,5 @@
 pub use libc::Elf64_Addr;
+pub use libc::Elf64_Ehdr;
 pub use libc::Elf64_Half;
 pub use libc::Elf64_Off;
 pub use libc::Elf64_Phdr;
@@ -8,7 +9,9 @@ pub use libc::Elf64_Sym;
 pub use libc::Elf64_Word;
 pub use libc::Elf64_Xword;
 
-pub use libc::Elf64_Ehdr;
+// SAFETY: `Elf64_Ehdr` is valid for any bit pattern.
+unsafe impl crate::util::Pod for Elf64_Ehdr {}
+
 pub use libc::ET_CORE;
 pub use libc::ET_DYN;
 pub use libc::ET_EXEC;

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -11,6 +11,8 @@ pub use libc::Elf64_Xword;
 
 // SAFETY: `Elf64_Ehdr` is valid for any bit pattern.
 unsafe impl crate::util::Pod for Elf64_Ehdr {}
+// SAFETY: `Elf64_Phdr` is valid for any bit pattern.
+unsafe impl crate::util::Pod for Elf64_Phdr {}
 // SAFETY: `Elf64_Shdr` is valid for any bit pattern.
 unsafe impl crate::util::Pod for Elf64_Shdr {}
 

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -129,14 +129,14 @@ pub fn run_op(
             // including max_delta.
             let range = header.max_delta - header.min_delta + 1;
             if range == 0 {
-                return RunResult::Err;
+                return RunResult::Err
             }
             let line_delta = header.min_delta + (adjusted % range);
             let addr_delta = adjusted / range;
 
             let file_line = ctx.file_line as i32 + line_delta as i32;
             if file_line < 1 {
-                return RunResult::Err;
+                return RunResult::Err
             }
 
             ctx.file_line = file_line as u32;

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -88,12 +88,12 @@ impl<'a> GsymContext<'a> {
         // Parse Header
         let magic = decode_uword(data);
         if magic != GSYM_MAGIC {
-            return Err(Error::new(ErrorKind::InvalidData, "invalid magic number"));
+            return Err(Error::new(ErrorKind::InvalidData, "invalid magic number"))
         }
         off += 4;
         let version = decode_uhalf(&data[off..]);
         if version != GSYM_VERSION {
-            return Err(Error::new(ErrorKind::InvalidData, "unknown version number"));
+            return Err(Error::new(ErrorKind::InvalidData, "unknown version number"))
         }
         off += 2;
         let addr_off_size = data[off];
@@ -120,7 +120,7 @@ impl<'a> GsymContext<'a> {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "the size of the file is smaller than expectation (address table)",
-            ));
+            ))
         }
         let addr_tab = &data[off..end_off];
         off = (end_off + 0x3) & !0x3;
@@ -129,7 +129,7 @@ impl<'a> GsymContext<'a> {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "the size of the file is smaller than expectation (address data offset table)",
-            ));
+            ))
         }
         let addr_data_off_tab = &data[off..end_off];
         off += num_addrs as usize * ADDR_DATA_OFFSET_SIZE;
@@ -140,7 +140,7 @@ impl<'a> GsymContext<'a> {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "the size of the file is smaller than expectation (file table)",
-            ));
+            ))
         }
         let file_tab = &data[off..end_off];
         let end_off = strtab_offset as usize + strtab_size as usize;
@@ -148,7 +148,7 @@ impl<'a> GsymContext<'a> {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "the size of the file is smaller than expectation (string table)",
-            ));
+            ))
         }
         let str_tab = &data[strtab_offset as usize..end_off];
 
@@ -179,7 +179,7 @@ impl<'a> GsymContext<'a> {
     /// Get the address of an entry in the Address Table.
     pub fn addr_at(&self, idx: usize) -> Option<u64> {
         if idx >= self.header.num_addrs as usize {
-            return None;
+            return None
         }
 
         let off = idx * self.header.addr_off_size as usize;
@@ -196,7 +196,7 @@ impl<'a> GsymContext<'a> {
     /// Get the AddressInfo of an address given by an index.
     pub fn addr_info(&self, idx: usize) -> Option<AddressInfo> {
         if idx >= self.header.num_addrs as usize {
-            return None;
+            return None
         }
 
         let off = idx * ADDR_DATA_OFFSET_SIZE;
@@ -215,7 +215,7 @@ impl<'a> GsymContext<'a> {
     /// Get the string at the given offset from the String Table.
     pub fn get_str(&self, off: usize) -> Option<&str> {
         if off >= self.str_tab.len() {
-            return None;
+            return None
         }
 
         // Ensure there is a null byte.
@@ -224,7 +224,7 @@ impl<'a> GsymContext<'a> {
             null_off -= 1;
         }
         if null_off == off {
-            return Some("");
+            return Some("")
         }
 
         // SAFETY: the lifetime of `CStr` can live as long as `self`.
@@ -238,7 +238,7 @@ impl<'a> GsymContext<'a> {
 
     pub fn file_info(&self, idx: usize) -> Option<FileInfo> {
         if idx >= self.file_tab.len() / FILE_INFO_SIZE {
-            return None;
+            return None
         }
         let mut off = idx * FILE_INFO_SIZE;
         let directory = decode_uword(&self.file_tab[off..(off + 4)]);
@@ -262,10 +262,10 @@ pub fn find_address(ctx: &GsymContext, addr: u64) -> Option<usize> {
     let mut right = ctx.num_addresses();
 
     if right == 0 {
-        return None;
+        return None
     }
     if addr < ctx.addr_at(0)? {
-        return None;
+        return None
     }
 
     while (left + 1) < right {
@@ -273,7 +273,7 @@ pub fn find_address(ctx: &GsymContext, addr: u64) -> Option<usize> {
         let cur_addr = ctx.addr_at(v)?;
 
         if addr == cur_addr {
-            return Some(v);
+            return Some(v)
         }
         if addr < cur_addr {
             right = v;
@@ -314,9 +314,7 @@ pub fn parse_address_data(data: &[u8]) -> Vec<AddressData> {
 
         #[allow(non_upper_case_globals)]
         match typ {
-            InfoTypeEndOfList => {
-                break;
-            }
+            InfoTypeEndOfList => break,
             InfoTypeLineTableInfo | InfoTypeInlineInfo => {}
             _ => {
                 #[cfg(debug_assertions)]
@@ -422,14 +420,14 @@ mod tests {
                 values[i] += 1;
                 if values[i] >= carry_out {
                     carry_out -= 1;
-                    continue;
+                    continue
                 }
                 // Make all values at right side minimal and strictly
                 // ascending.
                 for j in (i + 1)..values.len() {
                     values[j] = values[j - 1] + 1;
                 }
-                break;
+                break
             }
         };
 

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -45,7 +45,7 @@ impl SymResolver for GsymResolver {
     fn get_address_range(&self) -> (u64, u64) {
         let sz = self.ctx.num_addresses();
         if sz == 0 {
-            return (0, 0);
+            return (0, 0)
         }
 
         // TODO: Must not unwrap.
@@ -62,29 +62,29 @@ impl SymResolver for GsymResolver {
         let idx = if let Some(idx) = find_address(&self.ctx, addr) {
             idx
         } else {
-            return vec![];
+            return vec![]
         };
 
         let found = if let Some(addr) = self.ctx.addr_at(idx) {
             addr
         } else {
-            return vec![];
+            return vec![]
         };
 
         if addr < found {
-            return vec![];
+            return vec![]
         }
 
         let info = if let Some(info) = self.ctx.addr_info(idx) {
             info
         } else {
-            return Vec::new();
+            return Vec::new()
         };
 
         let name = if let Some(name) = self.ctx.get_str(info.name as usize) {
             name
         } else {
-            return Vec::new();
+            return Vec::new()
         };
 
         vec![(name, found + self.loaded_address)]
@@ -119,17 +119,17 @@ impl SymResolver for GsymResolver {
         let idx = find_address(&self.ctx, addr)?;
         let symaddr = self.ctx.addr_at(idx)?;
         if addr < symaddr {
-            return None;
+            return None
         }
         let addrinfo = self.ctx.addr_info(idx)?;
         if addr >= (symaddr + addrinfo.size as u64) {
-            return None;
+            return None
         }
 
         let addrdatas = parse_address_data(addrinfo.data);
         for adr_ent in addrdatas {
             if adr_ent.typ != InfoTypeLineTableInfo {
-                continue;
+                continue
             }
             // Continue to execute all GSYM line table operations
             // until the end of the buffer is reached or a row
@@ -151,22 +151,20 @@ impl SymResolver for GsymResolver {
                         if addr < lntab_row.address {
                             if row_cnt == 1 {
                                 // The address is lower than the first row.
-                                return None;
+                                return None
                             }
                             // Rollback to the last row.
                             lntab_row = last_lntab_row;
-                            break;
+                            break
                         }
                         last_lntab_row = lntab_row.clone();
                     }
-                    RunResult::End | RunResult::Err => {
-                        break;
-                    }
+                    RunResult::End | RunResult::Err => break,
                 }
             }
 
             if row_cnt == 0 {
-                continue;
+                continue
             }
 
             let finfo = self.ctx.file_info(lntab_row.file_idx as usize)?;
@@ -177,7 +175,7 @@ impl SymResolver for GsymResolver {
                 path,
                 line_no: lntab_row.file_line as usize,
                 column: 0,
-            });
+            })
         }
         None
     }

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -45,17 +45,17 @@ impl KSymResolver {
 
         while let Ok(sz) = reader.read_line(&mut line) {
             if sz == 0 {
-                break;
+                break
             }
             let tokens: Vec<&str> = line.split_whitespace().collect();
             if tokens.len() < 3 {
-                break;
+                break
             }
             let (addr, _symbol, func) = (tokens[0], tokens[1], tokens[2]);
             if let Ok(addr) = u64::from_str_radix(addr, 16) {
                 if addr == 0 {
                     line.truncate(0);
-                    continue;
+                    continue
                 }
                 let name = String::from(func);
                 self.syms.push(Ksym { addr, name });
@@ -77,7 +77,7 @@ impl KSymResolver {
 
     fn ensure_sym_to_addr(&self) {
         if self.sym_to_addr.borrow().len() > 0 {
-            return;
+            return
         }
         let mut sym_to_addr = self.sym_to_addr.borrow_mut();
         for Ksym { name, addr } in self.syms.iter() {
@@ -147,7 +147,7 @@ impl SymResolver for KSymResolver {
 
     fn find_address(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymbolInfo>> {
         if let SymbolType::Variable = opts.sym_type {
-            return None;
+            return None
         }
         self.ensure_sym_to_addr();
 
@@ -158,14 +158,14 @@ impl SymResolver for KSymResolver {
                 size: 0,
                 sym_type: SymbolType::Function,
                 ..Default::default()
-            }]);
+            }])
         }
         None
     }
 
     fn find_address_regex(&self, pattern: &str, opts: &FindAddrOpts) -> Option<Vec<SymbolInfo>> {
         if let SymbolType::Variable = opts.sym_type {
-            return None;
+            return None
         }
         self.ensure_sym_to_addr();
 
@@ -221,7 +221,7 @@ impl KSymCache {
     pub fn get_resolver(&self, path: &Path) -> Result<Rc<KSymResolver>, Error> {
         let mut resolvers = self.resolvers.borrow_mut();
         if let Some(resolver) = resolvers.get(path) {
-            return Ok(resolver.clone());
+            return Ok(resolver.clone())
         }
 
         let mut resolver = Rc::new(KSymResolver::new());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,13 +233,13 @@ impl X86_64StackSession {
 impl StackSession for X86_64StackSession {
     fn next_frame(&mut self) -> Option<&dyn StackFrame> {
         if self._is_at_bottom() {
-            return None;
+            return None
         }
 
         if self.frames.len() > self.current_frame_idx {
             let frame = &self.frames[self.current_frame_idx];
             self.current_frame_idx += 1;
-            return Some(frame);
+            return Some(frame)
         }
 
         let frame = X86_64StackFrame {
@@ -263,7 +263,7 @@ impl StackSession for X86_64StackSession {
 
     fn prev_frame(&mut self) -> Option<&dyn StackFrame> {
         if self.current_frame_idx == 0 {
-            return None;
+            return None
         }
 
         self.current_frame_idx -= 1;
@@ -320,7 +320,7 @@ impl KernelResolver {
                     kallsyms.display(),
                     kernel_image.display()
                 ),
-            ));
+            ))
         }
 
         Ok(KernelResolver {
@@ -483,20 +483,20 @@ impl ResolverMap {
 
         for entry in entries.iter() {
             if entry.path.as_path().components().next() != Some(Component::RootDir) {
-                continue;
+                continue
             }
             if (entry.mode & 0xa) != 0xa {
                 // r-x-
-                continue;
+                continue
             }
 
             if let Ok(filestat) = stat(&entry.path) {
                 if (filestat.st_mode & 0o170000) != 0o100000 {
                     // Not a regular file
-                    continue;
+                    continue
                 }
             } else {
-                continue;
+                continue
             }
             if let Ok(resolver) = ElfResolver::new(&entry.path, entry.loaded_address, cache_holder)
             {
@@ -541,11 +541,11 @@ impl ResolverMap {
                         let kernel_image = loop {
                             let path = dirs[i].join(format!("{basename}{release}"));
                             if stat(&path).is_ok() {
-                                break path;
+                                break path
                             }
                             i += 1;
                             if i >= dirs.len() {
-                                break path;
+                                break path
                             }
                         };
                         kernel_image
@@ -755,9 +755,7 @@ impl BlazeSymbolizer {
 
         let resolver_map = match ResolverMap::new(sym_srcs, &self.cache_holder) {
             Ok(map) => map,
-            _ => {
-                return None;
-            }
+            _ => return None,
         };
         let mut syms = vec![];
         for (_, resolver) in &resolver_map.resolvers {
@@ -818,9 +816,7 @@ impl BlazeSymbolizer {
 
         let resolver_map = match ResolverMap::new(sym_srcs, &self.cache_holder) {
             Ok(map) => map,
-            _ => {
-                return vec![];
-            }
+            _ => return vec![],
         };
         let mut syms_list = vec![];
         for name in names {
@@ -881,7 +877,7 @@ impl BlazeSymbolizer {
         } else {
             #[cfg(debug_assertions)]
             eprintln!("Fail to build ResolverMap");
-            return vec![];
+            return vec![]
         };
 
         let info: Vec<Vec<SymbolizedResult>> = addresses
@@ -890,7 +886,7 @@ impl BlazeSymbolizer {
                 let resolver = if let Some(resolver) = resolver_map.find_resolver(*addr) {
                     resolver
                 } else {
-                    return vec![];
+                    return vec![]
                 };
 
                 let res_syms = resolver.find_symbols(*addr);

--- a/src/util.rs
+++ b/src/util.rs
@@ -213,27 +213,25 @@ pub fn decode_udword(mut data: &[u8]) -> u64 {
     data.read_u64().unwrap()
 }
 
-mod sealed {
-    /// A marker trait for "plain old data" data types.
-    ///
-    /// # Safety
-    /// Only safe to implement for types that are valid for any bit pattern.
-    pub unsafe trait Pod {}
+/// A marker trait for "plain old data" data types.
+///
+/// # Safety
+/// Only safe to implement for types that are valid for any bit pattern.
+pub(crate) unsafe trait Pod {}
 
-    unsafe impl Pod for i8 {}
-    unsafe impl Pod for u8 {}
-    unsafe impl Pod for i16 {}
-    unsafe impl Pod for u16 {}
-    unsafe impl Pod for i32 {}
-    unsafe impl Pod for u32 {}
-    unsafe impl Pod for i64 {}
-    unsafe impl Pod for u64 {}
-    unsafe impl Pod for i128 {}
-    unsafe impl Pod for u128 {}
-}
+unsafe impl Pod for i8 {}
+unsafe impl Pod for u8 {}
+unsafe impl Pod for i16 {}
+unsafe impl Pod for u16 {}
+unsafe impl Pod for i32 {}
+unsafe impl Pod for u32 {}
+unsafe impl Pod for i64 {}
+unsafe impl Pod for u64 {}
+unsafe impl Pod for i128 {}
+unsafe impl Pod for u128 {}
 
 /// An trait providing utility functions for reading data from a byte buffer.
-pub trait ReadRaw<'data> {
+pub(crate) trait ReadRaw<'data> {
     /// Ensure that `len` bytes are available for consumption.
     fn ensure(&self, len: usize) -> Option<()>;
 
@@ -247,7 +245,7 @@ pub trait ReadRaw<'data> {
     #[inline]
     fn read_pod<T>(&mut self) -> Option<T>
     where
-        T: sealed::Pod,
+        T: Pod,
     {
         let data = self.read_slice(size_of::<T>())?;
         // SAFETY: `T` is `Pod` and hence valid for any bit pattern. The pointer

--- a/src/util.rs
+++ b/src/util.rs
@@ -99,24 +99,6 @@ pub fn search_address_opt_key<T, V: Ord>(
     Some(left)
 }
 
-pub fn extract_string(raw: &[u8], off: usize) -> Option<&str> {
-    let mut end = off;
-
-    if off >= raw.len() {
-        return None;
-    }
-    while end < raw.len() && raw[end] != 0 {
-        end += 1;
-    }
-    if end >= raw.len() {
-        return None;
-    }
-    CStr::from_bytes_with_nul(&raw[off..=end])
-        .ok()?
-        .to_str()
-        .ok()
-}
-
 pub struct LinuxMapsEntry {
     pub loaded_address: u64,
     pub end_address: u64,

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,10 +17,10 @@ pub fn search_address_key<T, V: Ord>(
     let mut right = data.len();
 
     if right == 0 {
-        return None;
+        return None
     }
     if address < keyfn(&data[0]) {
-        return None;
+        return None
     }
 
     while (left + 1) < right {
@@ -28,7 +28,7 @@ pub fn search_address_key<T, V: Ord>(
         let key = keyfn(&data[v]);
 
         if key == address {
-            return Some(v);
+            return Some(v)
         }
         if address < key {
             right = v;
@@ -52,17 +52,17 @@ pub fn search_address_opt_key<T, V: Ord>(
     while left < right {
         let left_key = keyfn(&data[left]);
         if left_key.is_some() {
-            break;
+            break
         }
         left += 1;
     }
 
     if left == right {
-        return None;
+        return None
     }
 
     if address < keyfn(&data[left]).unwrap() {
-        return None;
+        return None
     }
 
     while (left + 1) < right {
@@ -73,7 +73,7 @@ pub fn search_address_opt_key<T, V: Ord>(
         while v < right {
             let key = keyfn(&data[v]);
             if key.is_some() {
-                break;
+                break
             }
             v += 1;
         }
@@ -81,13 +81,13 @@ pub fn search_address_opt_key<T, V: Ord>(
         // Shrink to the left side.
         if v == right {
             right = v_saved;
-            continue;
+            continue
         }
 
         let key = keyfn(&data[v]).unwrap();
 
         if key == address {
-            return Some(v);
+            return Some(v)
         }
         if address < key {
             right = v;
@@ -122,7 +122,7 @@ pub fn parse_maps(pid: u32) -> Result<Vec<LinuxMapsEntry>, Error> {
     );
     if re_ptn.is_err() {
         println!("{re_ptn:?}");
-        return Err(Error::new(ErrorKind::InvalidData, "Failed to build regex"));
+        return Err(Error::new(ErrorKind::InvalidData, "Failed to build regex"))
     }
     let re_ptn = re_ptn.unwrap();
 
@@ -328,7 +328,7 @@ pub(crate) trait ReadRaw<'data> {
                 value |= ((byte & 0b0111_1111) as u128) << shift;
                 shift += 7;
                 if (byte & 0b1000_0000) == 0 {
-                    return Some((value, shift / 7));
+                    return Some((value, shift / 7))
                 }
             } else {
                 unreachable!()
@@ -354,7 +354,7 @@ impl<'data> ReadRaw<'data> for &'data [u8] {
     #[inline]
     fn ensure(&self, len: usize) -> Option<()> {
         if len > self.len() {
-            return None;
+            return None
         }
         Some(())
     }


### PR DESCRIPTION
Please see individual commits for descriptions.

With these changes, performance as measured with https://github.com/danielocfb/blazesym-benchmarks/tree/main improved as follows:
```
dwarf/lookup_end_to_end time:   [76.340 ms 76.791 ms 77.263 ms]
                        change: [-29.818% -29.285% -28.736%] (p = 0.00 < 0.02)
                        Performance has improved.
dwarf/symbolize_end_to_end
                        time:   [15.305 ms 15.397 ms 15.488 ms]
                        change: [-13.251% -12.452% -11.686%] (p = 0.00 < 0.02)
                        Performance has improved.
```
(~29% improvement for symbolization and ~12% improvement for reverse symbolization [lookup]; note that these numbers include the necessary setup, which includes IO and cache population etc., which is really what is modified here)

These results are for a ~700 MiB kernel image with debug information.

On top of that it reduces the number of `unsafe` blocks from 184 to 177 (that new count includes trivial `unsafe impl`, so in reality the decrease is larger than that), eliminating various in the process.