### PR TITLE
Add CHANGELOG entry for recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Removed no longer necessary `base_address` member from various types
 - Fixed incorrect allocation size calculation in C API
 
 


### PR DESCRIPTION
This change adds a CHANGELOG entry for the changes made by https://github.com/libbpf/blazesym/pull/165.