### PR TITLE
Export BlazeSymbolizer as blazesym in C API

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -8,6 +8,7 @@ exclude = ["Addr"]
 
 [export.rename]
 "Addr" = "uintptr_t"
+"BlazeSymbolizer" = "blazesym"
 
 [fn]
 args = "Vertical"

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -98,7 +98,7 @@ typedef enum blazesym_sym_type {
  * kallsyms (`SymbolSrcCfg::Kernel`).  Additionally, BlazeSymbolizer
  * uses information from these sources to symbolize addresses.
  */
-typedef struct BlazeSymbolizer BlazeSymbolizer;
+typedef struct blazesym blazesym;
 
 /**
  * A placeholder symbolizer for C API.
@@ -106,7 +106,7 @@ typedef struct BlazeSymbolizer BlazeSymbolizer;
  * It is returned by [`blazesym_new()`] and should be free by
  * [`blazesym_free()`].
  */
-typedef struct BlazeSymbolizer blazesym;
+typedef struct blazesym blazesym;
 
 typedef union blazesym_feature_params {
   bool enable;


### PR DESCRIPTION
Before commit 5e8b4edbbe37 ("Remove unnecessary indirection in blazesym C type") the C API type blazesym could be used as `struct blazesym`, but that no longer works, because the underlying typedef changed. By telling cbindgen to export BlazeSymbolizer as blazesym we can restore the original behavior.