### PR TITLE
Include blazesym-benchmarks into repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/vmlinux-5.17.12-100.fc34.x86_64.xz filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /data/*.bin
 /data/*.gsym
+/data/vmlinux-5.17.12-100.fc34.x86_64
 /target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,18 @@ license-file = "LICENSE"
 repository = "https://github.com/libbpf/blazesym"
 edition = "2021"
 exclude = ["data/dwarf-example"]
+autobenches = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 name = "blazesym"
 crate-type = ["cdylib", "rlib", "staticlib"]
+
+[[bench]]
+name = "main"
+harness = false
+required-features = ["generate-bench-files"]
 
 [dependencies]
 nix = "0.24"
@@ -22,16 +28,22 @@ libc = "0.2.137"
 
 [dev-dependencies]
 blazesym = {path = ".", features = ["generate-test-files"]}
+criterion = "0.4"
 
 [build-dependencies]
 anyhow = "1.0.68"
 cbindgen = {version = "0.24", optional = true}
+xz2 = {version = "0.1.7", optional = true}
 
 [features]
 cheader = ["cbindgen"]
 # Enable this feature to opt in to the generation of test files. Having test
 # files created is necessary for running tests.
 generate-test-files = []
+# Enable this feature to opt in to the generation of benchmark files.
+# This feature is required for some of the benchmarks. Note that git-lfs
+# needs to be installed in this case.
+generate-bench-files = ["xz2"]
 # Disable generation of test files. This feature takes preference over
 # `generate-test-files`.
 dont-generate-test-files = []

--- a/benches/dwarf.rs
+++ b/benches/dwarf.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+
+use blazesym::BlazeSymbolizer;
+use blazesym::SymbolSrcCfg;
+use blazesym::SymbolizerFeature;
+
+
+/// Symbolize an address, end-to-end, i.e., including all necessary setup.
+pub fn symbolize_end_to_end() {
+    let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("vmlinux-5.17.12-100.fc34.x86_64");
+    let features = [
+        SymbolizerFeature::DebugInfoSymbols(true),
+        SymbolizerFeature::LineNumberInfo(true),
+    ];
+    let sources = [SymbolSrcCfg::Elf {
+        file_name: dwarf_vmlinux,
+        base_address: 0,
+    }];
+    let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
+
+    let results = symbolizer
+        .symbolize(&sources, &[0xffffffff8110ecb0])
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
+
+    let result = results.first().unwrap();
+    assert_eq!(result.symbol, "abort_creds");
+}
+
+/// Lookup an address, end-to-end, i.e., including all necessary setup.
+pub fn lookup_end_to_end() {
+    let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("vmlinux-5.17.12-100.fc34.x86_64");
+    let features = [
+        SymbolizerFeature::DebugInfoSymbols(true),
+        SymbolizerFeature::LineNumberInfo(true),
+    ];
+    let sources = [SymbolSrcCfg::Elf {
+        file_name: dwarf_vmlinux,
+        base_address: 0,
+    }];
+
+    let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
+    let results = symbolizer
+        .find_addresses(&sources, &["abort_creds"])
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
+
+    let result = results.first().unwrap();
+    assert_eq!(result.address, 0xffffffff8110ecb0);
+}

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,25 @@
+mod dwarf;
+
+use std::time::Duration;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dwarf");
+    group.sample_size(500);
+    group.warm_up_time(Duration::from_secs(5));
+    group.confidence_level(0.98);
+    group.significance_level(0.02);
+    group.bench_function(stringify!(dwarf::lookup_end_to_end), |b| {
+        b.iter(dwarf::lookup_end_to_end)
+    });
+    group.bench_function(stringify!(dwarf::symbolize_end_to_end), |b| {
+        b.iter(dwarf::symbolize_end_to_end)
+    });
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/build.rs
+++ b/build.rs
@@ -145,11 +145,55 @@ fn build_test_bins(crate_root: &Path) {
     dwarf_mostly(&src, "test-dwarf.bin");
 }
 
+/// Unpack an xz compressed file.
+#[cfg(feature = "xz2")]
+fn unpack_xz(src: &Path, dst: &Path) {
+    use std::fs::File;
+    use std::io::copy;
+    use xz2::read::XzDecoder;
+
+    let src_file = File::options().create(false).read(true).open(src).unwrap();
+    let mut decoder = XzDecoder::new_multi_decoder(src_file);
+
+    let mut dst_file = File::options()
+        .create(true)
+        .truncate(true)
+        .read(false)
+        .write(true)
+        .open(dst)
+        .unwrap();
+
+    copy(&mut decoder, &mut dst_file).unwrap();
+}
+
+#[cfg(not(feature = "xz2"))]
+fn unpack_xz(_src: &Path, _dst: &Path) {
+    unimplemented!()
+}
+
+/// Unpack benchmark files.
+fn unpack_bench_files(crate_root: &Path) {
+    let src = Path::new(crate_root)
+        .join("data")
+        .join("vmlinux-5.17.12-100.fc34.x86_64.xz");
+    println!("cargo:rerun-if-changed={}", src.display());
+
+    let mut dst = src.clone();
+    assert!(dst.set_extension(""));
+    println!("cargo:rerun-if-changed={}", dst.display());
+
+    unpack_xz(&src, &dst)
+}
+
 fn main() {
     let crate_dir = env!("CARGO_MANIFEST_DIR");
 
     if cfg!(feature = "generate-test-files") && !cfg!(feature = "dont-generate-test-files") {
         build_test_bins(crate_dir.as_ref());
+    }
+
+    if cfg!(feature = "generate-bench-files") {
+        unpack_bench_files(crate_dir.as_ref());
     }
 
     #[cfg(feature = "cheader")]

--- a/data/vmlinux-5.17.12-100.fc34.x86_64.xz
+++ b/data/vmlinux-5.17.12-100.fc34.x86_64.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63119a022c3b5362d45141df489aecf34f8d8552f707ddff53d78b64a69d8bda
+size 114369740


### PR DESCRIPTION
I originally created blazesym-benchmarks [0] as a separate repository because we wanted to include and benchmark on "real world" data, which was rather big. But given that the data compresses rather well (700 MiB image down to ~100 MiB file) and that we now use git-lfs to manage this data outside of the repository proper and that checkout of it is optional, it arguably makes more sense to include these benchmarks here right away instead. Doing so has the advantage that benchmarks are co-located with library code in a single repository. In order to run this new set of benchmarks the generate-bench-files feature must be present. The benchmarks take a while to run and are generally run much less frequent than tests, so an opt-in scheme seems much more apt than what we have for tests where we generate test files by default in dev-builds. That's also done to not *require* users to have git-lfs installed.
We use criterion as opposed to Rust's built-in benchmark here. The former provide better configurability and more rigorous statistical analysis. The downside is that integration is not quite as nice (with a bunch of macro magic), but it is function over form in this instance.

[0] https://github.com/danielocfb/blazesym-benchmarks