### PR TITLE
Add benchmark for process symbolization

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,6 +1,7 @@
 mod dwarf;
 mod gsym;
 mod normalize;
+mod symbolize;
 
 use std::time::Duration;
 
@@ -18,6 +19,7 @@ fn benchmark(c: &mut Criterion) {
     dwarf::benchmark(&mut group);
     gsym::benchmark(&mut group);
     normalize::benchmark(&mut group);
+    symbolize::benchmark(&mut group);
 }
 
 criterion_group!(benches, benchmark);

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -1,0 +1,34 @@
+use blazesym::c_api;
+use blazesym::cfg;
+use blazesym::Addr;
+use blazesym::BlazeSymbolizer;
+use blazesym::SymbolSrcCfg;
+
+use criterion::measurement::Measurement;
+use criterion::BenchmarkGroup;
+
+
+/// Symbolize addresses in the current process.
+fn symbolize_process() {
+    let cfg = SymbolSrcCfg::Process(cfg::Process { pid: None });
+    let addrs = [
+        libc::__errno_location as Addr,
+        libc::dlopen as Addr,
+        libc::fopen as Addr,
+        symbolize_process as Addr,
+        c_api::blazesym_find_addresses as Addr,
+    ];
+
+    let symbolizer = BlazeSymbolizer::new().unwrap();
+    let results = symbolizer.symbolize(&cfg, &addrs).unwrap();
+    assert_eq!(results.len(), addrs.len());
+}
+
+pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
+where
+    M: Measurement,
+{
+    group.bench_function(stringify!(symbolize::symbolize_process), |b| {
+        b.iter(symbolize_process)
+    });
+}


### PR DESCRIPTION
This change introduces a benchmark for the process symbolization functionality. The benchmark measures end-to-end times for the symbolization of five addresses inside the current process.

```
> Benchmarking main/symbolize :: symbolize_process: Collecting 500 samples in estimated 5.
> main/symbolize :: symbolize_process
>     time:   [970.41 µs 970.62 µs 970.89 µs]
```