### PR TITLE
Remove Default impl for SymbolInfo

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -199,7 +199,8 @@ impl DwarfResolver {
                 address,
                 size,
                 sym_type,
-                ..Default::default()
+                file_offset: 0,
+                obj_file_name: None,
             });
             idx += 1;
         }
@@ -249,7 +250,8 @@ impl DwarfResolver {
                     address: *address,
                     size: *size,
                     sym_type: *sym_type,
-                    ..Default::default()
+                    file_offset: 0,
+                    obj_file_name: None,
                 });
             }
         }

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -469,7 +469,8 @@ impl ElfParser {
                             address: sym_ref.st_value,
                             size: sym_ref.st_size,
                             sym_type: SymbolType::Function,
-                            ..Default::default()
+                            file_offset: 0,
+                            obj_file_name: None,
                         });
                     }
                 }
@@ -515,7 +516,8 @@ impl ElfParser {
                         address: sym_ref.st_value,
                         size: sym_ref.st_size,
                         sym_type: SymbolType::Function,
-                        ..Default::default()
+                        file_offset: 0,
+                        obj_file_name: None,
                     });
                 }
             }

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -157,7 +157,8 @@ impl SymResolver for KSymResolver {
                 address: *addr,
                 size: 0,
                 sym_type: SymbolType::Function,
-                ..Default::default()
+                file_offset: 0,
+                obj_file_name: None,
             }])
         }
         None
@@ -178,7 +179,8 @@ impl SymResolver for KSymResolver {
                     address: *addr,
                     size: 0,
                     sym_type: SymbolType::Function,
-                    ..Default::default()
+                    file_offset: 0,
+                    obj_file_name: None,
                 });
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,18 +122,6 @@ pub struct SymbolInfo {
     pub obj_file_name: Option<PathBuf>,
 }
 
-impl Default for SymbolInfo {
-    fn default() -> Self {
-        SymbolInfo {
-            name: "".to_string(),
-            address: 0,
-            size: 0,
-            sym_type: SymbolType::Unknown,
-            file_offset: 0,
-            obj_file_name: None,
-        }
-    }
-}
 
 /// The trait of symbol resolvers.
 ///


### PR DESCRIPTION
It makes no sense whatsoever to implement `Default` for a type that does not have any logical default value, such as `SymbolInfo`. Remove it.