### PR TITLE
Rename Symbol{Info,Type} -> Sym{Info,Type}

### DIFF
--- a/src/c_api/inspect.rs
+++ b/src/c_api/inspect.rs
@@ -19,8 +19,8 @@ use crate::inspect;
 use crate::inspect::Elf;
 use crate::inspect::Inspector;
 use crate::inspect::Source;
-use crate::inspect::SymbolInfo;
-use crate::inspect::SymbolType;
+use crate::inspect::SymInfo;
+use crate::inspect::SymType;
 use crate::log::error;
 use crate::util::slice_from_user_array;
 use crate::Addr;
@@ -112,9 +112,9 @@ pub struct blaze_sym_info {
 }
 
 
-/// Convert [`SymbolInfo`] objects as returned by
+/// Convert [`SymInfo`] objects as returned by
 /// [`Symbolizer::find_addrs`] to a C array.
-fn convert_syms_list_to_c(syms_list: Vec<Vec<SymbolInfo>>) -> *const *const blaze_sym_info {
+fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_sym_info {
     let mut sym_cnt = 0;
     let mut str_buf_sz = 0;
 
@@ -145,7 +145,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymbolInfo>>) -> *const *const blaz
 
     for syms in syms_list {
         unsafe { *syms_ptr = sym_ptr };
-        for SymbolInfo {
+        for SymInfo {
             name,
             address,
             size,
@@ -177,9 +177,9 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymbolInfo>>) -> *const *const blaz
                     address,
                     size,
                     sym_type: match sym_type {
-                        SymbolType::Function => blaze_sym_type::BLAZE_SYM_FUNC,
-                        SymbolType::Variable => blaze_sym_type::BLAZE_SYM_VAR,
-                        SymbolType::Unknown => blaze_sym_type::BLAZE_SYM_UNKNOWN,
+                        SymType::Function => blaze_sym_type::BLAZE_SYM_FUNC,
+                        SymType::Variable => blaze_sym_type::BLAZE_SYM_VAR,
+                        SymType::Unknown => blaze_sym_type::BLAZE_SYM_UNKNOWN,
                     },
                     file_offset,
                     obj_file_name,

--- a/src/dwarf/parser.rs
+++ b/src/dwarf/parser.rs
@@ -11,7 +11,7 @@ use std::mem;
 use std::path::Path;
 
 use crate::elf::ElfParser;
-use crate::inspect::SymbolType;
+use crate::inspect::SymType;
 use crate::util::decode_leb128;
 use crate::util::decode_leb128_s;
 use crate::util::decode_udword;
@@ -656,7 +656,7 @@ pub(crate) struct DWSymInfo<'a> {
     pub name: &'a str,
     pub address: Addr,
     pub size: usize,
-    pub sym_type: SymbolType, // A function or a variable.
+    pub sym_type: SymType, // A function or a variable.
 }
 
 fn find_die_sibling(die: &mut debug_info::DIE<'_>) -> Option<usize> {
@@ -748,7 +748,7 @@ fn parse_die_subprogram<'a>(
             name,
             address,
             size: size as usize,
-            sym_type: SymbolType::Function,
+            sym_type: SymType::Function,
         })),
         _ => Ok(None),
     }

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -11,8 +11,8 @@ use std::rc::Rc;
 
 use crate::elf::ElfParser;
 use crate::inspect::FindAddrOpts;
-use crate::inspect::SymbolInfo;
-use crate::inspect::SymbolType;
+use crate::inspect::SymInfo;
+use crate::inspect::SymType;
 use crate::util::find_match_or_lower_bound_by;
 use crate::Addr;
 
@@ -150,12 +150,8 @@ impl DwarfResolver {
     ///
     /// * `name` - is the symbol name to find.
     /// * `opts` - is the context giving additional parameters.
-    pub(crate) fn find_addr(
-        &self,
-        name: &str,
-        opts: &FindAddrOpts,
-    ) -> Result<Vec<SymbolInfo>, Error> {
-        if let SymbolType::Variable = opts.sym_type {
+    pub(crate) fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>, Error> {
+        if let SymType::Variable = opts.sym_type {
             return Err(Error::new(ErrorKind::Unsupported, "Not implemented"))
         }
         let elf_r = self.parser.find_addr(name, opts)?;
@@ -187,7 +183,7 @@ impl DwarfResolver {
                 sym_type,
                 ..
             } = debug_info_syms[idx];
-            found.push(SymbolInfo {
+            found.push(SymInfo {
                 name: name.to_string(),
                 address: address as Addr,
                 size,
@@ -240,7 +236,7 @@ mod tests {
         let opts = FindAddrOpts {
             offset_in_file: false,
             obj_file_name: false,
-            sym_type: SymbolType::Function,
+            sym_type: SymType::Function,
         };
         let resolver = DwarfResolver::open(test_dwarf.as_ref(), true, true).unwrap();
 
@@ -261,7 +257,7 @@ mod tests {
         let opts = FindAddrOpts {
             offset_in_file: false,
             obj_file_name: false,
-            sym_type: SymbolType::Variable,
+            sym_type: SymType::Variable,
         };
         let resolver = DwarfResolver::open(test_dwarf.as_ref(), true, true).unwrap();
 

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -10,8 +10,8 @@ use std::ops::Deref as _;
 use std::path::Path;
 
 use crate::inspect::FindAddrOpts;
-use crate::inspect::SymbolInfo;
-use crate::inspect::SymbolType;
+use crate::inspect::SymInfo;
+use crate::inspect::SymType;
 use crate::mmap::Mmap;
 use crate::util::find_match_or_lower_bound_by;
 use crate::util::search_address_opt_key;
@@ -440,12 +440,8 @@ impl ElfParser {
         Ok((name, sym.st_value as Addr))
     }
 
-    pub(crate) fn find_addr(
-        &self,
-        name: &str,
-        opts: &FindAddrOpts,
-    ) -> Result<Vec<SymbolInfo>, Error> {
-        if let SymbolType::Variable = opts.sym_type {
+    pub(crate) fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>, Error> {
+        if let SymType::Variable = opts.sym_type {
             return Err(Error::new(ErrorKind::Unsupported, "Not implemented"))
         }
 
@@ -474,11 +470,11 @@ impl ElfParser {
                         )
                     })?;
                     if sym_ref.st_shndx != SHN_UNDEF {
-                        found.push(SymbolInfo {
+                        found.push(SymInfo {
                             name: name.to_string(),
                             address: sym_ref.st_value as Addr,
                             size: sym_ref.st_size as usize,
-                            sym_type: SymbolType::Function,
+                            sym_type: SymType::Function,
                             file_offset: 0,
                             obj_file_name: None,
                         });

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use crate::inspect::FindAddrOpts;
-use crate::inspect::SymbolInfo;
+use crate::inspect::SymInfo;
 use crate::log::warn;
 use crate::symbolize::AddrLineInfo;
 use crate::Addr;
@@ -133,7 +133,7 @@ impl SymResolver for ElfResolver {
         }
     }
 
-    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymbolInfo>> {
+    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymInfo>> {
         let mut addr_res = match &self.backend {
             ElfBackend::Dwarf(dwarf) => dwarf.find_addr(name, opts),
             ElfBackend::Elf(parser) => parser.find_addr(name, opts),

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::inspect::FindAddrOpts;
-use crate::inspect::SymbolInfo;
+use crate::inspect::SymInfo;
 use crate::symbolize::AddrLineInfo;
 use crate::Addr;
 use crate::SymResolver;
@@ -85,7 +85,7 @@ impl SymResolver for GsymResolver {
         find_addr_impl(self, addr).unwrap_or_default()
     }
 
-    fn find_addr(&self, _name: &str, _opts: &FindAddrOpts) -> Option<Vec<SymbolInfo>> {
+    fn find_addr(&self, _name: &str, _opts: &FindAddrOpts) -> Option<Vec<SymInfo>> {
         // It is inefficient to find the address of a symbol with
         // GSYM.  We may support it in the future if needed.
         None

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -7,8 +7,8 @@ use crate::SymResolver;
 use super::source::Elf;
 use super::source::Source;
 use super::FindAddrOpts;
-use super::SymbolInfo;
-use super::SymbolType;
+use super::SymInfo;
+use super::SymType;
 
 
 /// An inspector of various "sources".
@@ -29,11 +29,11 @@ impl Inspector {
 
     /// Look up information (address etc.) about a list of symbols,
     /// given their names.
-    pub fn lookup(&self, names: &[&str], src: &Source) -> Result<Vec<Vec<SymbolInfo>>> {
+    pub fn lookup(&self, names: &[&str], src: &Source) -> Result<Vec<Vec<SymInfo>>> {
         let opts = FindAddrOpts {
             offset_in_file: true,
             obj_file_name: true,
-            sym_type: SymbolType::Unknown,
+            sym_type: SymType::Unknown,
         };
 
         match src {

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -10,19 +10,22 @@ pub use source::Elf;
 pub use source::Source;
 
 
-/// Types of symbols.
+/// The type of a symbol.
 #[derive(Clone, Copy, Debug, Default)]
-pub enum SymbolType {
+pub enum SymType {
+    /// The symbol type is unknown.
     #[default]
     Unknown,
+    /// The symbol is a function.
     Function,
+    /// The symbol is a variable.
     Variable,
 }
 
 
-/// Information of a symbol.
+/// Information about a symbol.
 #[derive(Debug)]
-pub struct SymbolInfo {
+pub struct SymInfo {
     /// The name of the symbol; for example, a function name.
     pub name: String,
     /// Start address (the first byte) of the symbol
@@ -30,7 +33,7 @@ pub struct SymbolInfo {
     /// The size of the symbol. The size of a function for example.
     pub size: usize,
     /// A function or a variable.
-    pub sym_type: SymbolType,
+    pub sym_type: SymType,
     /// The offset in the object file.
     pub file_offset: u64,
     /// The file name of the shared object.
@@ -50,5 +53,5 @@ pub(crate) struct FindAddrOpts {
     pub obj_file_name: bool,
     /// Return the symbol(s) matching a given type. Unknown, by default,
     /// means all types.
-    pub sym_type: SymbolType,
+    pub sym_type: SymType,
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 
 use crate::elf::ElfResolver;
 use crate::inspect::FindAddrOpts;
-use crate::inspect::SymbolInfo;
+use crate::inspect::SymInfo;
 use crate::ksym::KSymResolver;
 use crate::symbolize::AddrLineInfo;
 use crate::Addr;
@@ -54,7 +54,7 @@ impl SymResolver for KernelResolver {
         }
     }
 
-    fn find_addr(&self, _name: &str, _opts: &FindAddrOpts) -> Option<Vec<SymbolInfo>> {
+    fn find_addr(&self, _name: &str, _opts: &FindAddrOpts) -> Option<Vec<SymInfo>> {
         None
     }
 

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use crate::inspect::FindAddrOpts;
-use crate::inspect::SymbolInfo;
-use crate::inspect::SymbolType;
+use crate::inspect::SymInfo;
+use crate::inspect::SymType;
 use crate::symbolize::AddrLineInfo;
 use crate::Addr;
 use crate::SymResolver;
@@ -136,18 +136,18 @@ impl SymResolver for KSymResolver {
             .collect()
     }
 
-    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymbolInfo>> {
-        if let SymbolType::Variable = opts.sym_type {
+    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymInfo>> {
+        if let SymType::Variable = opts.sym_type {
             return None
         }
         self.ensure_sym_to_addr();
 
         self.sym_to_addr.borrow().get(name).map(|addr| {
-            vec![SymbolInfo {
+            vec![SymInfo {
                 name: name.to_string(),
                 address: *addr,
                 size: 0,
-                sym_type: SymbolType::Function,
+                sym_type: SymType::Function,
                 file_offset: 0,
                 obj_file_name: None,
             }]
@@ -259,7 +259,7 @@ mod tests {
         let opts = FindAddrOpts {
             offset_in_file: false,
             obj_file_name: false,
-            sym_type: SymbolType::Function,
+            sym_type: SymType::Function,
         };
         let found = resolver.find_addr(&name, &opts);
         assert!(found.is_some());

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -379,7 +379,7 @@ mod tests {
     use std::mem::transmute;
 
     use crate::inspect::FindAddrOpts;
-    use crate::inspect::SymbolType;
+    use crate::inspect::SymType;
     use crate::mmap::Mmap;
 
 
@@ -508,7 +508,7 @@ mod tests {
         // object.
         let elf_parser = ElfParser::from_mmap(mmap.clone()).unwrap();
         let opts = FindAddrOpts {
-            sym_type: SymbolType::Function,
+            sym_type: SymType::Function,
             ..Default::default()
         };
         let symbols = elf_parser.find_addr("the_answer", &opts).unwrap();

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::elf::ElfCache;
 use crate::elf::ElfResolver;
 use crate::inspect::FindAddrOpts;
-use crate::inspect::SymbolInfo;
+use crate::inspect::SymInfo;
 use crate::ksym::KSymCache;
 use crate::symbolize;
 use crate::symbolize::AddrLineInfo;
@@ -27,7 +27,7 @@ where
     /// the given address.
     fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)>;
     /// Find the address and size of a symbol name.
-    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymbolInfo>>;
+    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymInfo>>;
     /// Find the file name and the line number of an address.
     fn find_line_info(&self, addr: Addr) -> Option<AddrLineInfo>;
     /// Translate an address (virtual) in a process to the file offset

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -7,8 +7,8 @@ use crate::elf::ElfCache;
 use crate::elf::ElfResolver;
 use crate::gsym::GsymResolver;
 use crate::inspect::FindAddrOpts;
-use crate::inspect::SymbolInfo;
-use crate::inspect::SymbolType;
+use crate::inspect::SymInfo;
+use crate::inspect::SymType;
 use crate::kernel::KernelResolver;
 use crate::ksym::KSymCache;
 use crate::ksym::KALLSYMS;
@@ -135,11 +135,11 @@ impl Symbolizer {
     ///
     /// Find the addresses of a list of symbol names using the provided
     /// configuration.
-    pub fn find_addrs(&self, src: &Source, names: &[&str]) -> Result<Vec<Vec<SymbolInfo>>> {
+    pub fn find_addrs(&self, src: &Source, names: &[&str]) -> Result<Vec<Vec<SymInfo>>> {
         let opts = FindAddrOpts {
             offset_in_file: false,
             obj_file_name: false,
-            sym_type: SymbolType::Unknown,
+            sym_type: SymType::Unknown,
         };
 
         let resolver_map = ResolverMap::new(&[src], &self.ksym_cache, &self.elf_cache)?;


### PR DESCRIPTION
Rename Symbol{Info,Type} to Sym{Info,Type}. We use abbreviated addr and sym (the latter also being contained in the moniker of the library), so shorten the type names accordingly.