### PR TITLE
Use nightly Rust for code coverage job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,10 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - name: Install cargo-llvm-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
+        profile: minimal
         override: true
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
@@ -71,6 +72,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
+        profile: minimal
         override: true
     - name: Enable debug symbols
       run: |
@@ -101,6 +103,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        profile: minimal
         override: true
     - run: cargo test --release
   c-header:
@@ -111,6 +114,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        profile: minimal
         override: true
     - run: cargo check --features=generate-c-header
     - name: Check that C header is up-to-date
@@ -124,6 +128,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
+        profile: minimal
         override: true
     - run: cargo bench --features=nightly,dont-generate-test-files
   clippy:
@@ -134,6 +139,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          profile: minimal
           components: clippy
           override: true
       - run: cargo clippy --no-deps --bins --lib --examples --tests --features=dont-generate-test-files -- -A unknown_lints
@@ -145,6 +151,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          profile: minimal
           components: rustfmt
           override: true
       - run: cargo +nightly fmt -- --check
@@ -158,5 +165,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          profile: minimal
           override: true
       - run: cargo doc --no-deps


### PR DESCRIPTION
We missed explicitly installing the most recent Rust for the coverage job. That resulted in us using the Ubuntu default Rust toolchain. Especially for code coverage, it can pay off to use the most recent Rust version, which uses more up-to-date LLVM toolchains, which in turn may provide better coverage instrumentation. In fact, code coverage still works best on nightly, so switch to using a nightly toolchain for this job.
