### PR TITLE
Bump version to 0.2.0-alpha.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,26 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    - name: Dry-run package creation
+      run: cargo package --no-verify
+    - name: Create git tag
+      env:
+        version: ${{ needs.version.outputs.version }}
+      run: |
+        curl --location \
+          --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/releases \
+          --header "Accept: application/vnd.github+json" \
+          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+          --header "X-GitHub-Api-Version: 2022-11-28" \
+          --data "{
+              \"tag_name\":\"v${version}\",
+              \"target_commitish\":\"${{ github.ref }}\",
+              \"name\":\"v${version}\",
+              \"draft\":false,
+              \"prerelease\":false,
+              \"generate_release_notes\":false
+            }"
     - name: Publish
       run: cargo publish --no-verify --token "${CARGO_REGISTRY_TOKEN}"
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.2.0-alpha.1
+-------------
 - Removed no longer necessary `base_address` member from various types
 - Fixed incorrect allocation size calculation in C API
 - Fixed file offset lookup potentially reporting subtly wrong offsets on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym"
 description = "blazesym is a library that can be used for address symbolization and more."
-version = "0.2.0-alpha.0"
+version = "0.2.0-alpha.1"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "0.2.0-alpha.0"
+blazesym = "0.2.0-alpha.1"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).


### PR DESCRIPTION
This change bumps the version of the crate to 0.2.0-alpha.1. As part of the bump, add logic for creating a GitHub release to the publish workflow.