### PR TITLE
Make symbolize call only take a single symbol source/configuration

### DIFF
--- a/benches/dwarf.rs
+++ b/benches/dwarf.rs
@@ -18,14 +18,14 @@ fn symbolize_end_to_end() {
         SymbolizerFeature::DebugInfoSymbols(true),
         SymbolizerFeature::LineNumberInfo(true),
     ];
-    let sources = [SymbolSrcCfg::Elf(cfg::Elf {
+    let cfg = SymbolSrcCfg::Elf(cfg::Elf {
         file_name: dwarf_vmlinux,
         base_address: 0,
-    })];
+    });
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
 
     let results = symbolizer
-        .symbolize(&sources, &[0xffffffff8110ecb0])
+        .symbolize(&cfg, &[0xffffffff8110ecb0])
         .unwrap()
         .into_iter()
         .flatten()
@@ -45,14 +45,14 @@ fn lookup_end_to_end() {
         SymbolizerFeature::DebugInfoSymbols(true),
         SymbolizerFeature::LineNumberInfo(true),
     ];
-    let sources = [SymbolSrcCfg::Elf(cfg::Elf {
+    let cfg = SymbolSrcCfg::Elf(cfg::Elf {
         file_name: dwarf_vmlinux,
         base_address: 0,
-    })];
+    });
 
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
     let results = symbolizer
-        .find_addresses(&sources, &["abort_creds"])
+        .find_addresses(&cfg, &["abort_creds"])
         .unwrap()
         .into_iter()
         .flatten()

--- a/benches/gsym.rs
+++ b/benches/gsym.rs
@@ -18,14 +18,14 @@ fn symbolize_end_to_end() {
         SymbolizerFeature::DebugInfoSymbols(true),
         SymbolizerFeature::LineNumberInfo(true),
     ];
-    let sources = [SymbolSrcCfg::Gsym(cfg::Gsym {
+    let cfg = SymbolSrcCfg::Gsym(cfg::Gsym {
         file_name: gsym_vmlinux,
         base_address: 0,
-    })];
+    });
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
 
     let results = symbolizer
-        .symbolize(&sources, &[0xffffffff8110ecb0])
+        .symbolize(&cfg, &[0xffffffff8110ecb0])
         .unwrap()
         .into_iter()
         .flatten()

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -22,10 +22,10 @@ fn main() {
 
     let bin_name = &args[1];
     let mut addr_str = &args[2][..];
-    let sym_srcs = [SymbolSrcCfg::Elf(cfg::Elf {
+    let cfg = SymbolSrcCfg::Elf(cfg::Elf {
         file_name: path::PathBuf::from(bin_name),
         base_address: 0x0,
-    })];
+    });
     let resolver = BlazeSymbolizer::new().unwrap();
 
     if &addr_str[0..2] == "0x" {
@@ -34,7 +34,7 @@ fn main() {
     }
     let addr = Addr::from_str_radix(addr_str, 16).unwrap();
 
-    let results = resolver.symbolize(&sym_srcs, &[addr]).unwrap();
+    let results = resolver.symbolize(&cfg, &[addr]).unwrap();
     if results.len() == 1 && !results[0].is_empty() {
         let result = &results[0][0];
         println!(

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -32,9 +32,9 @@ fn main() {
     }
     let addr = Addr::from_str_radix(addr_str, 16).unwrap();
 
-    let sym_files = [SymbolSrcCfg::Process(cfg::Process { pid: Some(pid) })];
+    let cfg = SymbolSrcCfg::Process(cfg::Process { pid: Some(pid) });
     let resolver = BlazeSymbolizer::new().unwrap();
-    let symlist = resolver.symbolize(&sym_files, &[addr]).unwrap();
+    let symlist = resolver.symbolize(&cfg, &[addr]).unwrap();
     if !symlist[0].is_empty() {
         let SymbolizedResult {
             symbol,

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -526,8 +526,7 @@ void blazesym_free(blazesym *symbolizer);
  * The returned pointer should be freed by [`blazesym_result_free()`].
  */
 const struct blazesym_result *blazesym_symbolize(blazesym *symbolizer,
-                                                 const struct blazesym_sym_src_cfg *sym_srcs,
-                                                 size_t sym_srcs_len,
+                                                 const struct blazesym_sym_src_cfg *cfg,
                                                  const uintptr_t *addrs,
                                                  size_t addr_cnt);
 
@@ -556,8 +555,7 @@ void blazesym_result_free(const struct blazesym_result *results);
  * The returned pointer should be free by [`blazesym_syms_free()`].
  */
 const struct blazesym_sym_info *blazesym_find_address_regex_opt(blazesym *symbolizer,
-                                                                const struct blazesym_sym_src_cfg *sym_srcs,
-                                                                size_t sym_srcs_len,
+                                                                const struct blazesym_sym_src_cfg *cfg,
                                                                 const char *pattern,
                                                                 const struct blazesym_faddr_feature *features,
                                                                 size_t num_features);
@@ -574,8 +572,7 @@ const struct blazesym_sym_info *blazesym_find_address_regex_opt(blazesym *symbol
  * The returned pointer should be free by [`blazesym_syms_free()`].
  */
 const struct blazesym_sym_info *blazesym_find_address_regex(blazesym *symbolizer,
-                                                            const struct blazesym_sym_src_cfg *sym_srcs,
-                                                            size_t sym_srcs_len,
+                                                            const struct blazesym_sym_src_cfg *cfg,
                                                             const char *pattern);
 
 /**
@@ -604,8 +601,7 @@ void blazesym_syms_free(const struct blazesym_sym_info *syms);
  * The returned pointer should be free by [`blazesym_syms_list_free()`].
  */
 const struct blazesym_sym_info *const *blazesym_find_addresses_opt(blazesym *symbolizer,
-                                                                   const struct blazesym_sym_src_cfg *sym_srcs,
-                                                                   size_t sym_srcs_len,
+                                                                   const struct blazesym_sym_src_cfg *cfg,
                                                                    const char *const *names,
                                                                    size_t name_cnt,
                                                                    const struct blazesym_faddr_feature *features,
@@ -621,8 +617,7 @@ const struct blazesym_sym_info *const *blazesym_find_addresses_opt(blazesym *sym
  * The returned data should be free by [`blazesym_syms_list_free()`].
  */
 const struct blazesym_sym_info *const *blazesym_find_addresses(blazesym *symbolizer,
-                                                               const struct blazesym_sym_src_cfg *sym_srcs,
-                                                               size_t sym_srcs_len,
+                                                               const struct blazesym_sym_src_cfg *cfg,
                                                                const char *const *names,
                                                                size_t name_cnt);
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -157,7 +157,7 @@ impl ResolverMap {
     }
 
     pub fn new(
-        sym_srcs: &[SymbolSrcCfg],
+        sym_srcs: &[&SymbolSrcCfg],
         ksym_cache: &KSymCache,
         elf_cache: &ElfCache,
     ) -> Result<ResolverMap> {

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -29,9 +29,7 @@ fn error_on_non_existent_source() {
     let symbolizer = BlazeSymbolizer::new().unwrap();
 
     for src in srcs {
-        let err = symbolizer
-            .symbolize([src].as_slice(), &[0x2000100])
-            .unwrap_err();
+        let err = symbolizer.symbolize(&src, &[0x2000100]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::NotFound);
     }
 }
@@ -44,14 +42,14 @@ fn symbolize_gsym() {
         .join("test.gsym");
 
     let features = vec![SymbolizerFeature::LineNumberInfo(true)];
-    let srcs = vec![SymbolSrcCfg::Gsym(cfg::Gsym {
+    let cfg = SymbolSrcCfg::Gsym(cfg::Gsym {
         file_name: test_gsym,
         base_address: 0,
-    })];
+    });
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
 
     let results = symbolizer
-        .symbolize(&srcs, &[0x2000100])
+        .symbolize(&cfg, &[0x2000100])
         .unwrap()
         .into_iter()
         .flatten()
@@ -72,13 +70,13 @@ fn symbolize_dwarf() {
         SymbolizerFeature::LineNumberInfo(true),
         SymbolizerFeature::DebugInfoSymbols(true),
     ];
-    let srcs = [SymbolSrcCfg::Elf(cfg::Elf {
+    let cfg = SymbolSrcCfg::Elf(cfg::Elf {
         file_name: test_dwarf,
         base_address: 0,
-    })];
+    });
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
     let results = symbolizer
-        .symbolize(&srcs, &[0x2000100])
+        .symbolize(&cfg, &[0x2000100])
         .unwrap()
         .into_iter()
         .flatten()
@@ -99,13 +97,13 @@ fn lookup_dwarf() {
         SymbolizerFeature::LineNumberInfo(true),
         SymbolizerFeature::DebugInfoSymbols(true),
     ];
-    let srcs = [SymbolSrcCfg::Elf(cfg::Elf {
+    let cfg = SymbolSrcCfg::Elf(cfg::Elf {
         file_name: test_dwarf,
         base_address: 0,
-    })];
+    });
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
     let results = symbolizer
-        .find_addresses(&srcs, &["factorial"])
+        .find_addresses(&cfg, &["factorial"])
         .unwrap()
         .into_iter()
         .flatten()
@@ -127,13 +125,13 @@ fn lookup_dwarf_no_debug_info() {
         SymbolizerFeature::LineNumberInfo(true),
         SymbolizerFeature::DebugInfoSymbols(false),
     ];
-    let srcs = [SymbolSrcCfg::Elf(cfg::Elf {
+    let cfg = SymbolSrcCfg::Elf(cfg::Elf {
         file_name: test_dwarf,
         base_address: 0,
-    })];
+    });
     let symbolizer = BlazeSymbolizer::new_opt(&features).unwrap();
     let results = symbolizer
-        .find_addresses(&srcs, &["factorial"])
+        .find_addresses(&cfg, &["factorial"])
         .unwrap()
         .into_iter()
         .flatten()
@@ -166,14 +164,14 @@ fn normalize_user_address() {
     let meta = &norm_addrs.meta[norm_addr.1];
     assert_eq!(meta.binary().unwrap().path, test_so);
 
-    let srcs = [SymbolSrcCfg::Elf(cfg::Elf {
+    let cfg = SymbolSrcCfg::Elf(cfg::Elf {
         file_name: test_so,
         // TODO: Fix our symbolizer. Base address should be 0.
         base_address: 0x1000,
-    })];
+    });
     let symbolizer = BlazeSymbolizer::new().unwrap();
     let results = symbolizer
-        .symbolize(&srcs, &[norm_addr.0])
+        .symbolize(&cfg, &[norm_addr.0])
         .unwrap()
         .into_iter()
         .flatten()

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -59,17 +59,8 @@ fn symbolizer_creation_with_features() {
 fn symbolize_from_file() {
     fn test(cfg: blazesym_sym_src_cfg) {
         let symbolizer = unsafe { blazesym_new() };
-        let srcs = [cfg];
         let addrs = [0x2000100];
-        let result = unsafe {
-            blazesym_symbolize(
-                symbolizer,
-                srcs.as_ptr(),
-                srcs.len(),
-                addrs.as_ptr(),
-                addrs.len(),
-            )
-        };
+        let result = unsafe { blazesym_symbolize(symbolizer, &cfg, addrs.as_ptr(), addrs.len()) };
 
         assert!(!result.is_null());
 
@@ -145,23 +136,15 @@ fn lookup_dwarf() {
         file_name: test_dwarf_c.as_ptr(),
         base_address: 0,
     });
-    let srcs = [blazesym_sym_src_cfg {
+    let cfg = blazesym_sym_src_cfg {
         src_type: blazesym_src_type::BLAZESYM_SRC_T_ELF,
         params: blazesym_ssc_params { elf: elf_src },
-    }];
+    };
 
     let factorial = CString::new("factorial").unwrap();
     let names = [factorial.as_ptr()];
 
-    let result = unsafe {
-        blazesym_find_addresses(
-            symbolizer,
-            srcs.as_ptr(),
-            srcs.len(),
-            names.as_ptr(),
-            names.len(),
-        )
-    };
+    let result = unsafe { blazesym_find_addresses(symbolizer, &cfg, names.as_ptr(), names.len()) };
     let sym_infos = unsafe { slice::from_raw_parts(result, names.len()) };
     let sym_info = unsafe { &*sym_infos[0] };
     assert_eq!(


### PR DESCRIPTION
There is not much of a point in passing a set of symbol sources/configurations to a symbolize call. Rather, it only complicates a bunch of things, from the API to the various internals. For one, now we need to create this "resolver map" in order to find the "correct" resolver to use. That in turn requires each resolver to know the range it covers -- which it otherwise would not have to. It also means that users are asked to provide a base address for sources such as gsym or ELF.
With this change we only accept a single symbol source/configuration and adjust all APIs accordingly.