### PR TITLE
Do not panic when encountering DWARF v5 unit headers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -196,6 +196,7 @@ fn prepare_test_files(crate_root: &Path) {
     let src = crate_root.join("data").join("test.c");
     cc(&src, "test-no-debug.bin", &["-g0"]);
     cc(&src, "test-dwarf-v4.bin", &["-gdwarf-4"]);
+    cc(&src, "test-dwarf-v5.bin", &["-gdwarf-5"]);
 
     let src = crate_root.join("data").join("test-stable-addresses.c");
     let ld_script = crate_root.join("data").join("test-stable-addresses.ld");


### PR DESCRIPTION
We currently may end up panicking the calling thread when encountering DWARF v5 unit header debug information, which we currently do not support. This is not great behavior in many production contexts. With this change we ignore DWARF v5 compile units during iteration, rather than panicking. While at it, remove needless recursion from `UnitIter::next`.