### PR TITLE
Add end-to-end test for DWARF symbol lookup

### DIFF
--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -55,3 +55,29 @@ fn symbolize_dwarf() {
     let result = results.first().unwrap();
     assert_eq!(result.symbol, "factorial");
 }
+
+/// Check that we can symbolize an address using DWARF.
+#[test]
+fn lookup_dwarf() {
+    let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-dwarf.bin");
+    let features = [
+        SymbolizerFeature::LineNumberInfo(true),
+        SymbolizerFeature::DebugInfoSymbols(true),
+    ];
+    let srcs = [SymbolSrcCfg::Elf {
+        file_name: test_dwarf,
+        base_address: 0,
+    }];
+    let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
+    let results = symbolizer
+        .find_addresses(&srcs, &["factorial"])
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
+
+    let result = results.first().unwrap();
+    assert_eq!(result.address, 0x2000100);
+}


### PR DESCRIPTION
A recent commit added an end-to-end test for symbolizing an address using DWARF debug information. This change introduces another test for the reverse operation: retrieving an address for a symbol.

Note that our GSYM resolver currently does not support such a lookup, which is why we cannot add a test for this format.