### PR TITLE
Rename BlazeSym -> blazesym

### DIFF
--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -291,7 +291,7 @@ typedef struct blaze_symbolize_src_process {
   /**
    * It is the PID of a process to symbolize.
    *
-   * BlazeSym will parse `/proc/<pid>/maps` and load all the object
+   * blazesym will parse `/proc/<pid>/maps` and load all the object
    * files.
    */
   uint32_t pid;

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -121,7 +121,7 @@ impl From<&blaze_symbolize_src_kernel> for Kernel {
 pub struct blaze_symbolize_src_process {
     /// It is the PID of a process to symbolize.
     ///
-    /// BlazeSym will parse `/proc/<pid>/maps` and load all the object
+    /// blazesym will parse `/proc/<pid>/maps` and load all the object
     /// files.
     pub pid: u32,
 }

--- a/src/dwarf/debug_info.rs
+++ b/src/dwarf/debug_info.rs
@@ -80,7 +80,7 @@ pub struct CUHeaderV4 {
 /// DIEs of the unit in the `.debug_info` section.  DWARFv5 is much
 /// more complicated.
 ///
-/// So far, BlazeSym supports only DWARFv4, that is common used.
+/// So far, blazesym supports only DWARFv4, that is common used.
 pub enum UnitHeader {
     CompileV4(CUHeaderV4),
     CompileV5(CUHeaderV5),
@@ -765,7 +765,7 @@ impl<'a> Iterator for UnitIter<'a> {
                         },
                     ))
                 }
-                // BlazeSym supports only v4 so far.
+                // blazesym supports only v4 so far.
                 UnitHeader::CompileV5(ref _cuh) => {
                     log::warn!("ignoring unsupported DWARF v5 unit header");
                 }


### PR DESCRIPTION
Let's rename the few usages of BlazeSym to blazesym.