### PR TITLE
Rename SymInfo::address to addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Removed no longer necessary `base_address` member from various types
+- Renamed `SymInfo::address` member to `addr`
 - Fixed incorrect allocation size calculation in C API
 - Fixed file offset lookup potentially reporting subtly wrong offsets on
   certain ELF file segment constellations

--- a/benches/inspect.rs
+++ b/benches/inspect.rs
@@ -25,7 +25,7 @@ fn lookup_dwarf() {
     assert_eq!(results.len(), 1);
 
     let result = results.first().unwrap();
-    assert_eq!(result.address, 0xffffffff8110ecb0);
+    assert_eq!(result.addr, 0xffffffff8110ecb0);
 }
 
 pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -71,7 +71,7 @@ typedef struct blaze_symbolizer blaze_symbolizer;
  */
 typedef struct blaze_sym_info {
   const char *name;
-  uintptr_t address;
+  uintptr_t addr;
   size_t size;
   uint64_t file_offset;
   const char *obj_file_name;

--- a/src/c_api/inspect.rs
+++ b/src/c_api/inspect.rs
@@ -114,7 +114,7 @@ impl From<SymType> for blaze_sym_type {
 #[derive(Debug)]
 pub struct blaze_sym_info {
     pub name: *const c_char,
-    pub address: Addr,
+    pub addr: Addr,
     pub size: usize,
     pub file_offset: u64,
     pub obj_file_name: *const c_char,
@@ -157,7 +157,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
         unsafe { *syms_ptr = sym_ptr };
         for SymInfo {
             name,
-            address,
+            addr,
             size,
             sym_type,
             file_offset,
@@ -184,7 +184,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
             unsafe {
                 (*sym_ptr) = blaze_sym_info {
                     name: name_ptr,
-                    address,
+                    addr,
                     size,
                     sym_type: match sym_type {
                         SymType::Function => blaze_sym_type::BLAZE_SYM_FUNC,
@@ -200,7 +200,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
         unsafe {
             (*sym_ptr) = blaze_sym_info {
                 name: ptr::null(),
-                address: 0,
+                addr: 0,
                 size: 0,
                 sym_type: blaze_sym_type::BLAZE_SYM_UNKNOWN,
                 file_offset: 0,
@@ -333,7 +333,7 @@ mod tests {
                         unsafe { CStr::from_ptr(c_sym.name) }.to_bytes(),
                         CString::new(sym.name).unwrap().to_bytes()
                     );
-                    assert_eq!(c_sym.address, sym.address);
+                    assert_eq!(c_sym.addr, sym.addr);
                     assert_eq!(c_sym.size, sym.size);
                     assert_eq!(c_sym.sym_type, blaze_sym_type::from(sym.sym_type));
                     assert_eq!(c_sym.file_offset, sym.file_offset);
@@ -363,7 +363,7 @@ mod tests {
         // Test conversion with a single symbol.
         let syms = vec![vec![SymInfo {
             name: "sym1".to_string(),
-            address: 0xdeadbeef,
+            addr: 0xdeadbeef,
             size: 42,
             sym_type: SymType::Function,
             file_offset: 1337,
@@ -375,7 +375,7 @@ mod tests {
         let syms = vec![vec![
             SymInfo {
                 name: "sym1".to_string(),
-                address: 0xdeadbeef,
+                addr: 0xdeadbeef,
                 size: 42,
                 sym_type: SymType::Function,
                 file_offset: 1337,
@@ -383,7 +383,7 @@ mod tests {
             },
             SymInfo {
                 name: "sym2".to_string(),
-                address: 0xdeadbeef + 52,
+                addr: 0xdeadbeef + 52,
                 size: 45,
                 sym_type: SymType::Unknown,
                 file_offset: 1338,
@@ -396,7 +396,7 @@ mod tests {
         let syms = vec![
             vec![SymInfo {
                 name: "sym1".to_string(),
-                address: 0xdeadbeef,
+                addr: 0xdeadbeef,
                 size: 42,
                 sym_type: SymType::Function,
                 file_offset: 1337,
@@ -404,7 +404,7 @@ mod tests {
             }],
             vec![SymInfo {
                 name: "sym2".to_string(),
-                address: 0xdeadbeef + 52,
+                addr: 0xdeadbeef + 52,
                 size: 45,
                 sym_type: SymType::Unknown,
                 file_offset: 1338,
@@ -416,7 +416,7 @@ mod tests {
         // Test conversion of a `SymInfo` vector with many elements.
         let sym = SymInfo {
             name: "sym1".to_string(),
-            address: 0xdeadbeef,
+            addr: 0xdeadbeef,
             size: 42,
             sym_type: SymType::Function,
             file_offset: 1337,

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -186,7 +186,7 @@ impl DwarfResolver {
             } = debug_info_syms[idx];
             found.push(SymInfo {
                 name: name.to_string(),
-                address: addr as Addr,
+                addr: addr as Addr,
                 size,
                 sym_type,
                 file_offset: 0,
@@ -246,7 +246,7 @@ mod tests {
 
         // `factorial` resides at address 0x2000100.
         let symbol = symbols.first().unwrap();
-        assert_eq!(symbol.address, 0x2000100);
+        assert_eq!(symbol.addr, 0x2000100);
     }
 
     /// Check that we fail to look up variables.

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -54,7 +54,7 @@ impl DwarfResolver {
             if dlcu.matrix.is_empty() {
                 continue
             }
-            let first_addr = dlcu.matrix[0].address;
+            let first_addr = dlcu.matrix[0].addr;
             addr_to_dlcu.push((first_addr, idx as u32));
         }
         addr_to_dlcu.sort_by_key(|v| v.0);
@@ -106,9 +106,9 @@ impl DwarfResolver {
         Self::open_for_addresses(filename, &[], debug_line_info, debug_info_symbols)
     }
 
-    fn find_dlcu_index(&self, address: Addr) -> Option<usize> {
+    fn find_dlcu_index(&self, addr: Addr) -> Option<usize> {
         let a2a = &self.addr_to_dlcu;
-        let a2a_idx = find_match_or_lower_bound_by(a2a, address, |a2dlcu| a2dlcu.0)?;
+        let a2a_idx = find_match_or_lower_bound_by(a2a, addr, |a2dlcu| a2dlcu.0)?;
         let dlcu_idx = a2a[a2a_idx].1 as usize;
 
         Some(dlcu_idx)
@@ -116,13 +116,14 @@ impl DwarfResolver {
 
     /// Find line information of an address.
     ///
-    /// `address` is an offset from the head of the loaded binary/or
-    /// shared object.  This function returns a tuple of `(dir_name, file_name, line_no)`.
-    pub fn find_line(&self, address: Addr) -> Option<(&Path, &OsStr, usize)> {
-        let idx = self.find_dlcu_index(address)?;
+    /// `addr` is an offset from the head of the loaded binary/or shared
+    /// object. This function returns a tuple of `(dir_name, file_name,
+    /// line_no)`.
+    pub fn find_line(&self, addr: Addr) -> Option<(&Path, &OsStr, usize)> {
+        let idx = self.find_dlcu_index(addr)?;
         let dlcu = &self.debug_line_cus[idx];
 
-        dlcu.find_line(address)
+        dlcu.find_line(addr)
     }
 
     /// Extract the symbol information from DWARf if having not done it before.
@@ -178,14 +179,14 @@ impl DwarfResolver {
         let mut found = vec![];
         while debug_info_syms[idx].name.eq(name) {
             let DWSymInfo {
-                address,
+                addr,
                 size,
                 sym_type,
                 ..
             } = debug_info_syms[idx];
             found.push(SymInfo {
                 name: name.to_string(),
-                address: address as Addr,
+                address: addr as Addr,
                 size,
                 sym_type,
                 file_offset: 0,

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -406,14 +406,14 @@ impl ElfParser {
         Ok(index)
     }
 
-    pub fn find_symbol(&self, address: Addr, st_type: u8) -> Result<(&str, Addr), Error> {
+    pub fn find_symbol(&self, addr: Addr, st_type: u8) -> Result<(&str, Addr), Error> {
         let mut cache = self.cache.borrow_mut();
         let () = cache.ensure_symtab()?;
         // SANITY: The above `ensure_symtab` ensures we have `symtab`
         //         available.
         let symtab = cache.symtab.as_ref().unwrap();
 
-        let idx_r = search_address_opt_key(symtab, address, &|sym: &&Elf64_Sym| {
+        let idx_r = search_address_opt_key(symtab, addr, &|sym: &&Elf64_Sym| {
             if sym.st_info & 0xf != st_type || sym.st_shndx == SHN_UNDEF {
                 None
             } else {
@@ -465,7 +465,7 @@ impl ElfParser {
                     if sym_ref.st_shndx != SHN_UNDEF {
                         found.push(SymInfo {
                             name: name.to_string(),
-                            address: sym_ref.st_value as Addr,
+                            addr: sym_ref.st_value as Addr,
                             size: sym_ref.st_size as usize,
                             sym_type: SymType::Function,
                             file_offset: 0,
@@ -571,7 +571,7 @@ mod tests {
         let opts = FindAddrOpts::default();
         let addr_r = parser.find_addr(sym_name, &opts).unwrap();
         assert_eq!(addr_r.len(), 1);
-        assert!(addr_r.iter().any(|x| x.address == addr));
+        assert!(addr_r.iter().any(|x| x.addr == addr));
     }
 
     /// Make sure that we can look up a symbol in an ELF file.
@@ -587,12 +587,12 @@ mod tests {
         assert_eq!(syms.len(), 1);
         let sym = &syms[0];
         assert_eq!(sym.name, "factorial");
-        assert_eq!(sym.address, 0x2000100);
+        assert_eq!(sym.addr, 0x2000100);
 
         let syms = parser.find_addr("factorial_wrapper", &opts).unwrap();
         assert_eq!(syms.len(), 2);
         assert_eq!(syms[0].name, "factorial_wrapper");
         assert_eq!(syms[1].name, "factorial_wrapper");
-        assert_ne!(syms[0].address, syms[1].address);
+        assert_ne!(syms[0].addr, syms[1].addr);
     }
 }

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -64,7 +64,7 @@ impl Inspector {
                         let mut syms = resolver.find_addr(name, &opts).unwrap_or_default();
                         let () = syms.iter_mut().for_each(|sym| {
                             if opts.offset_in_file {
-                                if let Some(off) = resolver.addr_file_off(sym.address) {
+                                if let Some(off) = resolver.addr_file_off(sym.addr) {
                                     sym.file_offset = off;
                                 }
                             }

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -44,8 +44,8 @@ pub enum SymType {
 pub struct SymInfo {
     /// The name of the symbol; for example, a function name.
     pub name: String,
-    /// Start address (the first byte) of the symbol
-    pub address: Addr,
+    /// Start address (the first byte) of the symbol.
+    pub addr: Addr,
     /// The size of the symbol. The size of a function for example.
     pub size: usize,
     /// A function or a variable.

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -141,7 +141,7 @@ impl SymResolver for KSymResolver {
         self.sym_to_addr.borrow().get(name).map(|addr| {
             vec![SymInfo {
                 name: name.to_string(),
-                address: *addr,
+                addr: *addr,
                 size: 0,
                 sym_type: SymType::Function,
                 file_offset: 0,
@@ -259,7 +259,7 @@ mod tests {
         };
         let found = resolver.find_addr(&name, &opts);
         assert!(found.is_some());
-        assert!(found.unwrap().iter().any(|x| x.address == addr));
+        assert!(found.unwrap().iter().any(|x| x.addr == addr));
     }
 
     #[test]

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -516,7 +516,7 @@ mod tests {
         assert_eq!(symbols.len(), 1);
         let symbol = symbols.first().unwrap();
 
-        let the_answer_addr = unsafe { mmap.as_ptr().add(symbol.address) };
+        let the_answer_addr = unsafe { mmap.as_ptr().add(symbol.addr) };
         // Now just double check that everything worked out and the function
         // is actually where it was meant to be.
         let the_answer_fn =
@@ -532,7 +532,7 @@ mod tests {
         assert_eq!(norm_addrs.meta.len(), 1);
 
         let norm_addr = norm_addrs.addrs[0];
-        assert_eq!(norm_addr.0, symbol.address);
+        assert_eq!(norm_addr.0, symbol.addr);
         let meta = &norm_addrs.meta[norm_addr.1];
         let so_path = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -155,7 +155,7 @@ fn inspect() {
         assert_eq!(results.len(), 1);
 
         let result = results.first().unwrap();
-        assert_eq!(result.address, 0x2000100);
+        assert_eq!(result.addr, 0x2000100);
         assert_ne!(result.file_offset, 0);
         assert_eq!(
             result.obj_file_name.as_deref().unwrap(),

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -249,7 +249,7 @@ fn lookup_dwarf() {
         unsafe { CStr::from_ptr(sym_info.name) },
         CStr::from_bytes_with_nul(b"factorial\0").unwrap()
     );
-    assert_eq!(sym_info.address, 0x2000100);
+    assert_eq!(sym_info.addr, 0x2000100);
 
     let () = unsafe { blaze_inspect_syms_free(result) };
     let () = unsafe { blaze_inspector_free(inspector) };


### PR DESCRIPTION
Rename the `SymInfo::address` member to `addr`, in pursuit of our aim of
using short hand "addr" throughout the crate eventually.
