### PR TITLE
Remove SymResolver::repr() method

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -1,3 +1,6 @@
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
@@ -176,11 +179,13 @@ impl SymResolver for ElfResolver {
     fn get_obj_file_name(&self) -> &Path {
         &self.file_name
     }
+}
 
-    fn repr(&self) -> String {
+impl Debug for ElfResolver {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self.backend {
-            ElfBackend::Dwarf(_) => format!("DWARF {}", self.file_name.display()),
-            ElfBackend::Elf(_) => format!("ELF {}", self.file_name.display()),
+            ElfBackend::Dwarf(_) => write!(f, "DWARF {}", self.file_name.display()),
+            ElfBackend::Elf(_) => write!(f, "ELF {}", self.file_name.display()),
         }
     }
 }

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -1,3 +1,6 @@
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 use std::fs::File;
 use std::io::{Error, Read};
 use std::mem;
@@ -188,11 +191,14 @@ impl SymResolver for GsymResolver {
     fn get_obj_file_name(&self) -> &Path {
         &self.file_name
     }
+}
 
-    fn repr(&self) -> String {
-        format!("GSYM {:?}", self.file_name)
+impl Debug for GsymResolver {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "GSYM {}", self.file_name.display())
     }
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -1,17 +1,22 @@
-use super::{FindAddrOpts, SymbolInfo, SymbolType};
-
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::default::Default;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Error};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::u64;
 
-use crate::SymResolver;
-
 use regex::Regex;
+
+use super::FindAddrOpts;
+use super::SymbolInfo;
+use super::SymbolType;
+
+use crate::SymResolver;
 
 pub const KALLSYMS: &str = "/proc/kallsyms";
 const DFL_KSYM_CAP: usize = 200000;
@@ -26,7 +31,6 @@ pub struct Ksym {
 ///
 /// The users should provide the path of kallsyms, so you can provide
 /// a copy from other devices.
-#[derive(Debug)]
 pub struct KSymResolver {
     syms: Vec<Ksym>,
     sym_to_addr: RefCell<HashMap<&'static str, u64>>,
@@ -198,11 +202,14 @@ impl SymResolver for KSymResolver {
     fn get_obj_file_name(&self) -> &Path {
         &self.file_name
     }
+}
 
-    fn repr(&self) -> String {
-        String::from("KSymResolver")
+impl Debug for KSymResolver {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "KSymResolver")
     }
 }
+
 
 /// Cache of KSymResolver.
 ///


### PR DESCRIPTION
It makes little sense to have the SymResolver::repr() method when we could equally well just implement Debug/Display, which is Rust's built-in functionality for accomplishing the same. Require the former and remove SymResolver::repr().