### PR TITLE
Make SymbolizedResult::path member a PathBuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ sources, and line numbers of addresses involved in a process.
 
       for result in sym_results {
         let SymbolizedResult {symbol, start_address, path, line_no, column} = result;
-        println!("    {}@0x{:016x} {}:{}", symbol, start_address, path, line_no);
+        println!("    {}@0x{:016x} {}:{}", symbol, start_address, path.display(), line_no);
       }
     } else {
       let SymbolizedResult {symbol, start_address, path, line_no, column} = &sym_results[0];
-      println!("0x{:016x} {}@0x{:016x} {}:{}", address, symbol, start_address, path, line_no);
+      println!("0x{:016x} {}@0x{:016x} {}:{}", address, symbol, start_address, path.display(), line_no);
     }
   }
 ```

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -39,7 +39,10 @@ fn main() {
         let result = &results[0][0];
         println!(
             "0x{:x} @ {} {}:{}",
-            addr, result.symbol, result.path, result.line_no
+            addr,
+            result.symbol,
+            result.path.display(),
+            result.line_no
         );
     } else {
         println!("0x{addr:x} is not found");

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -49,7 +49,7 @@ fn main() {
             symbol,
             start_address,
             addr - start_address,
-            path,
+            path.display(),
             line_no
         );
     } else {

--- a/src/symbolize.rs
+++ b/src/symbolize.rs
@@ -156,7 +156,7 @@ pub struct SymbolizedResult {
     /// shared object file.
     pub start_address: Addr,
     /// The source path that defines the symbol.
-    pub path: String,
+    pub path: PathBuf,
     /// The line number of the symbolized instruction in the source code.
     ///
     /// This is the line number of the instruction of the address being
@@ -456,7 +456,7 @@ impl BlazeSymbolizer {
                         vec![SymbolizedResult {
                             symbol: "".to_string(),
                             start_address: 0,
-                            path: linfo.path.to_str().unwrap().to_string(),
+                            path: linfo.path,
                             line_no: linfo.line_no,
                             column: linfo.column,
                         }]
@@ -471,7 +471,7 @@ impl BlazeSymbolizer {
                             results.push(SymbolizedResult {
                                 symbol: String::from(sym),
                                 start_address: start,
-                                path: linfo.path.to_str().unwrap().to_string(),
+                                path: linfo.path.clone(),
                                 line_no: linfo.line_no,
                                 column: linfo.column,
                             });
@@ -480,7 +480,7 @@ impl BlazeSymbolizer {
                             results.push(SymbolizedResult {
                                 symbol: String::from(sym),
                                 start_address: start,
-                                path: "".to_string(),
+                                path: PathBuf::new(),
                                 line_no: 0,
                                 column: 0,
                             });


### PR DESCRIPTION
This change converts the SymbolizedResult::path member from a String to a PathBuf.