### PR TITLE
Make BlazeSymbolizer::find_addresses() return a Result

### DIFF
--- a/benches/dwarf.rs
+++ b/benches/dwarf.rs
@@ -49,6 +49,7 @@ pub fn lookup_end_to_end() {
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
     let results = symbolizer
         .find_addresses(&sources, &["abort_creds"])
+        .unwrap()
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,13 +649,10 @@ impl BlazeSymbolizer {
         sym_srcs: &[SymbolSrcCfg],
         names: &[&str],
         features: &[FindAddrFeature],
-    ) -> Vec<Vec<SymbolInfo>> {
+    ) -> Result<Vec<Vec<SymbolInfo>>> {
         let ctx = Self::find_addr_features_context(features);
 
-        let resolver_map = match ResolverMap::new(sym_srcs, &self.cache_holder) {
-            Ok(map) => map,
-            _ => return vec![],
-        };
+        let resolver_map = ResolverMap::new(sym_srcs, &self.cache_holder)?;
         let mut syms_list = vec![];
         for name in names {
             let mut found = vec![];
@@ -676,7 +673,7 @@ impl BlazeSymbolizer {
             }
             syms_list.push(found);
         }
-        syms_list
+        Ok(syms_list)
     }
 
     /// Find the addresses of a list of symbol names.
@@ -692,7 +689,7 @@ impl BlazeSymbolizer {
         &self,
         sym_srcs: &[SymbolSrcCfg],
         names: &[&str],
-    ) -> Vec<Vec<SymbolInfo>> {
+    ) -> Result<Vec<Vec<SymbolInfo>>> {
         self.find_addresses_opt(sym_srcs, names, &[])
     }
 

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -100,6 +100,7 @@ fn lookup_dwarf() {
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
     let results = symbolizer
         .find_addresses(&srcs, &["factorial"])
+        .unwrap()
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();


### PR DESCRIPTION
Similar to what we did earlier for the symbolization paths, this change adjusts `BlazeSymbolizer::find_addresses()` to return a `Result`.