### PR TITLE
Fix NULL check condition for blaze_symbolize_src_kernel conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Added unused member variable to `blaze_user_addr_meta_unknown` type for
   compliance with C standard, stating undefined behavior for empty structs
 - Changed `blaze_inspect_elf_src::path` type to `*const _`
+- Fixed incorrect `NULL` checks when working with `blaze_symbolize_src_kernel`
+  objects
 - Switched away from using Git LFS for large benchmark files towards
   on-demand downloading from a different repository, controlled by
   `generate-bench-files` feature

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -38,7 +38,7 @@ impl From<Elf> for Source {
 
 
 /// Linux Kernel's binary image and a copy of /proc/kallsyms
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Kernel {
     /// The path of a kallsyms copy.
     ///


### PR DESCRIPTION
The `NULL` checks in the conversion from `&blaze_symbolize_src_kernel` to `Kernel` objects got the condition wrong, causing potential `NULL` pointer dereferences. Fix the issues.