### PR TITLE
Stop using Git LFS for large benchmark files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /data/*.so
 /data/*.zip
 /data/kallsyms
-/data/vmlinux-5.17.12-100.fc34.x86_64
+/data/vmlinux-5.17.12-100.fc34.x86_64*
 /data/zip-dir
 /target
 Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Unreleased
 - Added unused member variable to `blaze_user_addr_meta_unknown` type for
   compliance with C standard, stating undefined behavior for empty structs
 - Changed `blaze_inspect_elf_src::path` type to `*const _`
+- Switched away from using Git LFS for large benchmark files towards
+  on-demand downloading from a different repository, controlled by
+  `generate-bench-files` feature
 
 
 0.2.0-alpha.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ generate-test-files = ["xz2", "zip"]
 # Enable this feature to opt in to the generation of benchmark files.
 # This feature is required for some of the benchmarks. Note that git-lfs
 # needs to be installed in this case.
-generate-bench-files = ["xz2"]
+generate-bench-files = ["reqwest", "xz2"]
 # Disable generation of test files. This feature takes preference over
 # `generate-test-files`.
 dont-generate-test-files = []
@@ -73,6 +73,7 @@ test-log = "0.2"
 [build-dependencies]
 cbindgen = {version = "0.24", optional = true}
 libc = "0.2.137"
+reqwest = {version = "0.11.18", optional = true, features = ["blocking"]}
 xz2 = {version = "0.1.7", optional = true}
 which = {version = "4.4.0", optional = true}
 zip = {version = "0.6.4", optional = true, default-features = false}

--- a/data/vmlinux-5.17.12-100.fc34.x86_64.xz
+++ b/data/vmlinux-5.17.12-100.fc34.x86_64.xz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:63119a022c3b5362d45141df489aecf34f8d8552f707ddff53d78b64a69d8bda
-size 114369740


### PR DESCRIPTION
Git LFS turned out to be not exactly suitable for our intents and purposes. Most importantly, GitHub's LFS imposes a fixed, non-replenishable bandwidth limit (which includes downloads...) on the uploader. Second, because of the way it works, once installed on the system, by default downloading will happen as part of clone/checkout. Neither "qualities" are particularly appealing to us. With this change we move large binary blobs away from LFS and into a separate repository. Because GitHub has a 100 MiB file size limit, we split files accordingly. Our build script contains the logic for downloading all parts and piecing them back together. All of this is controlled by the generate-bench-files features, unchanged.