### PR TITLE
Remove multi-threading support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ harness = false
 required-features = ["generate-bench-files"]
 
 [dependencies]
-crossbeam-channel = "0.5"
 libc = "0.2.137"
 lru = "0.10"
 memmap = "0.7"

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -149,7 +149,7 @@ impl DwarfResolver {
             if dis_ref.is_some() {
                 return Ok(())
             }
-            let mut debug_info_syms = debug_info_parse_symbols(&self.parser, None, 1)?;
+            let mut debug_info_syms = debug_info_parse_symbols(&self.parser, None)?;
             debug_info_syms.sort_by_key(|v: &DWSymInfo| -> &str { v.name });
             *dis_ref = Some(unsafe { mem::transmute(debug_info_syms) });
         }


### PR DESCRIPTION
We have some limited support for doing DWARF parsing with multiple threads in debug_info_parse_symbols(), but it is not currently used anywhere but tests/benchmarks. I adjusted the resolver to use four instead of only a single thread but performance of our end-to-end test was unaffected:
```
  dwarf/dwarf :: lookup_end_to_end
                          time:   [38.452 ms 38.729 ms 39.055 ms]
                          change: [+0.4597% +1.5175% +2.5883%] (p = 0.00 < 0.02)
                          Change within noise threshold.
  Found 50 outliers among 500 measurements (10.00%)
    24 (4.80%) high mild
    26 (5.20%) high severe
  dwarf/dwarf :: symbolize_end_to_end
                          time:   [7.8156 ms 7.8725 ms 7.9420 ms]
                          change: [-0.7813% +0.0273% +0.9428%] (p = 0.95 > 0.02)
                          No change in performance detected.
  Found 43 outliers among 500 measurements (8.60%)
    16 (3.20%) high mild
    27 (5.40%) high severe
```

This change removes this multi-threaded code as it was not actually usable by users and consumed an additional dependency. We can resurrect it if truly needed, but APIs should likely be designed differently and not spawn threads internally.