### PR TITLE
Introduce and use Addr typedef

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ The following code makes use of BlazeSym to access symbol names, filenames of
 sources, and line numbers of addresses involved in a process.
 
 ```rust,no_run
-	use blazesym::{BlazeSymbolizer, SymbolSrcCfg, SymbolizedResult};
+	use blazesym::{Addr, BlazeSymbolizer, SymbolSrcCfg, SymbolizedResult};
 
 	let process_id: u32 = std::process::id(); // <some process id>
 	// load all symbols of loaded files of the given process.
 	let sym_srcs = [SymbolSrcCfg::Process { pid: Some(process_id) }];
 	let symbolizer = BlazeSymbolizer::new().unwrap();
 
-	let stack: [u64; 2] = [0xff023, 0x17ff93b];			// Addresses of instructions
+	let stack: [Addr; 2] = [0xff023, 0x17ff93b];		// Addresses of instructions
 	let symlist = symbolizer.symbolize(&sym_srcs,		// Pass this configuration every time
 	                                   &stack);
 	for i in 0..stack.len() {

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -3,6 +3,10 @@ include_guard = "__blazesym_h_"
 
 [export]
 item_types = ["globals", "enums", "structs", "unions", "typedefs", "opaque", "functions"]
+exclude = ["Addr"]
+
+[export.rename]
+"Addr" = "uintptr_t"
 
 [fn]
 args = "Vertical"

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -1,5 +1,6 @@
 extern crate blazesym;
 
+use blazesym::Addr;
 use blazesym::BlazeSymbolizer;
 use blazesym::SymbolSrcCfg;
 use std::env;
@@ -30,7 +31,7 @@ fn main() {
         // Remove prefixed 0x
         addr_str = &addr_str[2..];
     }
-    let addr = u64::from_str_radix(addr_str, 16).unwrap();
+    let addr = Addr::from_str_radix(addr_str, 16).unwrap();
 
     let results = resolver.symbolize(&sym_srcs, &[addr]);
     if results.len() == 1 && !results[0].is_empty() {

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -1,5 +1,6 @@
 extern crate blazesym;
 
+use blazesym::Addr;
 use blazesym::BlazeSymbolizer;
 use blazesym::SymbolSrcCfg;
 use blazesym::SymbolizedResult;
@@ -28,7 +29,7 @@ fn main() {
         // Remove prefixed 0x
         addr_str = &addr_str[2..];
     }
-    let addr = u64::from_str_radix(addr_str, 16).unwrap();
+    let addr = Addr::from_str_radix(addr_str, 16).unwrap();
 
     let sym_files = [SymbolSrcCfg::Process { pid: Some(pid) }];
     let resolver = BlazeSymbolizer::new().unwrap();

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -136,7 +136,7 @@ typedef struct blazesym_csym {
    * The address is already relocated to the address space of
    * the process.
    */
-  uint64_t start_address;
+  uintptr_t start_address;
   /**
    * The path of the source code defines the symbol.
    */
@@ -227,7 +227,7 @@ typedef struct blazesym_ssc_elf {
    * (executable).  For example, the first block is with the
    * permission of `r-xp`.
    */
-  uint64_t base_address;
+  uintptr_t base_address;
 } blazesym_ssc_elf;
 
 /**
@@ -304,7 +304,7 @@ typedef struct blazesym_sym_src_cfg {
 
 typedef struct blazesym_sym_info {
   const uint8_t *name;
-  uint64_t address;
+  uintptr_t address;
   uint64_t size;
   enum blazesym_sym_type sym_type;
   uint64_t file_offset;
@@ -376,7 +376,7 @@ void blazesym_free(struct blazesym *aSymbolizer);
 const struct blazesym_result *blazesym_symbolize(struct blazesym *aSymbolizer,
                                                  const struct blazesym_sym_src_cfg *aSymSrcs,
                                                  uint32_t aSymSrcsLen,
-                                                 const uint64_t *aAddrs,
+                                                 const uintptr_t *aAddrs,
                                                  uintptr_t aAddrCnt);
 
 /**

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -8,8 +8,8 @@ use std::os::raw::c_char;
 use std::os::unix::ffi::OsStrExt as _;
 use std::path::PathBuf;
 use std::ptr;
-use std::u64;
 
+use crate::Addr;
 use crate::BlazeSymbolizer;
 use crate::FindAddrFeature;
 use crate::SymbolInfo;
@@ -64,7 +64,7 @@ pub struct blazesym_ssc_elf {
     /// A loader would load an executable segment with the permission of `x`
     /// (executable).  For example, the first block is with the
     /// permission of `r-xp`.
-    pub base_address: u64,
+    pub base_address: Addr,
 }
 
 /// The parameters to load symbols and debug information from a kernel.
@@ -172,7 +172,7 @@ pub struct blazesym_csym {
     ///
     /// The address is already relocated to the address space of
     /// the process.
-    pub start_address: u64,
+    pub start_address: Addr,
     /// The path of the source code defines the symbol.
     pub path: *const c_char,
     /// The instruction of the address is in the line number of the source code.
@@ -437,7 +437,7 @@ pub unsafe extern "C" fn blazesym_symbolize(
     symbolizer: *mut blazesym,
     sym_srcs: *const blazesym_sym_src_cfg,
     sym_srcs_len: u32,
-    addrs: *const u64,
+    addrs: *const Addr,
     addr_cnt: usize,
 ) -> *const blazesym_result {
     let sym_srcs_rs =
@@ -450,7 +450,7 @@ pub unsafe extern "C" fn blazesym_symbolize(
         };
 
     let symbolizer = unsafe { &*(*symbolizer).symbolizer };
-    let addresses = unsafe { Vec::from_raw_parts(addrs as *mut u64, addr_cnt, addr_cnt) };
+    let addresses = unsafe { Vec::from_raw_parts(addrs as *mut _, addr_cnt, addr_cnt) };
 
     let results = symbolizer.symbolize(&sym_srcs_rs, &addresses);
 
@@ -487,7 +487,7 @@ pub unsafe extern "C" fn blazesym_result_free(results: *const blazesym_result) {
 #[repr(C)]
 pub struct blazesym_sym_info {
     name: *const u8,
-    address: u64,
+    address: Addr,
     size: u64,
     sym_type: blazesym_sym_type,
     file_offset: u64,

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -1,6 +1,7 @@
 //! Opcode runner of GSYM line table.
 
 use crate::util::ReadRaw as _;
+use crate::Addr;
 
 /// End of the line table
 const END_SEQUENCE: u8 = 0x00;
@@ -36,7 +37,7 @@ pub struct LineTableHeader {
 
 #[derive(Clone, Debug)]
 pub struct LineTableRow {
-    pub address: u64,
+    pub address: Addr,
     pub file_idx: u32,
     pub file_line: u32,
 }
@@ -51,7 +52,7 @@ impl LineTableRow {
     ///
     /// * `header` - is a [`LineTableHeader`] returned by [`parse_line_table_header()`].
     /// * `symaddr` - the address of the symbol that `header` belongs to.
-    pub fn line_table_row_from(header: &LineTableHeader, symaddr: u64) -> LineTableRow {
+    pub fn line_table_row_from(header: &LineTableHeader, symaddr: Addr) -> LineTableRow {
         Self {
             address: symaddr,
             file_idx: 1,
@@ -86,7 +87,7 @@ pub fn run_op(
         }
         ADVANCE_PC => {
             let (adv, _bytes) = ops.read_u128_leb128()?;
-            ctx.address += adv as u64;
+            ctx.address += adv as Addr;
             Some(RunResult::NewRow)
         }
         ADVANCE_LINE => {
@@ -117,7 +118,7 @@ pub fn run_op(
             }
 
             ctx.file_line = file_line as u32;
-            ctx.address = (ctx.address as i64 + addr_delta) as u64;
+            ctx.address += addr_delta as Addr;
             Some(RunResult::NewRow)
         }
     }

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -9,6 +9,8 @@ use std::io::ErrorKind;
 use std::io::Read;
 use std::path::PathBuf;
 
+use crate::Addr;
+
 
 /// An enumeration identifying a process.
 #[derive(Clone, Copy, Debug)]
@@ -28,8 +30,8 @@ impl Display for Pid {
 
 
 pub(crate) struct LinuxMapsEntry {
-    pub loaded_address: u64,
-    pub _end_address: u64,
+    pub loaded_address: Addr,
+    pub _end_address: Addr,
     pub mode: u8,
     pub _offset: u64,
     pub path: PathBuf,
@@ -62,13 +64,13 @@ fn parse_maps_line<'line>(line: &'line str, pid: Pid) -> Result<LinuxMapsEntry, 
             format!("encountered malformed address range in proc maps line: {full_line}"),
         )
     })?;
-    let loaded_address = u64::from_str_radix(loaded_str, 16).map_err(|err| {
+    let loaded_address = Addr::from_str_radix(loaded_str, 16).map_err(|err| {
         Error::new(
             ErrorKind::InvalidData,
             format!("encountered malformed start address in proc maps line: {full_line}: {err}"),
         )
     })?;
-    let end_address = u64::from_str_radix(end_str, 16).map_err(|err| {
+    let end_address = Addr::from_str_radix(end_str, 16).map_err(|err| {
         Error::new(
             ErrorKind::InvalidData,
             format!("encountered malformed end address in proc maps line: {full_line}: {err}"),


### PR DESCRIPTION
We mix `u64` and `usize` usage for representing addresses. This change introduces the `Addr` typedef that is to be used moving forward. We define that to map to usize, which is a machine word, which, on all but exotic systems, equals the address size (C additionally has `uintptr_t` for that purpose, but Rust decided not to have that and maps everything to `usize`).
I adjusted all usage that I could identify. Everything I missed can be cleaned up over time.