### PR TITLE
Eliminate nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ crossbeam-channel = "0.5"
 libc = "0.2.137"
 lru = "0.10"
 memmap = "0.7"
-nix = "0.24"
 regex = "1.6"
 
 [dev-dependencies]

--- a/src/elf/cache.rs
+++ b/src/elf/cache.rs
@@ -9,10 +9,8 @@ use std::rc::Rc;
 
 use lru::LruCache;
 
-use nix::sys::stat::fstat;
-use nix::sys::stat::FileStat;
-
 use crate::dwarf::DwarfResolver;
+use crate::util::fstat;
 
 use super::ElfParser;
 
@@ -79,7 +77,7 @@ impl ElfCacheEntry {
         })
     }
 
-    fn is_valid(&self, stat: &FileStat) -> bool {
+    fn is_valid(&self, stat: &libc::stat) -> bool {
         stat.st_dev == self.dev
             && stat.st_ino == self.inode
             && stat.st_size == self.size

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -1,4 +1,7 @@
 use std::cell::RefCell;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 use std::fs::File;
 use std::io::Error;
 use std::io::ErrorKind;
@@ -26,7 +29,6 @@ use super::types::SHN_UNDEF;
 use super::types::STT_FUNC;
 
 
-#[derive(Debug)]
 struct Cache<'mmap> {
     /// A slice of the raw ELF data that we are about to parse.
     elf_data: &'mmap [u8],
@@ -319,6 +321,12 @@ impl<'mmap> Cache<'mmap> {
 
         self.str2symtab = Some(str2symtab);
         Ok(())
+    }
+}
+
+impl Debug for Cache<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "Cache")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,6 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::u64;
 
-use nix::sys::utsname;
-
 mod c_api;
 mod dwarf;
 mod elf;
@@ -38,6 +36,7 @@ use elf::ElfResolver;
 use gsym::GsymResolver;
 use ksym::KSymCache;
 use ksym::KSymResolver;
+use util::uname_release;
 
 #[cfg(doc)]
 pub use c_api::*;
@@ -513,7 +512,7 @@ impl ResolverMap {
                     let kernel_image = if let Some(img) = kernel_image {
                         img.clone()
                     } else {
-                        let release = utsname::uname()?.release().to_str().unwrap().to_string();
+                        let release = uname_release()?.to_str().unwrap().to_string();
                         let basename = "vmlinux-";
                         let dirs = [Path::new("/boot/"), Path::new("/usr/lib/debug/boot/")];
                         let mut i = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::u64;
 
-use nix::sys::stat::stat;
 use nix::sys::utsname;
 
 mod c_api;
@@ -470,8 +469,8 @@ impl ResolverMap {
                 continue
             }
 
-            if let Ok(filestat) = stat(&entry.path) {
-                if (filestat.st_mode & 0o170000) != 0o100000 {
+            if let Ok(meta_data) = entry.path.metadata() {
+                if !meta_data.is_file() {
                     // Not a regular file
                     continue
                 }
@@ -520,7 +519,7 @@ impl ResolverMap {
                         let mut i = 0;
                         let kernel_image = loop {
                             let path = dirs[i].join(format!("{basename}{release}"));
-                            if stat(&path).is_ok() {
+                            if path.exists() {
                                 break path
                             }
                             i += 1;


### PR DESCRIPTION
Some of our users are troubled by the number of dependencies we have. This pull requests eliminates the `nix` dependency, replacing it with alternatives from `libc` (around which `nix` is only a thin wrapper anyway, for the most part).