### PR TITLE
Add unused member to blaze_user_addr_meta_unknown struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Added `extern "C"` guards in `blazesym.h` header for easy of use from C++ code
+- Added unused member variable to `blaze_user_addr_meta_unknown` type for
+  compliance with C standard, stating undefined behavior for empty structs
 
 
 0.2.0-alpha.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default = ["lru"]
 # up-to-date version of this header should already be available in the
 # include/ directory, so this feature is only necessary when APIs are
 # changed.
-generate-c-header = ["cbindgen"]
+generate-c-header = ["cbindgen", "which"]
 # Enable this feature to opt in to the generation of test files. Having test
 # files created is necessary for running tests.
 generate-test-files = ["xz2", "zip"]
@@ -74,4 +74,5 @@ test-log = "0.2"
 cbindgen = {version = "0.24", optional = true}
 libc = "0.2.137"
 xz2 = {version = "0.1.7", optional = true}
+which = {version = "4.4.0", optional = true}
 zip = {version = "0.6.4", optional = true, default-features = false}

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -117,7 +117,7 @@ typedef struct blaze_user_addr_meta_binary {
  * C compatible version of [`Unknown`].
  */
 typedef struct blaze_user_addr_meta_unknown {
-
+  uint8_t __unused;
 } blaze_user_addr_meta_unknown;
 
 /**

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -147,20 +147,22 @@ impl From<blaze_user_addr_meta_binary> for Binary {
 /// C compatible version of [`Unknown`].
 #[repr(C)]
 #[derive(Debug)]
-pub struct blaze_user_addr_meta_unknown {}
+pub struct blaze_user_addr_meta_unknown {
+    __unused: u8,
+}
 
 impl From<Unknown> for blaze_user_addr_meta_unknown {
     fn from(other: Unknown) -> Self {
         let Unknown {
             _non_exhaustive: (),
         } = other;
-        Self {}
+        Self { __unused: 0 }
     }
 }
 
 impl From<blaze_user_addr_meta_unknown> for Unknown {
     fn from(other: blaze_user_addr_meta_unknown) -> Self {
-        let blaze_user_addr_meta_unknown {} = other;
+        let blaze_user_addr_meta_unknown { __unused } = other;
         Unknown {
             _non_exhaustive: (),
         }
@@ -408,7 +410,7 @@ mod tests {
     /// [`blaze_user_addr_meta_variant`].
     #[test]
     fn debug_meta_variant() {
-        let unknown = blaze_user_addr_meta_unknown {};
+        let unknown = blaze_user_addr_meta_unknown { __unused: 0 };
         let variant = blaze_user_addr_meta_variant {
             unknown: ManuallyDrop::new(unknown),
         };


### PR DESCRIPTION
Apparently it is *illegal* to have an empty struct in C. gcc seems to fudge over that with a compiler specific hack [0]. Be that as it may, during integration into a C++ code base we noticed an error showing up:
  > empty struct has size 0 in C, size 1 in C++ [-Werror,-Wextern-c-compat]

While we cannot, for the love of it, reproduce that problem in an isolated manner, make sure to add an unused member to the type in questions. Also compile a C++ program, not that it would have caught this issue, but it's probably better than nothing.

[0] https://gcc.gnu.org/onlinedocs/gcc/Empty-Structures.html