### PR TITLE
Create C++ compatible header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `extern "C"` guards in `blazesym.h` header for easy of use from C++ code
+
+
 0.2.0-alpha.1
 -------------
 - Removed no longer necessary `base_address` member from various types

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,6 +1,7 @@
 # See https://github.com/eqrion/cbindgen/blob/master/docs.md#cbindgentoml
 
 language = "C"
+cpp_compat = true
 include_guard = "__blazesym_h_"
 usize_is_size_t = true
 

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -352,6 +352,10 @@ typedef struct blaze_symbolize_src_gsym {
   const char *path;
 } blaze_symbolize_src_gsym;
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 /**
  * Lookup symbol information in an ELF file.
  *
@@ -577,5 +581,9 @@ const struct blaze_result *blaze_symbolize_gsym(blaze_symbolizer *symbolizer,
  * variants.
  */
 void blaze_result_free(const struct blaze_result *results);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #endif /* __blazesym_h_ */


### PR DESCRIPTION
C++ code is free to use blazesym.h, but currently they need the "usual" `extern "C"` block around the include.
Instruct bindgen to take care of that transparently as part of the header generation, to lift this burden of all C++ users.