### PR TITLE
Print rerun directives for created zip files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -175,6 +175,11 @@ fn zip(files: &[PathBuf], dst: &Path) {
             .unwrap();
         let _count = zip.write(&contents).unwrap();
     }
+
+    for file in files {
+        println!("cargo:rerun-if-changed={}", file.display());
+    }
+    println!("cargo:rerun-if-changed={}", dst.display());
 }
 
 #[cfg(not(feature = "zip"))]


### PR DESCRIPTION
When we added logic for creating a zip archive for testing purposes we forgot to emit `cargo:rerun-if-changed` directives. Add them now.