### PR TITLE
Make blaze_inspect_elf_src::path a *const _

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 - Added `extern "C"` guards in `blazesym.h` header for easy of use from C++ code
 - Added unused member variable to `blaze_user_addr_meta_unknown` type for
   compliance with C standard, stating undefined behavior for empty structs
+- Changed `blaze_inspect_elf_src::path` type to `*const _`
 
 
 0.2.0-alpha.1

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -87,7 +87,7 @@ typedef struct blaze_inspect_elf_src {
   /**
    * The path to the binary. This member is always present.
    */
-  char *path;
+  const char *path;
   /**
    * Whether or not to consult debug information to satisfy the request (if
    * present).

--- a/src/c_api/inspect.rs
+++ b/src/c_api/inspect.rs
@@ -33,7 +33,7 @@ use crate::Addr;
 #[derive(Debug)]
 pub struct blaze_inspect_elf_src {
     /// The path to the binary. This member is always present.
-    path: *mut c_char,
+    path: *const c_char,
     /// Whether or not to consult debug information to satisfy the request (if
     /// present).
     debug_info: bool,
@@ -61,7 +61,7 @@ impl From<blaze_inspect_elf_src> for Elf {
 
         Elf {
             path: PathBuf::from(OsString::from_vec(
-                unsafe { CString::from_raw(path) }.into_bytes(),
+                unsafe { CString::from_raw(path as *mut _) }.into_bytes(),
             )),
             debug_info,
             _non_exhaustive: (),


### PR DESCRIPTION
The blaze_inspect_elf_src::path member currently can be mutated by C code. That's not exactly the intention. Because it is mutable it also prevents legitimate assignments of a *const _.
The reason for it being mutable in the first place was mostly because that's what Rust APIs used in the implementation work with. However, we should not expose this property.
To that end, this change adjusts the type from *mut _ to *const _.