### PR TITLE
Bump version to `0.2.0-alpha.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.2.0-alpha.2
+-------------
 - Added `extern "C"` guards in `blazesym.h` header for easy of use from C++ code
 - Added unused member variable to `blaze_user_addr_meta_unknown` type for
   compliance with C standard, stating undefined behavior for empty structs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym"
 description = "blazesym is a library that can be used for address symbolization and more."
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "0.2.0-alpha.1"
+blazesym = "0.2.0-alpha.2"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).


### PR DESCRIPTION
This change bumps the version of the crate to `0.2.0-alpha.2`.