### PR TITLE
Fix some confusion in C API documentation

### DIFF
--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -464,10 +464,12 @@ struct blaze_normalized_user_addrs *blaze_normalize_user_addrs_sorted(const stru
                                                                       uint32_t pid);
 
 /**
- * Free an object as returned by [`blaze_normalized_user_addrs`].
+ * Free an object as returned by [`blaze_normalized_user_addrs`] or
+ * [`blaze_normalize_user_addrs_sorted`].
  *
  * # Safety
  * The provided object should have been created by
+ * [`blaze_normalized_user_addrs`] or
  * [`blaze_normalize_user_addrs_sorted`].
  */
 void blaze_user_addrs_free(struct blaze_normalized_user_addrs *addrs);

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -339,10 +339,12 @@ pub unsafe extern "C" fn blaze_normalize_user_addrs_sorted(
     }
 }
 
-/// Free an object as returned by [`blaze_normalized_user_addrs`].
+/// Free an object as returned by [`blaze_normalized_user_addrs`] or
+/// [`blaze_normalize_user_addrs_sorted`].
 ///
 /// # Safety
 /// The provided object should have been created by
+/// [`blaze_normalized_user_addrs`] or
 /// [`blaze_normalize_user_addrs_sorted`].
 #[no_mangle]
 pub unsafe extern "C" fn blaze_user_addrs_free(addrs: *mut blaze_normalized_user_addrs) {


### PR DESCRIPTION
The documentation for the `blaze_user_addrs_free` function states that addresses should have been allocated by `blaze_normalized_user_addrs`, but then mentions that for safety they should come from `blaze_normalize_user_addrs_sorted`.
Mention both functions in both contexts for completeness and to avoid unnecessary confusion.