### PR TITLE
Remove suppression file usage from LSAN CI run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
         CXXFLAGS: "-fsanitize=${{ matrix.sanitizer }}"
         RUSTFLAGS: "-Zsanitizer=${{ matrix.sanitizer }}"
         ASAN_OPTIONS: "detect_odr_violation=0:detect_leaks=0"
-        LSAN_OPTIONS: "suppressions=lsan-suppressions.txt"
+        LSAN_OPTIONS: ""
       run: cargo test --lib --tests --target x86_64-unknown-linux-gnu
   test-release:
     name: Test with release build


### PR DESCRIPTION
We do not currently have a suppression file and so if we were to have a leak in our code, LSAN would attempt to open the non-existent lsan-suppressions.txt file and fail. Remove this option.