### PR TITLE
Use lru crate for LRU cache functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ required-features = ["generate-bench-files"]
 [dependencies]
 crossbeam-channel = "0.5"
 libc = "0.2.137"
+lru = "0.10"
 memmap = "0.7"
 nix = "0.24"
 regex = "1.6"

--- a/src/elf/cache.rs
+++ b/src/elf/cache.rs
@@ -1,21 +1,22 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::Error;
-use std::path::{Path, PathBuf};
-use std::ptr;
+use std::num::NonZeroUsize;
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+use std::path::PathBuf;
 use std::rc::Rc;
 
+use lru::LruCache;
+
 use nix::sys::stat::{fstat, FileStat};
-use std::os::unix::io::AsRawFd;
 
 use crate::dwarf::DwarfResolver;
 
 use super::ElfParser;
 
-type ElfCacheEntryKey = PathBuf;
-
-const DFL_CACHE_MAX: usize = 1024;
+// SAFETY: The provided value is non-zero.
+const DFL_CACHE_MAX: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1024) };
 
 #[derive(Clone, Debug)]
 pub enum ElfBackend {
@@ -40,12 +41,6 @@ impl ElfBackend {
 
 #[derive(Debug)]
 struct ElfCacheEntry {
-    // LRU links
-    prev: *mut ElfCacheEntry,
-    next: *mut ElfCacheEntry,
-
-    file_name: PathBuf,
-
     dev: libc::dev_t,
     inode: libc::ino_t,
     size: libc::off_t,
@@ -56,7 +51,6 @@ struct ElfCacheEntry {
 
 impl ElfCacheEntry {
     pub fn new(
-        file_name: &Path,
         file: File,
         line_number_info: bool,
         debug_info_symbols: bool,
@@ -75,9 +69,6 @@ impl ElfCacheEntry {
         };
 
         Ok(ElfCacheEntry {
-            prev: ptr::null_mut(),
-            next: ptr::null_mut(),
-            file_name: file_name.to_path_buf(),
             dev: stat.st_dev,
             inode: stat.st_ino,
             size: stat.st_size,
@@ -85,10 +76,6 @@ impl ElfCacheEntry {
             mtime_nsec: stat.st_mtime_nsec,
             backend,
         })
-    }
-
-    fn get_key(&self) -> &Path {
-        &self.file_name
     }
 
     fn is_valid(&self, stat: &FileStat) -> bool {
@@ -104,76 +91,10 @@ impl ElfCacheEntry {
     }
 }
 
-/// Maintain a LRU linked list of entries
-#[derive(Debug)]
-struct ElfCacheLru {
-    head: *mut ElfCacheEntry,
-    tail: *mut ElfCacheEntry,
-}
-
-impl ElfCacheLru {
-    /// # Safety
-    ///
-    /// Make all entries are valid.
-    unsafe fn touch(&mut self, ent: &ElfCacheEntry) {
-        unsafe { self.remove(ent) };
-        unsafe { self.push_back(ent) };
-    }
-
-    /// # Safety
-    ///
-    /// Make all entries are valid.
-    unsafe fn remove(&mut self, ent: &ElfCacheEntry) {
-        let ent_ptr = ent as *const ElfCacheEntry as *mut ElfCacheEntry;
-        let prev = unsafe { (*ent_ptr).prev };
-        let next = unsafe { (*ent_ptr).next };
-        if !prev.is_null() {
-            unsafe { (*prev).next = next };
-        } else {
-            self.head = next;
-        }
-        if !next.is_null() {
-            unsafe { (*next).prev = prev };
-        } else {
-            self.tail = prev;
-        }
-    }
-
-    /// # Safety
-    ///
-    /// Make all entries are valid.
-    unsafe fn push_back(&mut self, ent: &ElfCacheEntry) {
-        let ent_ptr = ent as *const ElfCacheEntry as *mut ElfCacheEntry;
-        if self.head.is_null() {
-            unsafe { (*ent_ptr).next = ptr::null_mut() };
-            unsafe { (*ent_ptr).prev = ptr::null_mut() };
-            self.head = ent_ptr;
-            self.tail = ent_ptr;
-        } else {
-            unsafe { (*ent_ptr).next = ptr::null_mut() };
-            unsafe { (*self.tail).next = ent_ptr };
-            unsafe { (*ent_ptr).prev = self.tail };
-            self.tail = ent_ptr;
-        }
-    }
-
-    /// # Safety
-    ///
-    /// Make all entries are valid.
-    unsafe fn pop_head(&mut self) -> *mut ElfCacheEntry {
-        let ent = self.head;
-        if !ent.is_null() {
-            unsafe { self.remove(&*ent) };
-        }
-        ent
-    }
-}
 
 #[derive(Debug)]
 struct _ElfCache {
-    elfs: HashMap<ElfCacheEntryKey, Box<ElfCacheEntry>>,
-    lru: ElfCacheLru,
-    max_elfs: usize,
+    cache: LruCache<PathBuf, ElfCacheEntry>,
     line_number_info: bool,
     debug_info_symbols: bool,
 }
@@ -181,63 +102,9 @@ struct _ElfCache {
 impl _ElfCache {
     fn new(line_number_info: bool, debug_info_symbols: bool) -> _ElfCache {
         _ElfCache {
-            elfs: HashMap::new(),
-            lru: ElfCacheLru {
-                head: ptr::null_mut(),
-                tail: ptr::null_mut(),
-            },
-            max_elfs: DFL_CACHE_MAX,
+            cache: LruCache::new(DFL_CACHE_MAX),
             line_number_info,
             debug_info_symbols,
-        }
-    }
-
-    /// # Safety
-    ///
-    /// The returned reference is only valid before next time calling
-    /// create_entry().
-    ///
-    unsafe fn find_entry(&mut self, file_name: &Path) -> Option<&ElfCacheEntry> {
-        let ent = self.elfs.get(file_name)?;
-        unsafe { self.lru.touch(ent) };
-
-        Some(ent.as_ref())
-    }
-
-    /// # Safety
-    ///
-    /// The returned reference is only valid before next time calling
-    /// create_entry().
-    ///
-    unsafe fn create_entry(
-        &mut self,
-        file_name: &Path,
-        file: File,
-    ) -> Result<&ElfCacheEntry, Error> {
-        let ent = Box::new(ElfCacheEntry::new(
-            file_name,
-            file,
-            self.line_number_info,
-            self.debug_info_symbols,
-        )?);
-        let key = ent.get_key().to_path_buf();
-
-        self.elfs.insert(key.clone(), ent);
-        unsafe { self.lru.push_back(self.elfs.get(&key).unwrap().as_ref()) };
-        unsafe { self.ensure_size() };
-
-        Ok(unsafe { &*self.lru.tail }) // Get 'static lifetime
-    }
-
-    /// # Safety
-    ///
-    /// This funciton may make some cache entries invalid.  Callers
-    /// should be careful about all references of cache entries they
-    /// are holding.
-    unsafe fn ensure_size(&mut self) {
-        if self.elfs.len() > self.max_elfs {
-            let to_remove = unsafe { self.lru.pop_head() };
-            self.elfs.remove(unsafe { (*to_remove).get_key() }).unwrap();
         }
     }
 
@@ -246,22 +113,18 @@ impl _ElfCache {
         file_name: &Path,
         file: File,
     ) -> Result<ElfBackend, Error> {
-        if let Some(ent) = unsafe { self.find_entry(file_name) } {
+        if let Some(entry) = self.cache.get(file_name) {
             let stat = fstat(file.as_raw_fd())?;
 
-            if ent.is_valid(&stat) {
-                return Ok(ent.get_backend())
+            if entry.is_valid(&stat) {
+                return Ok(entry.get_backend())
             }
-
-            // Purge the entry and load it from the filesystem.
-            unsafe {
-                let ent = &*(ent as *const ElfCacheEntry); // static lifetime to decouple borrowing
-                self.lru.remove(ent)
-            };
-            self.elfs.remove(file_name);
         }
 
-        Ok(unsafe { self.create_entry(file_name, file)? }.get_backend())
+        let entry = ElfCacheEntry::new(file, self.line_number_info, self.debug_info_symbols)?;
+        let backend = entry.get_backend();
+        let _previous = self.cache.put(file_name.to_path_buf(), entry);
+        Ok(backend)
     }
 
     pub fn find(&mut self, path: &Path) -> Result<ElfBackend, Error> {
@@ -291,7 +154,9 @@ impl ElfCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use std::env;
+    use std::ptr;
 
     #[test]
     fn test_cache() {


### PR DESCRIPTION
Use the lru crate for the LRU cache functionality we currently have in place instead of hand rolling our own.