### PR TITLE
Invoke `cargo-llvm-cov` with `--all-targets`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Test and gather coverage
-      run: cargo llvm-cov --lcov --output-path lcov.info
+      run: cargo llvm-cov --all-targets --lcov --output-path lcov.info
     - name: Upload code coverage results
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
Make sure to invoke `cargo-llvm-cov` with the `--all-targets` option to collect code coverage on all eligible targets. Doing so seems to include the running of benchmarks (in "test mode"), which has the potential to bump our coverage numbers, in addition to simply being the right thing to do (tm).