### PR TITLE
Make symbolization source types non-exhaustive

### DIFF
--- a/benches/dwarf.rs
+++ b/benches/dwarf.rs
@@ -18,10 +18,7 @@ fn symbolize_end_to_end() {
         SymbolizerFeature::DebugInfoSymbols(true),
         SymbolizerFeature::LineNumberInfo(true),
     ];
-    let src = Source::Elf(Elf {
-        file_name: dwarf_vmlinux,
-        base_address: 0,
-    });
+    let src = Source::Elf(Elf::new(dwarf_vmlinux));
     let symbolizer = Symbolizer::with_opts(&features).unwrap();
 
     let results = symbolizer
@@ -45,10 +42,7 @@ fn lookup_end_to_end() {
         SymbolizerFeature::DebugInfoSymbols(true),
         SymbolizerFeature::LineNumberInfo(true),
     ];
-    let src = Source::Elf(Elf {
-        file_name: dwarf_vmlinux,
-        base_address: 0,
-    });
+    let src = Source::Elf(Elf::new(dwarf_vmlinux));
 
     let symbolizer = Symbolizer::with_opts(&features).unwrap();
     let results = symbolizer

--- a/benches/gsym.rs
+++ b/benches/gsym.rs
@@ -18,10 +18,7 @@ fn symbolize_end_to_end() {
         SymbolizerFeature::DebugInfoSymbols(true),
         SymbolizerFeature::LineNumberInfo(true),
     ];
-    let src = Source::Gsym(Gsym {
-        file_name: gsym_vmlinux,
-        base_address: 0,
-    });
+    let src = Source::Gsym(Gsym::new(gsym_vmlinux));
     let symbolizer = Symbolizer::with_opts(&features).unwrap();
 
     let results = symbolizer

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -11,7 +11,7 @@ use criterion::BenchmarkGroup;
 
 /// Symbolize addresses in the current process.
 fn symbolize_process() {
-    let src = Source::Process(Process { pid: Pid::Slf });
+    let src = Source::Process(Process::new(Pid::Slf));
     let addrs = [
         libc::__errno_location as Addr,
         libc::dlopen as Addr,

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -5,7 +5,6 @@ use blazesym::symbolize::Source;
 use blazesym::symbolize::Symbolizer;
 use blazesym::Addr;
 use std::env;
-use std::path;
 
 fn show_usage() {
     let args: Vec<String> = env::args().collect();
@@ -22,10 +21,7 @@ fn main() {
 
     let bin_name = &args[1];
     let mut addr_str = &args[2][..];
-    let src = Source::Elf(Elf {
-        file_name: path::PathBuf::from(bin_name),
-        base_address: 0x0,
-    });
+    let src = Source::Elf(Elf::new(bin_name));
     let resolver = Symbolizer::new().unwrap();
 
     if &addr_str[0..2] == "0x" {

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -32,7 +32,7 @@ fn main() {
     }
     let addr = Addr::from_str_radix(addr_str, 16).unwrap();
 
-    let src = Source::Process(Process { pid: pid.into() });
+    let src = Source::Process(Process::new(pid.into()));
     let resolver = Symbolizer::new().unwrap();
     let symlist = resolver.symbolize(&src, &[addr]).unwrap();
     if !symlist[0].is_empty() {

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -163,6 +163,7 @@ impl From<&blazesym_sym_src_cfg> for Source {
                 Source::Elf(Elf {
                     file_name: unsafe { from_cstr(elf.file_name) },
                     base_address: elf.base_address,
+                    _non_exhaustive: (),
                 })
             }
             blazesym_src_type::BLAZESYM_SRC_T_KERNEL => {
@@ -181,12 +182,16 @@ impl From<&blazesym_sym_src_cfg> for Source {
                     } else {
                         None
                     },
+                    _non_exhaustive: (),
                 })
             }
             blazesym_src_type::BLAZESYM_SRC_T_PROCESS => {
                 // SAFETY: `process` is the union variant used for `BLAZESYM_SRC_T_PROCESS`.
                 let pid = unsafe { src.params.process.pid };
-                Source::Process(Process { pid: pid.into() })
+                Source::Process(Process {
+                    pid: pid.into(),
+                    _non_exhaustive: (),
+                })
             }
             blazesym_src_type::BLAZESYM_SRC_T_GSYM => {
                 // SAFETY: `gsym` is the union variant used for `BLAZESYM_SRC_T_GSYM`.
@@ -194,6 +199,7 @@ impl From<&blazesym_sym_src_cfg> for Source {
                 Source::Gsym(Gsym {
                     file_name: unsafe { from_cstr(gsym.file_name) },
                     base_address: gsym.base_address,
+                    _non_exhaustive: (),
                 })
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! let process_id: u32 = std::process::id(); // <some process id>
 //! // Load all symbols of loaded files of the given process.
-//! let src = Source::Process(Process { pid: process_id.into() });
+//! let src = Source::Process(Process::new(process_id.into()));
 //! let symbolizer = Symbolizer::new().unwrap();
 //!
 //! let stack: [Addr; 2] = [0xff023, 0x17ff93b];  // Addresses of instructions

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -50,6 +50,7 @@ impl ResolverMap {
         let symbolize::Elf {
             file_name,
             base_address,
+            _non_exhaustive: (),
         } = src;
 
         let backend = elf_cache.find(file_name)?;

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -37,6 +37,20 @@ pub struct Elf {
     /// `x`.  For example, the first block is with the permission of
     /// `r-xp`.
     pub base_address: Addr,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub(crate) _non_exhaustive: (),
+}
+
+impl Elf {
+    /// Create a new [`Elf`] object, referencing the provided path.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            file_name: path.into(),
+            base_address: 0,
+            _non_exhaustive: (),
+        }
+    }
 }
 
 impl From<Elf> for Source {
@@ -47,7 +61,7 @@ impl From<Elf> for Source {
 
 
 /// Linux Kernel's binary image and a copy of /proc/kallsyms
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Kernel {
     /// The path of a kallsyms copy.
     ///
@@ -64,6 +78,9 @@ pub struct Kernel {
     /// kernel image of the running kernel in `"/boot/"` or
     /// `"/usr/lib/debug/boot/"`.
     pub kernel_image: Option<PathBuf>,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub(crate) _non_exhaustive: (),
 }
 
 impl From<Kernel> for Source {
@@ -81,6 +98,19 @@ impl From<Kernel> for Source {
 #[derive(Clone, Debug)]
 pub struct Process {
     pub pid: Pid,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub(crate) _non_exhaustive: (),
+}
+
+impl Process {
+    /// Create a new [`Process`] object using the provided `pid`.
+    pub fn new(pid: Pid) -> Self {
+        Self {
+            pid,
+            _non_exhaustive: (),
+        }
+    }
 }
 
 impl From<Process> for Source {
@@ -97,6 +127,20 @@ pub struct Gsym {
     pub file_name: PathBuf,
     /// The base address.
     pub base_address: Addr,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub(crate) _non_exhaustive: (),
+}
+
+impl Gsym {
+    /// Create a new [`Gsym`] object, referencing the provided path.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            file_name: path.into(),
+            base_address: 0,
+            _non_exhaustive: (),
+        }
+    }
 }
 
 impl From<Gsym> for Source {

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -280,6 +280,7 @@ impl Symbolizer {
         let Kernel {
             kallsyms,
             kernel_image,
+            _non_exhaustive: (),
         } = src;
 
         let ksym_resolver = if let Some(kallsyms) = kallsyms {
@@ -353,6 +354,7 @@ impl Symbolizer {
             Source::Elf(Elf {
                 file_name,
                 base_address,
+                _non_exhaustive: (),
             }) => {
                 let backend = self.elf_cache.find(file_name)?;
                 let resolver = ElfResolver::with_backend(file_name, *base_address, backend)?;
@@ -360,10 +362,14 @@ impl Symbolizer {
                 Ok(symbols)
             }
             Source::Kernel(kernel) => self.symbolize_kernel_addrs(addrs, kernel),
-            Source::Process(Process { pid }) => self.symbolize_user_addrs(addrs, *pid),
+            Source::Process(Process {
+                pid,
+                _non_exhaustive: (),
+            }) => self.symbolize_user_addrs(addrs, *pid),
             Source::Gsym(Gsym {
                 file_name,
                 base_address,
+                _non_exhaustive: (),
             }) => {
                 let resolver = GsymResolver::new(file_name.clone(), *base_address)?;
                 let symbols = self.symbolize_addrs(addrs, &resolver);

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -20,14 +20,8 @@ use blazesym::Pid;
 fn error_on_non_existent_source() {
     let non_existent = Path::new("/does-not-exists");
     let srcs = vec![
-        symbolize::Source::Gsym(symbolize::Gsym {
-            file_name: non_existent.to_path_buf(),
-            base_address: 0,
-        }),
-        symbolize::Source::Elf(symbolize::Elf {
-            file_name: non_existent.to_path_buf(),
-            base_address: 0,
-        }),
+        symbolize::Source::Gsym(symbolize::Gsym::new(non_existent)),
+        symbolize::Source::Elf(symbolize::Elf::new(non_existent)),
     ];
     let symbolizer = Symbolizer::new().unwrap();
 
@@ -45,10 +39,7 @@ fn symbolize_gsym() {
         .join("test.gsym");
 
     let features = vec![symbolize::SymbolizerFeature::LineNumberInfo(true)];
-    let src = symbolize::Source::Gsym(symbolize::Gsym {
-        file_name: test_gsym,
-        base_address: 0,
-    });
+    let src = symbolize::Source::Gsym(symbolize::Gsym::new(test_gsym));
     let symbolizer = Symbolizer::with_opts(&features).unwrap();
 
     let results = symbolizer
@@ -73,10 +64,7 @@ fn symbolize_dwarf() {
         symbolize::SymbolizerFeature::LineNumberInfo(true),
         symbolize::SymbolizerFeature::DebugInfoSymbols(true),
     ];
-    let src = symbolize::Source::Elf(symbolize::Elf {
-        file_name: test_dwarf,
-        base_address: 0,
-    });
+    let src = symbolize::Source::Elf(symbolize::Elf::new(test_dwarf));
     let symbolizer = Symbolizer::with_opts(&features).unwrap();
     let results = symbolizer
         .symbolize(&src, &[0x2000100])
@@ -93,7 +81,7 @@ fn symbolize_dwarf() {
 /// Check that we can symbolize addresses inside our own process.
 #[test]
 fn symbolize_process() {
-    let src = symbolize::Source::Process(symbolize::Process { pid: Pid::Slf });
+    let src = symbolize::Source::Process(symbolize::Process::new(Pid::Slf));
     let addrs = [symbolize_process as Addr, Symbolizer::new as Addr];
     let symbolizer = Symbolizer::new().unwrap();
     let results = symbolizer
@@ -121,10 +109,7 @@ fn lookup_dwarf() {
         symbolize::SymbolizerFeature::LineNumberInfo(true),
         symbolize::SymbolizerFeature::DebugInfoSymbols(true),
     ];
-    let src = symbolize::Source::Elf(symbolize::Elf {
-        file_name: test_dwarf,
-        base_address: 0,
-    });
+    let src = symbolize::Source::Elf(symbolize::Elf::new(test_dwarf));
     let symbolizer = Symbolizer::with_opts(&features).unwrap();
     let results = symbolizer
         .find_addrs(&src, &["factorial"])
@@ -164,11 +149,11 @@ fn normalize_user_address() {
         let meta = &norm_addrs.meta[norm_addr.1];
         assert_eq!(meta.binary().unwrap().path, test_so);
 
-        let src = symbolize::Source::Elf(symbolize::Elf {
-            file_name: test_so,
-            // TODO: Fix our symbolizer. Base address should be 0.
-            base_address: 0x1000,
-        });
+        let mut elf = symbolize::Elf::new(test_so);
+        // TODO: Fix our symbolizer. Base address should be 0.
+        elf.base_address = 0x1000;
+
+        let src = symbolize::Source::Elf(elf);
         let symbolizer = Symbolizer::new().unwrap();
         let results = symbolizer
             .symbolize(&src, &[norm_addr.0])


### PR DESCRIPTION
Make sure that potential additions to our symbol source types are not breaking changes by making the structs non-exhaustive.