### PR TITLE
Remove file system based "is file" check from is_symbolization_releva…

### DIFF
--- a/src/maps.rs
+++ b/src/maps.rs
@@ -196,16 +196,6 @@ pub(crate) fn is_symbolization_relevant(entry: &MapsEntry) -> bool {
         return false
     }
 
-    if let Ok(meta_data) = entry.path.metadata() {
-        if !meta_data.is_file() {
-            return false
-        }
-    } else {
-        // TODO: We probably should handle errors more gracefully. It's not
-        //       clear that silently ignoring them is the right thing to do.
-        return false
-    }
-
     true
 }
 


### PR DESCRIPTION
…nt()

The proc maps logic for filtering of relevant entries currently makes a system call to get file system information about whether the provided path is a file or not. It's not entirely clear why we need that: if the path starts with a slash (which we already check) it will presumably always be a file, or at least it's not clear what else it could be. Omit this addition check via system call.