### PR TITLE
Use KALLSYMS constant in more places

### DIFF
--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -13,7 +13,7 @@ use crate::SymResolver;
 
 use regex::Regex;
 
-const KALLSYMS: &str = "/proc/kallsyms";
+pub const KALLSYMS: &str = "/proc/kallsyms";
 const DFL_KSYM_CAP: usize = 200000;
 
 #[derive(Debug)]
@@ -204,7 +204,7 @@ impl SymResolver for KSymResolver {
 
 /// Cache of KSymResolver.
 ///
-/// It returns the same isntance if path is the same.
+/// It returns the same instance if path is the same.
 #[derive(Debug)]
 pub struct KSymCache {
     resolvers: RefCell<HashMap<PathBuf, Rc<KSymResolver>>>,
@@ -248,7 +248,7 @@ mod tests {
 
         assert!(
             resolver.syms.len() > 10000,
-            "kallsyms seems to be unavailable or with all 0 addresses. (Check /proc/kallsyms)"
+            "kallsyms seems to be unavailable or with all 0 addresses. (Check {KALLSYMS})"
         );
 
         // Find the address of the symbol placed at the middle

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,7 +530,7 @@ impl ResolverMap {
                 } => {
                     let kallsyms = kallsyms
                         .as_deref()
-                        .unwrap_or_else(|| Path::new("/proc/kallsyms"));
+                        .unwrap_or_else(|| Path::new(ksym::KALLSYMS));
                     let kernel_image = if let Some(img) = kernel_image {
                         img.clone()
                     } else {
@@ -1033,7 +1033,7 @@ mod tests {
         let signatures: Vec<_> = resolver_map.resolvers.iter().map(|x| x.1.repr()).collect();
         assert!(signatures.iter().any(|x| x.contains("KernelResolver")));
 
-        let kallsyms = Path::new("/proc/kallsyms");
+        let kallsyms = Path::new(ksym::KALLSYMS);
         let kernel_image = Path::new("/dev/null");
         let kresolver = KernelResolver::new(kallsyms, kernel_image, &cache_holder).unwrap();
         assert!(kresolver.ksymresolver.is_some());


### PR DESCRIPTION
If we have a constant representing the default path of /proc/kallsyms, we probably should use everywhere the path is needed and not just half the time.