### PR TITLE
Add zip reading support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /data/*.bin
 /data/*.gsym
+/data/*.zip
 /data/kallsyms
 /data/vmlinux-5.17.12-100.fc34.x86_64
 /target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = "3.4"
 anyhow = "1.0.68"
 cbindgen = {version = "0.24", optional = true}
 xz2 = {version = "0.1.7", optional = true}
+zip = {version = "0.6.4", optional = true, default-features = false}
 
 [features]
 # Enable this feature to re-generate the library's C header file. An
@@ -43,7 +44,7 @@ xz2 = {version = "0.1.7", optional = true}
 generate-c-header = ["cbindgen"]
 # Enable this feature to opt in to the generation of test files. Having test
 # files created is necessary for running tests.
-generate-test-files = ["xz2"]
+generate-test-files = ["xz2", "zip"]
 # Enable this feature to opt in to the generation of benchmark files.
 # This feature is required for some of the benchmarks. Note that git-lfs
 # needs to be installed in this case.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@ mod ksym;
 mod maps;
 mod mmap;
 mod util;
+// TODO: Remove `allow`.
+#[allow(unused)]
+mod zip;
 
 use elf::ElfCache;
 use elf::ElfResolver;

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -1,0 +1,305 @@
+/// Specification of ZIP file format can be found here:
+/// https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+/// For a high level overview of the structure of a ZIP file see
+/// sections 4.3.1 - 4.3.6.
+///
+/// Data structures appearing in ZIP files do not contain any
+/// padding and they might be misaligned. To allow us to safely
+/// operate on pointers to such structures and their members, we
+/// declare the types as packed.
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Result;
+use std::mem::size_of;
+use std::os::unix::ffi::OsStrExt as _;
+use std::path::Path;
+
+use crate::mmap::Mmap;
+use crate::util::Pod;
+use crate::util::ReadRaw as _;
+
+const CD_FILE_HEADER_MAGIC: u32 = 0x02014b50;
+const END_OF_CD_RECORD_MAGIC: u32 = 0x06054b50;
+const LOCAL_FILE_HEADER_MAGIC: u32 = 0x04034b50;
+const FLAG_ENCRYPTED: u16 = 1 << 0;
+const FLAG_HAS_DATA_DESCRIPTOR: u16 = 1 << 3;
+
+
+/// See section 4.3.16 of the spec.
+#[repr(C, packed)]
+struct EndOfCdRecord {
+    /// Magic value equal to END_OF_CD_RECORD_MAGIC.
+    magic: u32,
+    /// Number of the file containing this structure or 0xFFFF if ZIP64 archive.
+    /// Zip archive might span multiple files (disks).
+    this_disk: u16,
+    /// Number of the file containing the beginning of the central directory or
+    /// 0xFFFF if ZIP64 archive.
+    cd_disk: u16,
+    /// Number of central directory records on this disk or 0xFFFF if ZIP64
+    /// archive.
+    cd_records: u16,
+    /// Number of central directory records on all disks or 0xFFFF if ZIP64
+    /// archive.
+    cd_records_total: u16,
+    /// Size of the central directory record or 0xFFFFFFFF if ZIP64 archive.
+    cd_size: u32,
+    /// Offset of the central directory from the beginning of the archive or
+    /// 0xFFFFFFFF if ZIP64 archive.
+    cd_offset: u32,
+    /// Length of comment data following end of central directory record.
+    comment_length: u16,
+    // Up to 64k of arbitrary bytes. */
+    // uint8_t comment[comment_length] */
+}
+
+// SAFETY: `EndOfCdRecord` is valid for any bit pattern.
+unsafe impl Pod for EndOfCdRecord {}
+
+
+/// See section 4.3.12 of the spec.
+#[repr(C, packed)]
+struct CdFileHeader {
+    /// Magic value equal to CD_FILE_HEADER_MAGIC.
+    magic: u32,
+    version: u16,
+    /// Minimum zip version needed to extract the file.
+    min_version: u16,
+    flags: u16,
+    compression: u16,
+    last_modified_time: u16,
+    last_modified_date: u16,
+    crc: u32,
+    compressed_size: u32,
+    uncompressed_size: u32,
+    file_name_length: u16,
+    extra_field_length: u16,
+    file_comment_length: u16,
+    /// Number of the disk where the file starts or 0xFFFF if ZIP64 archive.
+    disk: u16,
+    internal_attributes: u16,
+    external_attributes: u32,
+    /// Offset from the start of the disk containing the local file header to the
+    /// start of the local file header.
+    offset: u32,
+}
+
+// SAFETY: `CdFileHeader` is valid for any bit pattern.
+unsafe impl Pod for CdFileHeader {}
+
+
+/// See section 4.3.7 of the spec.
+#[repr(C, packed)]
+struct LocalFileHeader {
+    /// Magic value equal to LOCAL_FILE_HEADER_MAGIC.
+    magic: u32,
+    /// Minimum zip version needed to extract the file.
+    min_version: u16,
+    flags: u16,
+    compression: u16,
+    last_modified_time: u16,
+    last_modified_date: u16,
+    crc: u32,
+    compressed_size: u32,
+    uncompressed_size: u32,
+    file_name_length: u16,
+    extra_field_length: u16,
+}
+
+// SAFETY: `LocalFileHeader` is valid for any bit pattern.
+unsafe impl Pod for LocalFileHeader {}
+
+
+/// Carries information on name, compression method, and data corresponding to a
+/// file in a zip archive.
+#[derive(Debug)]
+pub struct Entry<'archive> {
+    /// Compression method as defined in pkzip spec. 0 means data is uncompressed.
+    pub compression: u16,
+    /// Name of the file.
+    pub name: &'archive OsStr,
+    /// Pointer to the file data.
+    pub data: &'archive [u8],
+}
+
+
+/// An open zip archive.
+///
+/// Only basic ZIP files are supported, in particular the following are not
+/// supported:
+/// - encryption
+/// - streaming
+/// - multi-part ZIP files
+/// - ZIP64
+#[derive(Debug)]
+pub struct Archive {
+    mmap: Mmap,
+    cd_offset: u32,
+    cd_records: u16,
+}
+
+impl Archive {
+    /// Open a zip archive at the provided `path`.
+    pub fn open<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        fn open_impl(path: &Path) -> Result<Archive> {
+            let file = File::open(path)?;
+            let mmap = Mmap::map(&file)?;
+
+            // Check that a central directory is present as at least some form
+            // of validation that we are in fact dealing with a valid zip file.
+            let (cd_offset, cd_records) = Archive::find_cd(&mmap)?;
+            let slf = Archive {
+                mmap,
+                cd_offset,
+                cd_records,
+            };
+            Ok(slf)
+        }
+
+        open_impl(path.as_ref())
+    }
+
+    fn try_parse_end_of_cd(mut data: &[u8]) -> Option<Result<(u32, u16)>> {
+        let eocd = data.read_pod::<EndOfCdRecord>()?;
+        if eocd.magic != END_OF_CD_RECORD_MAGIC {
+            return None
+        }
+
+        // Make sure that another `comment_length` bytes exist after the end of
+        // cd record.
+        let () = data.ensure(eocd.comment_length.into())?;
+
+        if eocd.this_disk != 0 || eocd.cd_disk != 0 || eocd.cd_records_total != eocd.cd_records {
+            // This is a valid eocd, but we only support single-file non-ZIP64 archives.
+            Some(Err(Error::new(
+                ErrorKind::InvalidData,
+                "archive is unsupported and cannot be opened",
+            )))
+        } else {
+            Some(Ok((eocd.cd_offset, eocd.cd_records)))
+        }
+    }
+
+    /// Search for the central directory at the end of the archive (represented
+    /// by the provided slice of bytes).
+    fn find_cd(data: &[u8]) -> Result<(u32, u16)> {
+        // Because the end of central directory ends with a variable length
+        // array of up to 0xFFFF bytes we can't know exactly where it starts and
+        // need to search for it at the end of the file, scanning the [start,
+        // end] range.
+        let end = data
+            .len()
+            .checked_sub(size_of::<EndOfCdRecord>())
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    "archive is too small to contain end of central directory object",
+                )
+            })?;
+        let start = end.saturating_sub(1 << 16);
+
+        for offset in (start..=end).rev() {
+            let result = Self::try_parse_end_of_cd(data.get(offset..).unwrap());
+            match result {
+                None => continue,
+                Some(Ok((cd_offset, cd_records))) => return Ok((cd_offset, cd_records)),
+                Some(Err(err)) => return Err(err),
+            }
+        }
+
+        Err(Error::new(
+            ErrorKind::InvalidData,
+            "archive does not contain central directory",
+        ))
+    }
+
+    fn parse_entry_at_offset(data: &[u8], offset: u32) -> Result<Entry<'_>> {
+        fn entry_impl(data: &[u8], offset: u32) -> Option<Result<Entry<'_>>> {
+            let mut data = data.get(offset as usize..)?;
+
+            let lfh = data.read_pod::<LocalFileHeader>()?;
+            if lfh.magic != LOCAL_FILE_HEADER_MAGIC {
+                return Some(Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "local file header contains invalid magic number",
+                )))
+            }
+
+            if (lfh.flags & FLAG_ENCRYPTED) != 0 || (lfh.flags & FLAG_HAS_DATA_DESCRIPTOR) != 0 {
+                return Some(Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "attempted lookup of unsupported entry",
+                )))
+            }
+
+            let name = data.read_slice(lfh.file_name_length.into())?;
+            let name = OsStr::from_bytes(name);
+
+            let _extra = data.read_slice(lfh.extra_field_length.into())?;
+            let data = data.read_slice(lfh.compressed_size as usize)?;
+
+            let entry = Entry {
+                compression: lfh.compression,
+                name,
+                data,
+            };
+
+            Some(Ok(entry))
+        }
+
+        entry_impl(data, offset).unwrap_or_else(|| {
+            Err(Error::new(
+                ErrorKind::InvalidData,
+                "failed to read archive entry",
+            ))
+        })
+    }
+
+    /// Look up an entry corresponding to a file in given zip archive.
+    pub fn find_entry(&self, file_name: &str) -> Result<Entry<'_>> {
+        fn entry_impl<'archive>(
+            archive: &'archive Archive,
+            file_name: &str,
+        ) -> Option<Result<Entry<'archive>>> {
+            let mut data = archive.mmap.get(archive.cd_offset as usize..)?;
+
+            for _ in 0..archive.cd_records {
+                let cdfh = data.read_pod::<CdFileHeader>()?;
+
+                if cdfh.magic != CD_FILE_HEADER_MAGIC {
+                    return Some(Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "central directory file header contains invalid magic number",
+                    )))
+                }
+
+                let name = data.read_slice(cdfh.file_name_length.into())?;
+                let name = OsStr::from_bytes(name);
+
+                let _extra = data.read_slice(cdfh.extra_field_length.into())?;
+                let _comment = data.read_slice(cdfh.file_comment_length.into())?;
+
+                if (cdfh.flags & FLAG_ENCRYPTED) == 0
+                    && (cdfh.flags & FLAG_HAS_DATA_DESCRIPTOR) == 0
+                    && name == OsStr::new(file_name)
+                {
+                    return Some(Archive::parse_entry_at_offset(&archive.mmap, cdfh.offset))
+                }
+            }
+
+            None
+        }
+
+        entry_impl(self, file_name).unwrap_or_else(|| {
+            Err(Error::new(
+                ErrorKind::NotFound,
+                "failed to find archive entry",
+            ))
+        })
+    }
+}


### PR DESCRIPTION
Introduce zip reading support. We use our own bespoke implementation to keep dependencies low. That's a requirement for one of our consumers.

The final set of APIs is subject to change as we better understand our use cases. For now this is a pretty straight forward translation of the corresponding C logic.