### PR TITLE
Use single line use statements

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,3 @@
 blank_lines_upper_bound = 2
+imports_granularity = "item"
 trailing_semicolon = false

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -1,6 +1,7 @@
 extern crate blazesym;
 
-use blazesym::{BlazeSymbolizer, SymbolSrcCfg};
+use blazesym::BlazeSymbolizer;
+use blazesym::SymbolSrcCfg;
 use std::env;
 use std::path;
 

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -1,6 +1,8 @@
 extern crate blazesym;
 
-use blazesym::{BlazeSymbolizer, SymbolSrcCfg, SymbolizedResult};
+use blazesym::BlazeSymbolizer;
+use blazesym::SymbolSrcCfg;
+use blazesym::SymbolizedResult;
 use std::env;
 
 fn show_usage() {

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -1,4 +1,6 @@
-use std::alloc::{alloc, dealloc, Layout};
+use std::alloc::alloc;
+use std::alloc::dealloc;
+use std::alloc::Layout;
 use std::ffi::CStr;
 use std::ffi::OsStr;
 use std::mem;

--- a/src/dwarf/debug_info.rs
+++ b/src/dwarf/debug_info.rs
@@ -21,7 +21,8 @@
 //! It will walk through the data in the `.debug_info` and
 //! `.debug_abbrev` section to return Units.
 
-use std::io::{Error, ErrorKind};
+use std::io::Error;
+use std::io::ErrorKind;
 use std::iter::Iterator;
 use std::mem;
 

--- a/src/dwarf/parser.rs
+++ b/src/dwarf/parser.rs
@@ -4,7 +4,8 @@ use std::ffi::CStr;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
-use std::io::{Error, ErrorKind};
+use std::io::Error;
+use std::io::ErrorKind;
 use std::mem;
 #[cfg(test)]
 use std::path::Path;

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -2,7 +2,8 @@ use std::cell::RefCell;
 #[cfg(test)]
 use std::env;
 use std::fmt::Debug;
-use std::io::{Error, ErrorKind};
+use std::io::Error;
+use std::io::ErrorKind;
 use std::mem;
 #[cfg(test)]
 use std::path::Path;

--- a/src/elf/cache.rs
+++ b/src/elf/cache.rs
@@ -9,7 +9,8 @@ use std::rc::Rc;
 
 use lru::LruCache;
 
-use nix::sys::stat::{fstat, FileStat};
+use nix::sys::stat::fstat;
+use nix::sys::stat::FileStat;
 
 use crate::dwarf::DwarfResolver;
 

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -302,7 +302,8 @@ mod tests {
 
     use std::env;
     use std::fs::File;
-    use std::io::{Read, Write};
+    use std::io::Read;
+    use std::io::Write;
     use std::path::Path;
 
 

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -6,9 +6,13 @@ use std::io::Error;
 use std::io::ErrorKind;
 use std::io::Read as _;
 use std::mem;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 
-use crate::{AddressLineInfo, FindAddrOpts, SymResolver, SymbolInfo};
+use crate::AddressLineInfo;
+use crate::FindAddrOpts;
+use crate::SymResolver;
+use crate::SymbolInfo;
 
 use super::linetab::run_op;
 use super::linetab::LineTableRow;

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -5,8 +5,11 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Error};
-use std::path::{Path, PathBuf};
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Error;
+use std::path::Path;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::u64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@ mod util;
 use elf::ElfCache;
 use elf::ElfResolver;
 use gsym::GsymResolver;
-use ksym::{KSymCache, KSymResolver};
+use ksym::KSymCache;
+use ksym::KSymResolver;
 
 #[cfg(doc)]
 pub use c_api::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,9 @@
 use std::ffi::CStr;
 use std::fs;
-use std::io::{BufRead, BufReader, Error, ErrorKind};
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Error;
+use std::io::ErrorKind;
 use std::mem::align_of;
 use std::mem::size_of;
 use std::path::PathBuf;


### PR DESCRIPTION
The
>  use <...>::{XXX, YYY, ZZZ}

style for `use` statements is causing merge conflicts all over the place, making it extremely cumbersome to have multiple pull requests in flight. Switch to a different style that is less prone to such issues.