### PR TITLE
Disable Codecov file annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+    annotations: false


### PR DESCRIPTION
We are seeing loads of code coverage annotations on pull requests for files that weren't even touched by said PR, e.g., [here][0]. This change introduces a configuration that hopefully [1] disables the feature.

[0]: https://github.com/libbpf/blazesym/pull/75/commits/57522fcd16a27461cd436cce7de5026e7acecd28
[1]: https://docs.codecov.com/docs/github-checks#disabling-github-checks-patch-annotations-via-yaml