### PR TITLE
Swap 'symbolization' keyword with 'stacktrace'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = [
   "dwarf",
   "elf",
   "gsym",
-  "symbolization",
+  "stacktrace",
   "tracing",
 ]
 exclude = ["data/dwarf-example", "data/kallsyms.xz"]


### PR DESCRIPTION
Replace the 'symbolization' keyword in Cargo.toml with 'stacktrace', as per earlier discussion [0].

[0]: https://github.com/libbpf/blazesym/pull/156#discussion_r1185584238