### PR TITLE
Make Symbolizer constructors infallible

### DIFF
--- a/benches/dwarf.rs
+++ b/benches/dwarf.rs
@@ -19,7 +19,7 @@ fn symbolize_end_to_end() {
         SymbolizerFeature::LineNumberInfo(true),
     ];
     let src = Source::Elf(Elf::new(dwarf_vmlinux));
-    let symbolizer = Symbolizer::with_opts(&features).unwrap();
+    let symbolizer = Symbolizer::with_opts(&features);
 
     let results = symbolizer
         .symbolize(&src, &[0xffffffff8110ecb0])
@@ -44,7 +44,7 @@ fn lookup_end_to_end() {
     ];
     let src = Source::Elf(Elf::new(dwarf_vmlinux));
 
-    let symbolizer = Symbolizer::with_opts(&features).unwrap();
+    let symbolizer = Symbolizer::with_opts(&features);
     let results = symbolizer
         .find_addrs(&src, &["abort_creds"])
         .unwrap()

--- a/benches/dwarf.rs
+++ b/benches/dwarf.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use blazesym::symbolize::Elf;
 use blazesym::symbolize::Source;
 use blazesym::symbolize::Symbolizer;
-use blazesym::symbolize::SymbolizerFeature;
 
 use criterion::measurement::Measurement;
 use criterion::BenchmarkGroup;
@@ -14,12 +13,8 @@ fn symbolize_end_to_end() {
     let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("vmlinux-5.17.12-100.fc34.x86_64");
-    let features = [
-        SymbolizerFeature::DebugInfoSymbols(true),
-        SymbolizerFeature::LineNumberInfo(true),
-    ];
     let src = Source::Elf(Elf::new(dwarf_vmlinux));
-    let symbolizer = Symbolizer::with_opts(&features);
+    let symbolizer = Symbolizer::new();
 
     let results = symbolizer
         .symbolize(&src, &[0xffffffff8110ecb0])
@@ -38,13 +33,9 @@ fn lookup_end_to_end() {
     let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("vmlinux-5.17.12-100.fc34.x86_64");
-    let features = [
-        SymbolizerFeature::DebugInfoSymbols(true),
-        SymbolizerFeature::LineNumberInfo(true),
-    ];
     let src = Source::Elf(Elf::new(dwarf_vmlinux));
 
-    let symbolizer = Symbolizer::with_opts(&features);
+    let symbolizer = Symbolizer::new();
     let results = symbolizer
         .find_addrs(&src, &["abort_creds"])
         .unwrap()

--- a/benches/gsym.rs
+++ b/benches/gsym.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use blazesym::symbolize::Gsym;
 use blazesym::symbolize::Source;
 use blazesym::symbolize::Symbolizer;
-use blazesym::symbolize::SymbolizerFeature;
 
 use criterion::measurement::Measurement;
 use criterion::BenchmarkGroup;
@@ -14,12 +13,8 @@ fn symbolize_end_to_end() {
     let gsym_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("vmlinux-5.17.12-100.fc34.x86_64.gsym");
-    let features = [
-        SymbolizerFeature::DebugInfoSymbols(true),
-        SymbolizerFeature::LineNumberInfo(true),
-    ];
     let src = Source::Gsym(Gsym::new(gsym_vmlinux));
-    let symbolizer = Symbolizer::with_opts(&features);
+    let symbolizer = Symbolizer::new();
 
     let results = symbolizer
         .symbolize(&src, &[0xffffffff8110ecb0])

--- a/benches/gsym.rs
+++ b/benches/gsym.rs
@@ -19,7 +19,7 @@ fn symbolize_end_to_end() {
         SymbolizerFeature::LineNumberInfo(true),
     ];
     let src = Source::Gsym(Gsym::new(gsym_vmlinux));
-    let symbolizer = Symbolizer::with_opts(&features).unwrap();
+    let symbolizer = Symbolizer::with_opts(&features);
 
     let results = symbolizer
         .symbolize(&src, &[0xffffffff8110ecb0])

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -20,7 +20,7 @@ fn symbolize_process() {
         c_api::blaze_inspector_free as Addr,
     ];
 
-    let symbolizer = Symbolizer::new().unwrap();
+    let symbolizer = Symbolizer::new();
     let results = symbolizer.symbolize(&src, &addrs).unwrap();
     assert_eq!(results.len(), addrs.len());
 }

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
     let bin_name = &args[1];
     let mut addr_str = &args[2][..];
     let src = Source::Elf(Elf::new(bin_name));
-    let resolver = Symbolizer::new().unwrap();
+    let symbolizer = Symbolizer::new();
 
     if &addr_str[0..2] == "0x" {
         // Remove prefixed 0x
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
     let addr = Addr::from_str_radix(addr_str, 16)
         .with_context(|| format!("failed to parse address: {addr_str}"))?;
 
-    let results = resolver
+    let results = symbolizer
         .symbolize(&src, &[addr])
         .with_context(|| format!("failed to symbolize address {addr}"))?;
     if results.len() == 1 && !results[0].is_empty() {

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -34,8 +34,8 @@ print its symbol, the file name of the source, and the line number.",
         .with_context(|| format!("failed to parse address: {addr_str}"))?;
 
     let src = Source::Process(Process::new(pid.into()));
-    let resolver = Symbolizer::new().unwrap();
-    let symlist = resolver
+    let symbolizer = Symbolizer::new();
+    let symlist = symbolizer
         .symbolize(&src, &[addr])
         .with_context(|| format!("failed to symbolize address {addr}"))?;
     if !symlist[0].is_empty() {

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -41,26 +41,6 @@ typedef enum blaze_user_addr_meta_kind {
 } blaze_user_addr_meta_kind;
 
 /**
- * Names of the BlazeSym features.
- */
-typedef enum blazesym_feature_name {
-  /**
-   * Enable or disable returning line numbers of addresses.
-   *
-   * Users should set `blazesym_feature.params.enable` to enable or
-   * disable the feature.
-   */
-  BLAZESYM_LINE_NUMBER_INFO,
-  /**
-   * Enable or disable loading symbols from DWARF.
-   *
-   * Users should set `blazesym_feature.params.enable` to enable or
-   * disable the feature. This feature is disabled by default.
-   */
-  BLAZESYM_DEBUG_INFO_SYMBOLS,
-} blazesym_feature_name;
-
-/**
  * Types of symbol sources and debug information for C API.
  */
 typedef enum blazesym_src_type {
@@ -238,19 +218,21 @@ typedef struct blaze_normalized_user_addrs {
  */
 typedef struct blaze_symbolizer blaze_symbolizer;
 
-typedef union blazesym_feature_params {
-  bool enable;
-} blazesym_feature_params;
-
 /**
- * Setting of the blazesym features.
- *
- * Contain parameters to enable, disable, or customize a feature.
+ * Options for configuring `blaze_symbolizer` objects.
  */
-typedef struct blazesym_feature {
-  enum blazesym_feature_name feature;
-  union blazesym_feature_params params;
-} blazesym_feature;
+typedef struct blaze_symbolizer_opts {
+  /**
+   * Whether to enable usage of debug symbols.
+   */
+  bool debug_syms;
+  /**
+   * Whether to attempt to gather source code location information.
+   *
+   * This setting implies `debug_syms` (and forces it to `true`).
+   */
+  bool src_location;
+} blaze_symbolizer_opts;
 
 /**
  * The result of symbolization of an address for C API.
@@ -575,19 +557,17 @@ struct blaze_normalized_user_addrs *blaze_normalize_user_addrs_sorted(const stru
 void blaze_user_addrs_free(struct blaze_normalized_user_addrs *addrs);
 
 /**
- * Create an instance of blazesym a symbolizer for C API.
+ * Create an instance of a symbolizer.
  */
 blaze_symbolizer *blaze_symbolizer_new(void);
 
 /**
- * Create an instance of blazesym a symbolizer for C API.
+ * Create an instance of a symbolizer with configurable options.
  *
  * # Safety
- *
- * `features` needs to be a valid pointer to `feature_cnt` elements.
+ * `opts` needs to be a valid pointer.
  */
-blaze_symbolizer *blaze_symbolizer_new_opts(const struct blazesym_feature *features,
-                                            size_t feature_cnt);
+blaze_symbolizer *blaze_symbolizer_new_opts(const struct blaze_symbolizer_opts *opts);
 
 /**
  * Free an instance of blazesym a symbolizer for C API.

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -213,12 +213,12 @@ typedef struct blaze_symbolizer_opts {
 } blaze_symbolizer_opts;
 
 /**
- * The result of symbolization of an address for C API.
+ * The result of symbolization of an address.
  *
- * A `blazesym_csym` is the information of a symbol found for an
- * address.  One address may result in several symbols.
+ * A `blaze_sym` is the information of a symbol found for an
+ * address. One address may result in several symbols.
  */
-typedef struct blazesym_csym {
+typedef struct blaze_sym {
   /**
    * The symbol name is where the given address should belong to.
    */
@@ -239,13 +239,13 @@ typedef struct blazesym_csym {
    */
   size_t line;
   size_t column;
-} blazesym_csym;
+} blaze_sym;
 
 /**
  * `blazesym_entry` is the output of symbolization for an address for C API.
  *
  * Every address has an `blazesym_entry` in
- * [`blazesym_result::entries`] to collect symbols found by BlazeSym.
+ * [`blazesym_result::entries`] to collect symbols found.
  */
 typedef struct blazesym_entry {
   /**
@@ -255,9 +255,9 @@ typedef struct blazesym_entry {
   /**
    * All symbols found.
    *
-   * `syms` is an array of blazesym_csym in the size `size`.
+   * `syms` is an array of [`blaze_sym`] in the size `size`.
    */
-  const struct blazesym_csym *syms;
+  const struct blaze_sym *syms;
 } blazesym_entry;
 
 /**

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -385,13 +385,13 @@ typedef struct blaze_symbolize_src_gsym {
  * Lookup symbol information in an ELF file.
  *
  * Return an array with the same size as the input names. The caller should
- * free the returned array by calling [`blaze_syms_free`].
+ * free the returned array by calling [`blaze_inspect_syms_free`].
  *
  * Every name in the input name list may have more than one address.
  * The respective entry in the returned array is an array containing
  * all addresses and ended with a null (0x0).
  *
- * The returned pointer should be freed by [`blaze_syms_free`].
+ * The returned pointer should be freed by [`blaze_inspect_syms_free`].
  *
  * # Safety
  * The `inspector` object should have been created using
@@ -411,7 +411,7 @@ const struct blaze_sym_info *const *blaze_inspect_syms_elf(const struct blaze_in
  * The pointer must be returned by [`blaze_inspect_syms_elf`].
  *
  */
-void blaze_syms_free(const struct blaze_sym_info *const *syms);
+void blaze_inspect_syms_free(const struct blaze_sym_info *const *syms);
 
 /**
  * Create an instance of a blazesym inspector.

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -288,7 +288,7 @@ typedef struct blazesym_result {
  * Load all ELF files in a process as the sources of symbols and debug
  * information.
  */
-typedef struct blazesym_ssc_process {
+typedef struct blaze_symbolize_src_process {
   /**
    * It is the PID of a process to symbolize.
    *
@@ -296,7 +296,7 @@ typedef struct blazesym_ssc_process {
    * files.
    */
   uint32_t pid;
-} blazesym_ssc_process;
+} blaze_symbolize_src_process;
 
 /**
  * The parameters to load symbols and debug information from a kernel.
@@ -304,7 +304,7 @@ typedef struct blazesym_ssc_process {
  * Use a kernel image and a snapshot of its kallsyms as a source of symbols and
  * debug information.
  */
-typedef struct blazesym_ssc_kernel {
+typedef struct blaze_symbolize_src_kernel {
   /**
    * The path of a copy of kallsyms.
    *
@@ -323,7 +323,7 @@ typedef struct blazesym_ssc_kernel {
    * `"/usr/lib/debug/boot/"`.
    */
   const char *kernel_image;
-} blazesym_ssc_kernel;
+} blaze_symbolize_src_kernel;
 
 /**
  * The parameters to load symbols and debug information from an ELF.
@@ -331,7 +331,7 @@ typedef struct blazesym_ssc_kernel {
  * Describes the path and address of an ELF file loaded in a
  * process.
  */
-typedef struct blazesym_ssc_elf {
+typedef struct blaze_symbolize_src_elf {
   /**
    * The path to the ELF file.
    *
@@ -365,12 +365,12 @@ typedef struct blazesym_ssc_elf {
    * permission of `r-xp`.
    */
   uintptr_t base_address;
-} blazesym_ssc_elf;
+} blaze_symbolize_src_elf;
 
 /**
  * The parameters to load symbols and debug information from a gsym file.
  */
-typedef struct blazesym_ssc_gsym {
+typedef struct blaze_symbolize_src_gsym {
   /**
    * The path to a gsym file.
    */
@@ -379,7 +379,7 @@ typedef struct blazesym_ssc_gsym {
    * The base address is where the file's executable segment(s) is loaded.
    */
   uintptr_t base_address;
-} blazesym_ssc_gsym;
+} blaze_symbolize_src_gsym;
 
 /**
  * Lookup symbol information in an ELF file.
@@ -534,11 +534,11 @@ void blaze_symbolizer_free(blaze_symbolizer *symbolizer);
  * # Safety
  * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
  * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blazesym_ssc_process`] object. `addrs` must represent an array of
+ * [`blaze_symbolize_src_process`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
 const struct blazesym_result *blaze_symbolize_process(blaze_symbolizer *symbolizer,
-                                                      const struct blazesym_ssc_process *src,
+                                                      const struct blaze_symbolize_src_process *src,
                                                       const uintptr_t *addrs,
                                                       size_t addr_cnt);
 
@@ -552,11 +552,11 @@ const struct blazesym_result *blaze_symbolize_process(blaze_symbolizer *symboliz
  * # Safety
  * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
  * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blazesym_ssc_kernel`] object. `addrs` must represent an array of
+ * [`blaze_symbolize_src_kernel`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
 const struct blazesym_result *blaze_symbolize_kernel(blaze_symbolizer *symbolizer,
-                                                     const struct blazesym_ssc_kernel *src,
+                                                     const struct blaze_symbolize_src_kernel *src,
                                                      const uintptr_t *addrs,
                                                      size_t addr_cnt);
 
@@ -570,11 +570,11 @@ const struct blazesym_result *blaze_symbolize_kernel(blaze_symbolizer *symbolize
  * # Safety
  * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
  * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blazesym_ssc_elf`] object. `addrs` must represent an array of
+ * [`blaze_symbolize_src_elf`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
 const struct blazesym_result *blaze_symbolize_elf(blaze_symbolizer *symbolizer,
-                                                  const struct blazesym_ssc_elf *src,
+                                                  const struct blaze_symbolize_src_elf *src,
                                                   const uintptr_t *addrs,
                                                   size_t addr_cnt);
 
@@ -588,11 +588,11 @@ const struct blazesym_result *blaze_symbolize_elf(blaze_symbolizer *symbolizer,
  * # Safety
  * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
  * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blazesym_ssc_gsym`] object. `addrs` must represent an array of
+ * [`blaze_symbolize_src_gsym`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
 const struct blazesym_result *blaze_symbolize_gsym(blaze_symbolizer *symbolizer,
-                                                   const struct blazesym_ssc_gsym *src,
+                                                   const struct blaze_symbolize_src_gsym *src,
                                                    const uintptr_t *addrs,
                                                    size_t addr_cnt);
 

--- a/src/c_api/inspect.rs
+++ b/src/c_api/inspect.rs
@@ -209,13 +209,13 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymbolInfo>>) -> *const *const blaz
 /// Lookup symbol information in an ELF file.
 ///
 /// Return an array with the same size as the input names. The caller should
-/// free the returned array by calling [`blaze_syms_free`].
+/// free the returned array by calling [`blaze_inspect_syms_free`].
 ///
 /// Every name in the input name list may have more than one address.
 /// The respective entry in the returned array is an array containing
 /// all addresses and ended with a null (0x0).
 ///
-/// The returned pointer should be freed by [`blaze_syms_free`].
+/// The returned pointer should be freed by [`blaze_inspect_syms_free`].
 ///
 /// # Safety
 /// The `inspector` object should have been created using
@@ -260,7 +260,7 @@ pub unsafe extern "C" fn blaze_inspect_syms_elf(
 /// The pointer must be returned by [`blaze_inspect_syms_elf`].
 ///
 #[no_mangle]
-pub unsafe extern "C" fn blaze_syms_free(syms: *const *const blaze_sym_info) {
+pub unsafe extern "C" fn blaze_inspect_syms_free(syms: *const *const blaze_sym_info) {
     if syms.is_null() {
         return
     }

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -165,13 +165,14 @@ impl From<&blaze_symbolize_src_gsym> for Gsym {
 /// [`blaze_symbolizer_free`].
 pub type blaze_symbolizer = Symbolizer;
 
-/// The result of symbolization of an address for C API.
+
+/// The result of symbolization of an address.
 ///
-/// A `blazesym_csym` is the information of a symbol found for an
-/// address.  One address may result in several symbols.
+/// A `blaze_sym` is the information of a symbol found for an
+/// address. One address may result in several symbols.
 #[repr(C)]
 #[derive(Debug)]
-pub struct blazesym_csym {
+pub struct blaze_sym {
     /// The symbol name is where the given address should belong to.
     pub symbol: *const c_char,
     /// The address (i.e.,the first byte) is where the symbol is located.
@@ -189,7 +190,7 @@ pub struct blazesym_csym {
 /// `blazesym_entry` is the output of symbolization for an address for C API.
 ///
 /// Every address has an `blazesym_entry` in
-/// [`blazesym_result::entries`] to collect symbols found by BlazeSym.
+/// [`blazesym_result::entries`] to collect symbols found.
 #[repr(C)]
 #[derive(Debug)]
 pub struct blazesym_entry {
@@ -197,8 +198,8 @@ pub struct blazesym_entry {
     pub size: usize,
     /// All symbols found.
     ///
-    /// `syms` is an array of blazesym_csym in the size `size`.
-    pub syms: *const blazesym_csym,
+    /// `syms` is an array of [`blaze_sym`] in the size `size`.
+    pub syms: *const blaze_sym,
 }
 
 /// `blazesym_result` is the result of symbolization for C API.
@@ -297,7 +298,7 @@ unsafe fn convert_symbolizedresults_to_c(
     results: Vec<Vec<SymbolizedResult>>,
 ) -> *const blazesym_result {
     // Allocate a buffer to contain a blazesym_result, all
-    // blazesym_csym, and C strings of symbol and path.
+    // blaze_sym, and C strings of symbol and path.
     let strtab_size = results.iter().flatten().fold(0, |acc, result| {
         acc + result.symbol.len() + result.path.as_os_str().len() + 2
     });
@@ -305,7 +306,7 @@ unsafe fn convert_symbolizedresults_to_c(
     let buf_size = strtab_size
         + mem::size_of::<blazesym_result>()
         + mem::size_of::<blazesym_entry>() * results.len()
-        + mem::size_of::<blazesym_csym>() * all_csym_size;
+        + mem::size_of::<blaze_sym>() * all_csym_size;
     let raw_buf_with_sz =
         unsafe { alloc(Layout::from_size_align(buf_size + mem::size_of::<u64>(), 8).unwrap()) };
     if raw_buf_with_sz.is_null() {
@@ -323,12 +324,12 @@ unsafe fn convert_symbolizedresults_to_c(
         raw_buf.add(
             mem::size_of::<blazesym_result>() + mem::size_of::<blazesym_entry>() * results.len(),
         )
-    } as *mut blazesym_csym;
+    } as *mut blaze_sym;
     let mut cstr_last = unsafe {
         raw_buf.add(
             mem::size_of::<blazesym_result>()
                 + mem::size_of::<blazesym_entry>() * results.len()
-                + mem::size_of::<blazesym_csym>() * all_csym_size,
+                + mem::size_of::<blaze_sym>() * all_csym_size,
         )
     } as *mut c_char;
 

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -322,10 +322,7 @@ unsafe fn from_cstr(cstr: *const c_char) -> PathBuf {
 /// Create an instance of blazesym a symbolizer for C API.
 #[no_mangle]
 pub extern "C" fn blaze_symbolizer_new() -> *mut blaze_symbolizer {
-    let symbolizer = match Symbolizer::new() {
-        Ok(s) => s,
-        Err(_) => return ptr::null_mut(),
-    };
+    let symbolizer = Symbolizer::new();
     let symbolizer_box = Box::new(symbolizer);
     Box::into_raw(symbolizer_box)
 }
@@ -357,10 +354,7 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
         })
         .collect::<Vec<_>>();
 
-    let symbolizer = match Symbolizer::with_opts(&features_r) {
-        Ok(s) => s,
-        Err(_) => return ptr::null_mut(),
-    };
+    let symbolizer = Symbolizer::with_opts(&features_r);
     let symbolizer_box = Box::new(symbolizer);
     Box::into_raw(symbolizer_box)
 }

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -30,7 +30,7 @@ use crate::Addr;
 /// process.
 #[repr(C)]
 #[derive(Debug)]
-pub struct blazesym_ssc_elf {
+pub struct blaze_symbolize_src_elf {
     /// The path to the ELF file.
     ///
     /// The referenced file may be an executable or shared object. For example,
@@ -62,9 +62,9 @@ pub struct blazesym_ssc_elf {
     pub base_address: Addr,
 }
 
-impl From<&blazesym_ssc_elf> for Elf {
-    fn from(elf: &blazesym_ssc_elf) -> Self {
-        let blazesym_ssc_elf { path, base_address } = elf;
+impl From<&blaze_symbolize_src_elf> for Elf {
+    fn from(elf: &blaze_symbolize_src_elf) -> Self {
+        let blaze_symbolize_src_elf { path, base_address } = elf;
         Self {
             path: unsafe { from_cstr(*path) },
             base_address: *base_address,
@@ -80,7 +80,7 @@ impl From<&blazesym_ssc_elf> for Elf {
 /// debug information.
 #[repr(C)]
 #[derive(Debug)]
-pub struct blazesym_ssc_kernel {
+pub struct blaze_symbolize_src_kernel {
     /// The path of a copy of kallsyms.
     ///
     /// It can be `"/proc/kallsyms"` for the running kernel on the
@@ -97,9 +97,9 @@ pub struct blazesym_ssc_kernel {
     pub kernel_image: *const c_char,
 }
 
-impl From<&blazesym_ssc_kernel> for Kernel {
-    fn from(kernel: &blazesym_ssc_kernel) -> Self {
-        let blazesym_ssc_kernel {
+impl From<&blaze_symbolize_src_kernel> for Kernel {
+    fn from(kernel: &blaze_symbolize_src_kernel) -> Self {
+        let blaze_symbolize_src_kernel {
             kallsyms,
             kernel_image,
         } = kernel;
@@ -118,7 +118,7 @@ impl From<&blazesym_ssc_kernel> for Kernel {
 /// information.
 #[repr(C)]
 #[derive(Debug)]
-pub struct blazesym_ssc_process {
+pub struct blaze_symbolize_src_process {
     /// It is the PID of a process to symbolize.
     ///
     /// BlazeSym will parse `/proc/<pid>/maps` and load all the object
@@ -126,9 +126,9 @@ pub struct blazesym_ssc_process {
     pub pid: u32,
 }
 
-impl From<&blazesym_ssc_process> for Process {
-    fn from(process: &blazesym_ssc_process) -> Self {
-        let blazesym_ssc_process { pid } = process;
+impl From<&blaze_symbolize_src_process> for Process {
+    fn from(process: &blaze_symbolize_src_process) -> Self {
+        let blaze_symbolize_src_process { pid } = process;
         Self {
             pid: (*pid).into(),
             _non_exhaustive: (),
@@ -140,16 +140,16 @@ impl From<&blazesym_ssc_process> for Process {
 /// The parameters to load symbols and debug information from a gsym file.
 #[repr(C)]
 #[derive(Debug)]
-pub struct blazesym_ssc_gsym {
+pub struct blaze_symbolize_src_gsym {
     /// The path to a gsym file.
     pub path: *const c_char,
     /// The base address is where the file's executable segment(s) is loaded.
     pub base_address: Addr,
 }
 
-impl From<&blazesym_ssc_gsym> for Gsym {
-    fn from(gsym: &blazesym_ssc_gsym) -> Self {
-        let blazesym_ssc_gsym { path, base_address } = gsym;
+impl From<&blaze_symbolize_src_gsym> for Gsym {
+    fn from(gsym: &blaze_symbolize_src_gsym) -> Self {
+        let blaze_symbolize_src_gsym { path, base_address } = gsym;
         Self {
             path: unsafe { from_cstr(*path) },
             base_address: *base_address,
@@ -405,12 +405,12 @@ unsafe fn blaze_symbolize_impl(
 /// # Safety
 /// `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
 /// [`blaze_symbolizer_new_opts`]. `src` must point to a valid
-/// [`blazesym_ssc_process`] object. `addrs` must represent an array of
+/// [`blaze_symbolize_src_process`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_process(
     symbolizer: *mut blaze_symbolizer,
-    src: *const blazesym_ssc_process,
+    src: *const blaze_symbolize_src_process,
     addrs: *const Addr,
     addr_cnt: usize,
 ) -> *const blazesym_result {
@@ -429,12 +429,12 @@ pub unsafe extern "C" fn blaze_symbolize_process(
 /// # Safety
 /// `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
 /// [`blaze_symbolizer_new_opts`]. `src` must point to a valid
-/// [`blazesym_ssc_kernel`] object. `addrs` must represent an array of
+/// [`blaze_symbolize_src_kernel`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_kernel(
     symbolizer: *mut blaze_symbolizer,
-    src: *const blazesym_ssc_kernel,
+    src: *const blaze_symbolize_src_kernel,
     addrs: *const Addr,
     addr_cnt: usize,
 ) -> *const blazesym_result {
@@ -453,12 +453,12 @@ pub unsafe extern "C" fn blaze_symbolize_kernel(
 /// # Safety
 /// `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
 /// [`blaze_symbolizer_new_opts`]. `src` must point to a valid
-/// [`blazesym_ssc_elf`] object. `addrs` must represent an array of
+/// [`blaze_symbolize_src_elf`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_elf(
     symbolizer: *mut blaze_symbolizer,
-    src: *const blazesym_ssc_elf,
+    src: *const blaze_symbolize_src_elf,
     addrs: *const Addr,
     addr_cnt: usize,
 ) -> *const blazesym_result {
@@ -477,12 +477,12 @@ pub unsafe extern "C" fn blaze_symbolize_elf(
 /// # Safety
 /// `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
 /// [`blaze_symbolizer_new_opts`]. `src` must point to a valid
-/// [`blazesym_ssc_gsym`] object. `addrs` must represent an array of
+/// [`blaze_symbolize_src_gsym`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_gsym(
     symbolizer: *mut blaze_symbolizer,
-    src: *const blazesym_ssc_gsym,
+    src: *const blaze_symbolize_src_gsym,
     addrs: *const Addr,
     addr_cnt: usize,
 ) -> *const blazesym_result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! let process_id: u32 = std::process::id(); // <some process id>
 //! // Load all symbols of loaded files of the given process.
 //! let src = Source::Process(Process::new(process_id.into()));
-//! let symbolizer = Symbolizer::new().unwrap();
+//! let symbolizer = Symbolizer::new();
 //!
 //! let stack: [Addr; 2] = [0xff023, 0x17ff93b];  // Addresses of instructions
 //! let symlist = symbolizer.symbolize(&src,      // Pass this configuration every time

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -8,9 +8,9 @@ pub use source::Gsym;
 pub use source::Kernel;
 pub use source::Process;
 pub use source::Source;
+pub use symbolizer::Builder;
 pub use symbolizer::SymbolizedResult;
 pub use symbolizer::Symbolizer;
-pub use symbolizer::SymbolizerFeature;
 
 
 pub(crate) struct AddrLineInfo {

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -88,25 +88,25 @@ pub struct Symbolizer {
 
 impl Symbolizer {
     /// Create a new [`Symbolizer`].
-    pub fn new() -> Result<Symbolizer> {
+    pub fn new() -> Self {
         let ksym_cache = KSymCache::new();
 
         let line_number_info = true;
         let debug_info_symbols = false;
         let elf_cache = ElfCache::new(line_number_info, debug_info_symbols);
 
-        Ok(Symbolizer {
+        Self {
             ksym_cache,
             elf_cache,
             line_number_info,
-        })
+        }
     }
 
     /// Create a new [`Symbolizer`] with the provided set of features.
     ///
     /// This constructor works like [`Symbolizer::new`] except it receives a
     /// list of [`SymbolizerFeature`] to turn on or off some features.
-    pub fn with_opts(features: &[SymbolizerFeature]) -> Result<Symbolizer> {
+    pub fn with_opts(features: &[SymbolizerFeature]) -> Symbolizer {
         let mut line_number_info = true;
         let mut debug_info_symbols = false;
 
@@ -124,11 +124,11 @@ impl Symbolizer {
         let ksym_cache = KSymCache::new();
         let elf_cache = ElfCache::new(line_number_info, debug_info_symbols);
 
-        Ok(Symbolizer {
+        Self {
             ksym_cache,
             elf_cache,
             line_number_info,
-        })
+        }
     }
 
     /// Find the addresses of a list of symbol names.
@@ -376,5 +376,11 @@ impl Symbolizer {
                 Ok(symbols)
             }
         }
+    }
+}
+
+impl Default for Symbolizer {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -23,7 +23,7 @@ fn error_on_non_existent_source() {
         symbolize::Source::Gsym(symbolize::Gsym::new(non_existent)),
         symbolize::Source::Elf(symbolize::Elf::new(non_existent)),
     ];
-    let symbolizer = Symbolizer::new().unwrap();
+    let symbolizer = Symbolizer::new();
 
     for src in srcs {
         let err = symbolizer.symbolize(&src, &[0x2000100]).unwrap_err();
@@ -38,9 +38,8 @@ fn symbolize_gsym() {
         .join("data")
         .join("test.gsym");
 
-    let features = vec![symbolize::SymbolizerFeature::LineNumberInfo(true)];
     let src = symbolize::Source::Gsym(symbolize::Gsym::new(test_gsym));
-    let symbolizer = Symbolizer::with_opts(&features).unwrap();
+    let symbolizer = Symbolizer::new();
 
     let results = symbolizer
         .symbolize(&src, &[0x2000100])
@@ -65,7 +64,7 @@ fn symbolize_dwarf() {
         symbolize::SymbolizerFeature::DebugInfoSymbols(true),
     ];
     let src = symbolize::Source::Elf(symbolize::Elf::new(test_dwarf));
-    let symbolizer = Symbolizer::with_opts(&features).unwrap();
+    let symbolizer = Symbolizer::with_opts(&features);
     let results = symbolizer
         .symbolize(&src, &[0x2000100])
         .unwrap()
@@ -83,7 +82,7 @@ fn symbolize_dwarf() {
 fn symbolize_process() {
     let src = symbolize::Source::Process(symbolize::Process::new(Pid::Slf));
     let addrs = [symbolize_process as Addr, Symbolizer::new as Addr];
-    let symbolizer = Symbolizer::new().unwrap();
+    let symbolizer = Symbolizer::new();
     let results = symbolizer
         .symbolize(&src, &addrs)
         .unwrap()
@@ -110,7 +109,7 @@ fn lookup_dwarf() {
         symbolize::SymbolizerFeature::DebugInfoSymbols(true),
     ];
     let src = symbolize::Source::Elf(symbolize::Elf::new(test_dwarf));
-    let symbolizer = Symbolizer::with_opts(&features).unwrap();
+    let symbolizer = Symbolizer::with_opts(&features);
     let results = symbolizer
         .find_addrs(&src, &["factorial"])
         .unwrap()
@@ -154,7 +153,7 @@ fn normalize_user_address() {
         elf.base_address = 0x1000;
 
         let src = symbolize::Source::Elf(elf);
-        let symbolizer = Symbolizer::new().unwrap();
+        let symbolizer = Symbolizer::new();
         let results = symbolizer
             .symbolize(&src, &[norm_addr.0])
             .unwrap()

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -59,12 +59,8 @@ fn symbolize_dwarf() {
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("test-dwarf.bin");
-    let features = [
-        symbolize::SymbolizerFeature::LineNumberInfo(true),
-        symbolize::SymbolizerFeature::DebugInfoSymbols(true),
-    ];
     let src = symbolize::Source::Elf(symbolize::Elf::new(test_dwarf));
-    let symbolizer = Symbolizer::with_opts(&features);
+    let symbolizer = Symbolizer::new();
     let results = symbolizer
         .symbolize(&src, &[0x2000100])
         .unwrap()
@@ -104,12 +100,8 @@ fn lookup_dwarf() {
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("test-dwarf.bin");
-    let features = [
-        symbolize::SymbolizerFeature::LineNumberInfo(true),
-        symbolize::SymbolizerFeature::DebugInfoSymbols(true),
-    ];
     let src = symbolize::Source::Elf(symbolize::Elf::new(test_dwarf));
-    let symbolizer = Symbolizer::with_opts(&features);
+    let symbolizer = Symbolizer::new();
     let results = symbolizer
         .find_addrs(&src, &["factorial"])
         .unwrap()

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -10,6 +10,7 @@ use blazesym::inspect;
 
 use blazesym::c_api::blaze_inspect_elf_src;
 use blazesym::c_api::blaze_inspect_syms_elf;
+use blazesym::c_api::blaze_inspect_syms_free;
 use blazesym::c_api::blaze_inspector_free;
 use blazesym::c_api::blaze_inspector_new;
 use blazesym::c_api::blaze_normalize_user_addrs;
@@ -26,7 +27,6 @@ use blazesym::c_api::blaze_symbolizer_free;
 use blazesym::c_api::blaze_symbolizer_new;
 use blazesym::c_api::blaze_symbolizer_new_opts;
 use blazesym::c_api::blaze_symbolizer_opts;
-use blazesym::c_api::blaze_syms_free;
 use blazesym::c_api::blaze_user_addrs_free;
 use blazesym::c_api::blazesym_result_free;
 use blazesym::Addr;
@@ -253,6 +253,6 @@ fn lookup_dwarf() {
     );
     assert_eq!(sym_info.address, 0x2000100);
 
-    let () = unsafe { blaze_syms_free(result) };
+    let () = unsafe { blaze_inspect_syms_free(result) };
     let () = unsafe { blaze_inspector_free(inspector) };
 }

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -19,6 +19,9 @@ use blazesym::c_api::blaze_normalizer_new;
 use blazesym::c_api::blaze_symbolize_elf;
 use blazesym::c_api::blaze_symbolize_gsym;
 use blazesym::c_api::blaze_symbolize_process;
+use blazesym::c_api::blaze_symbolize_src_elf;
+use blazesym::c_api::blaze_symbolize_src_gsym;
+use blazesym::c_api::blaze_symbolize_src_process;
 use blazesym::c_api::blaze_symbolizer_free;
 use blazesym::c_api::blaze_symbolizer_new;
 use blazesym::c_api::blaze_symbolizer_new_opts;
@@ -26,9 +29,6 @@ use blazesym::c_api::blaze_symbolizer_opts;
 use blazesym::c_api::blaze_syms_free;
 use blazesym::c_api::blaze_user_addrs_free;
 use blazesym::c_api::blazesym_result_free;
-use blazesym::c_api::blazesym_ssc_elf;
-use blazesym::c_api::blazesym_ssc_gsym;
-use blazesym::c_api::blazesym_ssc_process;
 use blazesym::Addr;
 
 
@@ -61,7 +61,7 @@ fn symbolize_from_elf() {
         .join("test-dwarf.bin");
     let test_dwarf_c = CString::new(test_dwarf.to_str().unwrap()).unwrap();
 
-    let elf_src = blazesym_ssc_elf {
+    let elf_src = blaze_symbolize_src_elf {
         path: test_dwarf_c.as_ptr(),
         base_address: 0,
     };
@@ -97,7 +97,7 @@ fn symbolize_from_gsym() {
         .join("data")
         .join("test.gsym");
     let test_gsym_c = CString::new(test_gsym.to_str().unwrap()).unwrap();
-    let gsym_src = blazesym_ssc_gsym {
+    let gsym_src = blaze_symbolize_src_gsym {
         path: test_gsym_c.as_ptr(),
         base_address: 0,
     };
@@ -130,7 +130,7 @@ fn symbolize_from_gsym() {
 /// Make sure that we can symbolize an address in a process.
 #[test]
 fn symbolize_in_process() {
-    let process_src = blazesym_ssc_process { pid: 0 };
+    let process_src = blaze_symbolize_src_process { pid: 0 };
 
     let symbolizer = blaze_symbolizer_new();
     let addrs = [blaze_symbolizer_new as Addr];

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -21,11 +21,9 @@ use blazesym::c_api::blaze_symbolize;
 use blazesym::c_api::blaze_symbolizer_free;
 use blazesym::c_api::blaze_symbolizer_new;
 use blazesym::c_api::blaze_symbolizer_new_opts;
+use blazesym::c_api::blaze_symbolizer_opts;
 use blazesym::c_api::blaze_syms_free;
 use blazesym::c_api::blaze_user_addrs_free;
-use blazesym::c_api::blazesym_feature;
-use blazesym::c_api::blazesym_feature_name;
-use blazesym::c_api::blazesym_feature_params;
 use blazesym::c_api::blazesym_result_free;
 use blazesym::c_api::blazesym_src_type;
 use blazesym::c_api::blazesym_ssc_elf;
@@ -44,20 +42,14 @@ fn symbolizer_creation() {
 
 
 /// Make sure that we can create and free a symbolizer instance with the
-/// provided features.
+/// provided options.
 #[test]
-fn symbolizer_creation_with_features() {
-    let features = [
-        blazesym_feature {
-            feature: blazesym_feature_name::BLAZESYM_LINE_NUMBER_INFO,
-            params: blazesym_feature_params { enable: true },
-        },
-        blazesym_feature {
-            feature: blazesym_feature_name::BLAZESYM_DEBUG_INFO_SYMBOLS,
-            params: blazesym_feature_params { enable: true },
-        },
-    ];
-    let symbolizer = unsafe { blaze_symbolizer_new_opts(features.as_ptr(), features.len()) };
+fn symbolizer_creation_with_opts() {
+    let opts = blaze_symbolizer_opts {
+        debug_syms: true,
+        src_location: false,
+    };
+    let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };
     let () = unsafe { blaze_symbolizer_free(symbolizer) };
 }
 


### PR DESCRIPTION
Inspector and Normalizer constructors are infallible. Change Symbolizer ones to mirror that behavior.