### PR TITLE
Fix incorrect allocation size calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+Unreleased
+----------
+- Fixed incorrect allocation size calculation in C API
+
+
+0.2.0-alpha.0
+-------------
+- Initial documented release

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 # blazesym
 
+- [Changelog](CHANGELOG.md)
+
 **blazesym** is a library that can be used to symbolize addresses. Address
 symbolization is a common problem in tracing contexts, for example, where users
 want to reason about functions by name, but low level components report only the

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -40,7 +40,7 @@ pub enum SymType {
 
 
 /// Information about a symbol.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SymInfo {
     /// The name of the symbol; for example, a function name.
     pub name: String,


### PR DESCRIPTION
This change fixes a wrong allocation size calculation, potentially causing too small a buffer to be allocated, resulting in out-of-bounds writes when looking up symbol information from names using the C API. Thanks @anakryiko for spotting the issue!