### PR TITLE
Remove concept of base_address

### DIFF
--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -340,30 +340,6 @@ typedef struct blaze_symbolize_src_elf {
    * libc.
    */
   const char *path;
-  /**
-   * The base address is where the file's executable segment(s) is loaded.
-   *
-   * It should be the address
-   * in the process mapping to the executable segment's first byte.
-   * For example, in /proc/&lt;pid&gt;/maps
-   *
-   * ```text
-   *     7fe1b2dc4000-7fe1b2f80000 r-xp 00000000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-   *     7fe1b2f80000-7fe1b3180000 ---p 001bc000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-   *     7fe1b3180000-7fe1b3184000 r--p 001bc000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-   *     7fe1b3184000-7fe1b3186000 rw-p 001c0000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-   * ```
-   *
-   * It reveals that the executable segment of libc-2.28.so was
-   * loaded at 0x7fe1b2dc4000.  This base address is used to
-   * translate an address in the segment to the corresponding
-   * address in the ELF file.
-   *
-   * A loader would load an executable segment with the permission of `x`
-   * (executable).  For example, the first block is with the
-   * permission of `r-xp`.
-   */
-  uintptr_t base_address;
 } blaze_symbolize_src_elf;
 
 /**
@@ -374,10 +350,6 @@ typedef struct blaze_symbolize_src_gsym {
    * The path to a gsym file.
    */
   const char *path;
-  /**
-   * The base address is where the file's executable segment(s) is loaded.
-   */
-  uintptr_t base_address;
 } blaze_symbolize_src_gsym;
 
 /**

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -38,36 +38,13 @@ pub struct blaze_symbolize_src_elf {
     /// passing "/lib/libc.so.xxx" will load symbols and debug information from
     /// libc.
     pub path: *const c_char,
-    /// The base address is where the file's executable segment(s) is loaded.
-    ///
-    /// It should be the address
-    /// in the process mapping to the executable segment's first byte.
-    /// For example, in /proc/&lt;pid&gt;/maps
-    ///
-    /// ```text
-    ///     7fe1b2dc4000-7fe1b2f80000 r-xp 00000000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-    ///     7fe1b2f80000-7fe1b3180000 ---p 001bc000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-    ///     7fe1b3180000-7fe1b3184000 r--p 001bc000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-    ///     7fe1b3184000-7fe1b3186000 rw-p 001c0000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-    /// ```
-    ///
-    /// It reveals that the executable segment of libc-2.28.so was
-    /// loaded at 0x7fe1b2dc4000.  This base address is used to
-    /// translate an address in the segment to the corresponding
-    /// address in the ELF file.
-    ///
-    /// A loader would load an executable segment with the permission of `x`
-    /// (executable).  For example, the first block is with the
-    /// permission of `r-xp`.
-    pub base_address: Addr,
 }
 
 impl From<&blaze_symbolize_src_elf> for Elf {
     fn from(elf: &blaze_symbolize_src_elf) -> Self {
-        let blaze_symbolize_src_elf { path, base_address } = elf;
+        let blaze_symbolize_src_elf { path } = elf;
         Self {
             path: unsafe { from_cstr(*path) },
-            base_address: *base_address,
             _non_exhaustive: (),
         }
     }
@@ -143,16 +120,13 @@ impl From<&blaze_symbolize_src_process> for Process {
 pub struct blaze_symbolize_src_gsym {
     /// The path to a gsym file.
     pub path: *const c_char,
-    /// The base address is where the file's executable segment(s) is loaded.
-    pub base_address: Addr,
 }
 
 impl From<&blaze_symbolize_src_gsym> for Gsym {
     fn from(gsym: &blaze_symbolize_src_gsym) -> Self {
-        let blaze_symbolize_src_gsym { path, base_address } = gsym;
+        let blaze_symbolize_src_gsym { path } = gsym;
         Self {
             path: unsafe { from_cstr(*path) },
-            base_address: *base_address,
             _non_exhaustive: (),
         }
     }

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -36,7 +36,6 @@ pub struct ElfResolver {
     loaded_address: Addr,
     loaded_to_virt: Addr,
     foff_to_virt: usize,
-    size: usize,
     file_name: PathBuf,
 }
 
@@ -86,14 +85,12 @@ impl ElfResolver {
         };
         let loaded_to_virt = low_addr;
         let foff_to_virt = low_addr - low_off;
-        let size = max_addr - low_addr;
 
         Ok(ElfResolver {
             backend,
             loaded_address,
             loaded_to_virt: loaded_to_virt as Addr,
             foff_to_virt: foff_to_virt as usize,
-            size: size as usize,
             file_name: file_name.to_path_buf(),
         })
     }
@@ -107,10 +104,6 @@ impl ElfResolver {
 }
 
 impl SymResolver for ElfResolver {
-    fn get_address_range(&self) -> (Addr, Addr) {
-        (self.loaded_address, self.loaded_address + self.size)
-    }
-
     fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)> {
         let parser = self.get_parser();
 

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -40,11 +40,7 @@ pub struct ElfResolver {
 }
 
 impl ElfResolver {
-    pub(crate) fn with_backend(
-        file_name: &Path,
-        loaded_address: Addr,
-        backend: ElfBackend,
-    ) -> Result<ElfResolver> {
+    pub(crate) fn with_backend(file_name: &Path, backend: ElfBackend) -> Result<ElfResolver> {
         let parser = match &backend {
             ElfBackend::Dwarf(dwarf) => dwarf.get_parser(),
             ElfBackend::Elf(parser) => parser,
@@ -81,7 +77,7 @@ impl ElfResolver {
         let loaded_address = if e_type == ET_EXEC {
             low_addr as Addr
         } else {
-            loaded_address
+            0
         };
         let loaded_to_virt = low_addr;
         let foff_to_virt = low_addr - low_off;

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -150,11 +150,6 @@ impl GsymContext<'_> {
         })?
     }
 
-    #[inline]
-    fn num_addresses(&self) -> usize {
-        self.header.num_addrs as usize
-    }
-
     /// Find the index of an entry in the address table potentially containing the
     /// given address.
     ///
@@ -206,18 +201,6 @@ impl GsymContext<'_> {
         let info = AddrInfo { size, name, data };
 
         Some(info)
-    }
-
-    /// Retrieve the [start, end] address range
-    pub fn address_range(&self) -> Option<(Addr, Addr)> {
-        let len = self.num_addresses();
-        if len == 0 {
-            return Some((0, 0))
-        }
-
-        let start = self.addr_at(0)?;
-        let end = self.addr_at(len - 1)? + self.addr_info(len - 1)?.size as Addr;
-        Some((start, end))
     }
 
     /// Get the string at the given offset from the String Table.

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -57,7 +57,7 @@ impl Inspector {
                     backend
                 };
 
-                let resolver = ElfResolver::with_backend(path, 0, backend)?;
+                let resolver = ElfResolver::with_backend(path, backend)?;
                 let syms = names
                     .iter()
                     .map(|name| {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -42,10 +42,6 @@ impl KernelResolver {
 }
 
 impl SymResolver for KernelResolver {
-    fn get_address_range(&self) -> (Addr, Addr) {
-        (0xffffffff80000000, 0xffffffffffffffff)
-    }
-
     fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)> {
         if let Some(ksym_resolver) = self.ksym_resolver.as_ref() {
             ksym_resolver.find_symbols(addr)

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -126,10 +126,6 @@ impl KSymResolver {
 }
 
 impl SymResolver for KSymResolver {
-    fn get_address_range(&self) -> (Addr, Addr) {
-        (0xffffffff80000000, 0xffffffffffffffff)
-    }
-
     fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)> {
         self.find_addresses_ksym(addr)
             .map(|sym| (sym.name.as_str(), sym.addr))

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -15,8 +15,6 @@ pub(crate) trait SymResolver
 where
     Self: Debug,
 {
-    /// Return the range that this resolver serves in an address space.
-    fn get_address_range(&self) -> (Addr, Addr);
     /// Find the names and the start addresses of a symbol found for
     /// the given address.
     fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)>;

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use crate::Addr;
 use crate::Pid;
 
 #[cfg(doc)]
@@ -16,27 +15,6 @@ pub struct Elf {
     /// For example, passing `"/bin/sh"` will load symbols and debug information from `sh`.
     /// Whereas passing `"/lib/libc.so.xxx"` will load symbols and debug information from the libc.
     pub path: PathBuf,
-    /// The address where the executable segment loaded.
-    ///
-    /// The address in the process should be the executable segment's
-    /// first byte.  For example, in `/proc/<pid>/maps`.
-    ///
-    /// ```text
-    ///     7fe1b2dc4000-7fe1b2f80000 r-xp 00000000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-    ///     7fe1b2f80000-7fe1b3180000 ---p 001bc000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-    ///     7fe1b3180000-7fe1b3184000 r--p 001bc000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-    ///     7fe1b3184000-7fe1b3186000 rw-p 001c0000 00:1d 71695032                   /usr/lib64/libc-2.28.so
-    /// ```
-    ///
-    /// It reveals that the executable segment of libc-2.28.so was
-    /// loaded at 0x7fe1b2dc4000.  This base address is used to
-    /// translate an address in the segment to the corresponding
-    /// address in the ELF file.
-    ///
-    /// A loader would load an executable segment with the permission of
-    /// `x`.  For example, the first block is with the permission of
-    /// `r-xp`.
-    pub base_address: Addr,
     /// The struct is non-exhaustive and open to extension.
     #[doc(hidden)]
     pub(crate) _non_exhaustive: (),
@@ -47,7 +25,6 @@ impl Elf {
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self {
             path: path.into(),
-            base_address: 0,
             _non_exhaustive: (),
         }
     }
@@ -126,8 +103,6 @@ impl From<Process> for Source {
 pub struct Gsym {
     /// The path to the gsym file.
     pub path: PathBuf,
-    /// The base address.
-    pub base_address: Addr,
     /// The struct is non-exhaustive and open to extension.
     #[doc(hidden)]
     pub(crate) _non_exhaustive: (),
@@ -138,7 +113,6 @@ impl Gsym {
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self {
             path: path.into(),
-            base_address: 0,
             _non_exhaustive: (),
         }
     }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -196,7 +196,7 @@ impl Symbolizer {
 
     fn resolve_addr_in_binary(&self, addr: Addr, path: &Path) -> Result<Vec<SymbolizedResult>> {
         let backend = self.elf_cache.find(path)?;
-        let resolver = ElfResolver::with_backend(path, 0, backend)?;
+        let resolver = ElfResolver::with_backend(path, backend)?;
         let symbols = self.symbolize_with_resolver(addr, &resolver);
         Ok(symbols)
     }
@@ -268,7 +268,7 @@ impl Symbolizer {
 
         let elf_resolver = if let Some(image) = kernel_image {
             let backend = self.elf_cache.find(image)?;
-            let elf_resolver = ElfResolver::with_backend(image, 0, backend)?;
+            let elf_resolver = ElfResolver::with_backend(image, backend)?;
             Some(elf_resolver)
         } else {
             let release = uname_release()?.to_str().unwrap().to_string();
@@ -283,7 +283,7 @@ impl Symbolizer {
                 let result = self.elf_cache.find(&image);
                 match result {
                     Ok(backend) => {
-                        let result = ElfResolver::with_backend(&image, 0, backend);
+                        let result = ElfResolver::with_backend(&image, backend);
                         match result {
                             Ok(resolver) => Some(resolver),
                             Err(err) => {
@@ -321,7 +321,7 @@ impl Symbolizer {
                 _non_exhaustive: (),
             }) => {
                 let backend = self.elf_cache.find(path)?;
-                let resolver = ElfResolver::with_backend(path, 0, backend)?;
+                let resolver = ElfResolver::with_backend(path, backend)?;
                 let symbols = self.symbolize_addrs(addrs, &resolver);
                 Ok(symbols)
             }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -318,11 +318,10 @@ impl Symbolizer {
         match src {
             Source::Elf(Elf {
                 path,
-                base_address,
                 _non_exhaustive: (),
             }) => {
                 let backend = self.elf_cache.find(path)?;
-                let resolver = ElfResolver::with_backend(path, *base_address, backend)?;
+                let resolver = ElfResolver::with_backend(path, 0, backend)?;
                 let symbols = self.symbolize_addrs(addrs, &resolver);
                 Ok(symbols)
             }
@@ -333,10 +332,9 @@ impl Symbolizer {
             }) => self.symbolize_user_addrs(addrs, *pid),
             Source::Gsym(Gsym {
                 path,
-                base_address,
                 _non_exhaustive: (),
             }) => {
-                let resolver = GsymResolver::new(path.clone(), *base_address)?;
+                let resolver = GsymResolver::new(path.clone(), 0)?;
                 let symbols = self.symbolize_addrs(addrs, &resolver);
                 Ok(symbols)
             }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -334,7 +334,7 @@ impl Symbolizer {
                 path,
                 _non_exhaustive: (),
             }) => {
-                let resolver = GsymResolver::new(path.clone(), 0)?;
+                let resolver = GsymResolver::new(path.clone())?;
                 let symbols = self.symbolize_addrs(addrs, &resolver);
                 Ok(symbols)
             }

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -120,10 +120,7 @@ fn normalize_user_addr() {
         let meta = &norm_addrs.meta[norm_addr.1];
         assert_eq!(meta.binary().unwrap().path, test_so);
 
-        let mut elf = symbolize::Elf::new(test_so);
-        // TODO: Fix our symbolizer. Base address should be 0.
-        elf.base_address = 0x1000;
-
+        let elf = symbolize::Elf::new(test_so);
         let src = symbolize::Source::Elf(elf);
         let symbolizer = Symbolizer::new();
         let results = symbolizer

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -63,7 +63,6 @@ fn symbolize_from_elf() {
 
     let elf_src = blaze_symbolize_src_elf {
         path: test_dwarf_c.as_ptr(),
-        base_address: 0,
     };
 
     let symbolizer = blaze_symbolizer_new();
@@ -99,7 +98,6 @@ fn symbolize_from_gsym() {
     let test_gsym_c = CString::new(test_gsym.to_str().unwrap()).unwrap();
     let gsym_src = blaze_symbolize_src_gsym {
         path: test_gsym_c.as_ptr(),
-        base_address: 0,
     };
 
     let symbolizer = blaze_symbolizer_new();


### PR DESCRIPTION
Now that we have removed the Symbolizer::find_addrs functionality with commit c504b0fefc9d ("Remove no longer used functionality"), we no longer use or need the base_address that is still a member of a bunch of types. Remove it, as it was never a sustainable concept to work with.