### PR TITLE
Expose blaze_user_addr_meta* types in C API

### DIFF
--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -117,12 +117,27 @@ typedef struct blazesym blazesym;
 /**
  * C compatible version of [`Binary`].
  */
-typedef struct blaze_user_addr_meta_binary blaze_user_addr_meta_binary;
+typedef struct blaze_user_addr_meta_binary {
+  /**
+   * The path to the binary. This member is always present.
+   */
+  char *path;
+  /**
+   * The length of the build ID, in bytes.
+   */
+  size_t build_id_len;
+  /**
+   * The optional build ID of the binary, if found.
+   */
+  uint8_t *build_id;
+} blaze_user_addr_meta_binary;
 
 /**
  * C compatible version of [`Unknown`].
  */
-typedef struct blaze_user_addr_meta_unknown blaze_user_addr_meta_unknown;
+typedef struct blaze_user_addr_meta_unknown {
+
+} blaze_user_addr_meta_unknown;
 
 /**
  * The actual variant data in [`blaze_user_addr_meta`].

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -52,6 +52,7 @@ pub enum blaze_user_addr_meta_kind {
 
 /// C compatible version of [`Binary`].
 #[allow(non_camel_case_types)]
+#[repr(C)]
 #[derive(Debug)]
 pub struct blaze_user_addr_meta_binary {
     /// The path to the binary. This member is always present.
@@ -116,6 +117,7 @@ impl From<blaze_user_addr_meta_binary> for Binary {
 
 /// C compatible version of [`Unknown`].
 #[allow(non_camel_case_types)]
+#[repr(C)]
 #[derive(Debug)]
 pub struct blaze_user_addr_meta_unknown {}
 


### PR DESCRIPTION
We missed tagging `blaze_user_addr_meta_binary` and
`blaze_user_addr_meta_unknown` with `repr(C)` and so they didn't get picked up by `cbindgen`. Do that now.