### PR TITLE
Extend documentation some more

### DIFF
--- a/src/c_api/mod.rs
+++ b/src/c_api/mod.rs
@@ -1,3 +1,5 @@
+//! C API bindings for the library.
+
 #[allow(non_camel_case_types)]
 mod inspect;
 #[allow(non_camel_case_types)]

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -1,3 +1,19 @@
+//! Functionality for inspecting files such as ELF or Gsym.
+//!
+//! ```no_run
+//! use blazesym::inspect;
+//! use blazesym::inspect::Inspector;
+//!
+//! let src = inspect::Source::Elf(inspect::Elf::new("/usr/bin/libc.so"));
+//! let inspector = Inspector::new();
+//! let results = inspector
+//!     .lookup(&["fopen"], &src)
+//!     .unwrap();
+//!
+//! // `results` contains a list of addresses of `fopen` symbols in `libc`.
+//! // There probably will only be a single one.
+//! ```
+
 mod inspector;
 mod source;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,46 +7,19 @@
 //! operation: looking up addresses from symbol names. That can be useful, for
 //! example, for configuring breakpoints or tracepoints.
 //!
-//! Here an example illustrating usage of the symbolization functionality:
-//! ```no_run
-//! use blazesym::Addr;
-//! use blazesym::symbolize::Symbolizer;
-//! use blazesym::symbolize::Source;
-//! use blazesym::symbolize::Process;
-//! use blazesym::symbolize::SymbolizedResult;
+//! ## Overview
+//! The crate is organized via public modules that expose functionality
+//! pertaining a certain topic. Specifically, these areas are currently covered:
 //!
-//! let process_id: u32 = std::process::id(); // <some process id>
-//! // Load all symbols of loaded files of the given process.
-//! let src = Source::Process(Process::new(process_id.into()));
-//! let symbolizer = Symbolizer::new();
+//! - [`symbolize`] covers address symbolization functionality
+//! - [`inspect`] contains APIs for inspecting files such as ELF and Gsym to
+//!   lookup addresses to symbol names, for example
+//! - [`normalize`] exposes address normalization functionality
 //!
-//! let stack: [Addr; 2] = [0xff023, 0x17ff93b];  // Addresses of instructions
-//! let symlist = symbolizer.symbolize(&src,      // Pass this configuration every time
-//!                                    &stack).unwrap();
-//! for i in 0..stack.len() {
-//!   let addr = stack[i];
-//!
-//!   if symlist.len() <= i || symlist[i].len() == 0 {  // Unknown address
-//!     println!("0x{addr:016x}");
-//!     continue;
-//!   }
-//!
-//!   let sym_results = &symlist[i];
-//!   if sym_results.len() > 1 {
-//!     // One address may get several results (e.g., when defined in multiple
-//!     // compilation units)
-//!     println!("0x{addr:016x} ({} entries)", sym_results.len());
-//!
-//!     for result in sym_results {
-//!       let SymbolizedResult {symbol, addr, path, line, column} = result;
-//!       println!("    {symbol}@0x{addr:016x} {}:{line}", path.display());
-//!     }
-//!   } else {
-//!     let SymbolizedResult {symbol, addr, path, line, column} = &sym_results[0];
-//!     println!("0x{addr:016x} {symbol}@0x{addr:016x} {}:{line}", path.display());
-//!   }
-//! }
-//! ```
+//! C API bindings are defined in a cross-cutting manner as part of the
+//! [`c_api`] module (note that Rust code should not have to consume these
+//! functions and on the ABI level this module organization has no relevance for
+//! C).
 
 #![allow(clippy::collapsible_if, clippy::let_and_return, clippy::let_unit_value)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1,3 +1,24 @@
+//! Functionality for address normalization.
+//!
+//! Address normalization is one step of address symbolization: before can
+//! address as captured in a process can be looked up in a file, it needs to be
+//! converted into an address as it will be used inside the file. E.g.,
+//! addresses in a shared object (or any position independent binary) may be
+//! relative to that file. When such a shared object is loaded into a process,
+//! it is relocated. Normalization removes this relocation information and
+//! similar adjustments made by the system (e.g., by address space layout
+//! randomization).
+//!
+//! ```no_run
+//! use blazesym::normalize::Normalizer;
+//! use blazesym::Pid;
+//!
+//! let normalizer = Normalizer::new();
+//! let addrs = [0xdeadbeef];
+//! let pid = Pid::from(1234);
+//! let norm_addrs = normalizer.normalize_user_addrs(&addrs, pid).unwrap();
+//! ```
+
 mod meta;
 mod normalizer;
 

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -1,3 +1,48 @@
+//! Functionality for symbolizing addresses.
+//!
+//! This module contains functionality for symbolizing addresses, i.e., finding
+//! symbol names and other information based on "raw" addresses.
+//!
+//! Here an example illustrating usage of the symbolization functionality:
+//! ```no_run
+//! use blazesym::Addr;
+//! use blazesym::symbolize::Symbolizer;
+//! use blazesym::symbolize::Source;
+//! use blazesym::symbolize::Process;
+//! use blazesym::symbolize::SymbolizedResult;
+//!
+//! let process_id: u32 = std::process::id(); // <some process id>
+//! // Load all symbols of loaded files of the given process.
+//! let src = Source::Process(Process::new(process_id.into()));
+//! let symbolizer = Symbolizer::new();
+//!
+//! let stack: [Addr; 2] = [0xff023, 0x17ff93b];  // Addresses of instructions
+//! let symlist = symbolizer.symbolize(&src,      // Pass this configuration every time
+//!                                    &stack).unwrap();
+//! for i in 0..stack.len() {
+//!   let addr = stack[i];
+//!
+//!   if symlist.len() <= i || symlist[i].len() == 0 {  // Unknown address
+//!     println!("0x{addr:016x}");
+//!     continue;
+//!   }
+//!
+//!   let sym_results = &symlist[i];
+//!   if sym_results.len() > 1 {
+//!     // One address may get several results.
+//!     println!("0x{addr:016x} ({} entries)", sym_results.len());
+//!
+//!     for result in sym_results {
+//!       let SymbolizedResult {symbol, addr, path, line, column} = result;
+//!       println!("    {symbol}@0x{addr:016x} {}:{line}", path.display());
+//!     }
+//!   } else {
+//!     let SymbolizedResult {symbol, addr, path, line, column} = &sym_results[0];
+//!     println!("0x{addr:016x} {symbol}@0x{addr:016x} {}:{line}", path.display());
+//!   }
+//! }
+//! ```
+
 mod source;
 mod symbolizer;
 

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -116,7 +116,7 @@ fn lookup_dwarf() {
 
 /// Check that we can normalize user addresses in our own shared object.
 #[test]
-fn normalize_user_address() {
+fn normalize_user_addr() {
     fn test(so: &str) {
         let test_so = Path::new(&env!("CARGO_MANIFEST_DIR")).join("data").join(so);
         let so_cstr = CString::new(test_so.clone().into_os_string().into_vec()).unwrap();


### PR DESCRIPTION
This change extends the documentation with an overview of the crate, more examples, and a bunch of explanations of the public modules.