### PR TITLE
Make FindAddrOpts internal

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -163,7 +163,11 @@ impl DwarfResolver {
     ///
     /// * `name` - is the symbol name to find.
     /// * `opts` - is the context giving additional parameters.
-    pub fn find_address(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymbolInfo>, Error> {
+    pub(crate) fn find_address(
+        &self,
+        name: &str,
+        opts: &FindAddrOpts,
+    ) -> Result<Vec<SymbolInfo>, Error> {
         if let SymbolType::Variable = opts.sym_type {
             return Err(Error::new(ErrorKind::Unsupported, "Not implemented"))
         }
@@ -217,7 +221,7 @@ impl DwarfResolver {
     /// * `opts` - is the context giving additional parameters.
     ///
     /// Return a list of symbols including addresses and other information.
-    pub fn find_address_regex(
+    pub(crate) fn find_address_regex(
         &self,
         pattern: &str,
         opts: &FindAddrOpts,

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -436,7 +436,11 @@ impl ElfParser {
         Ok((name, sym.st_value as Addr))
     }
 
-    pub fn find_address(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymbolInfo>, Error> {
+    pub(crate) fn find_address(
+        &self,
+        name: &str,
+        opts: &FindAddrOpts,
+    ) -> Result<Vec<SymbolInfo>, Error> {
         if let SymbolType::Variable = opts.sym_type {
             return Err(Error::new(ErrorKind::Unsupported, "Not implemented"))
         }
@@ -488,7 +492,7 @@ impl ElfParser {
         }
     }
 
-    pub fn find_address_regex(
+    pub(crate) fn find_address_regex(
         &self,
         pattern: &str,
         opts: &FindAddrOpts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,8 @@ pub enum SymbolType {
 /// The context of an address finding request.
 ///
 /// This type passes additional parameters to resolvers.
-#[doc(hidden)]
 #[derive(Debug)]
-pub struct FindAddrOpts {
+pub(crate) struct FindAddrOpts {
     /// Return the offset of the symbol from the first byte of the
     /// object file if it is true. (False by default)
     offset_in_file: bool,


### PR DESCRIPTION
FindAddrOpts is not meant to be used outside of the crate. Stop exporting it.