### PR TITLE
Start ELF section search at index one

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -214,7 +214,7 @@ impl<'mmap> Cache<'mmap> {
     /// This function return the index of the section if found.
     fn find_section(&mut self, name: &str) -> Result<usize, Error> {
         let ehdr = self.ensure_ehdr()?;
-        for i in 0..ehdr.e_shnum.into() {
+        for i in 1..ehdr.e_shnum.into() {
             if self.section_name(i)? == name {
                 return Ok(i)
             }


### PR DESCRIPTION
The zeroth ELF section index seems to be reserved and will never contain a valid section. From elf(5):
  > A section header table index is a subscript into this array. Some
  > section header table indices are reserved: the initial entry and the
  > indices between SHN_LORESERVE and SHN_HIRESERVE.  The initial entry
  > is used in ELF extensions for e_phnum, e_shnum, and e_shstrndx; in
  > other cases, each field in the initial entry is set to zero.

We do not have to check it when trying to find a section by name.