### PR TITLE
Eliminate unnecessary rebuilds in build script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,29 @@ jobs:
     - name: Build ${{ matrix.profile }}
       run: |
         cargo build --profile=${{ matrix.profile }} ${{ matrix.args }} --lib
+  nop-rebuilds:
+    name: No-op rebuilds
+    runs-on: ubuntu-22.04
+    env:
+       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        override: true
+    - name: Install required tools
+      run: sudo apt-get install -y llvm-14
+    - name: Check incremental rebuilds
+      run: |
+        cargo check --features=generate-test-files --quiet --tests
+        # We need another build here to have the reference `output` file
+        # present. As long as we converge eventually it's probably good
+        # enough...
+        cargo check --features=generate-test-files --quiet --tests
+        output=$(CARGO_LOG=cargo::core::compiler::fingerprint=info cargo check --features=generate-test-files --quiet --tests 2>&1)
+        [ -z "${output}" ] || (echo "!!!! cargo check --tests rebuild was not a no-op: ${output} !!!!" && false)
   test-coverage:
     name: Test and coverage
     runs-on: ubuntu-22.04

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::let_unit_value)]
+
 use std::env;
 use std::ffi::OsStr;
 use std::ffi::OsString;
@@ -94,20 +96,54 @@ where
     }
 }
 
+fn adjust_mtime(path: &Path) -> Result<()> {
+    // Note that `OUT_DIR` is only present at runtime.
+    let out_dir = env::var("OUT_DIR").unwrap();
+    // The $OUT_DIR/output file is (in current versions of Cargo [as of
+    // 1.69]) the file containing the reference time stamp that Cargo
+    // checks to determine whether something is considered outdated and
+    // in need to be rebuild. It's an implementation detail, yes, but we
+    // don't rely on it for anything essential.
+    let output = Path::new(&out_dir)
+        .parent()
+        .ok_or_else(|| Error::new(ErrorKind::Other, "OUT_DIR has no parent"))?
+        .join("output");
+
+    if !output.exists() {
+        // The file may not exist for legitimate reasons, e.g., when we
+        // build for the very first time. If there is not reference there
+        // is nothing for us to do, so just bail.
+        return Ok(())
+    }
+
+    let () = run(
+        "touch",
+        [
+            "-m".as_ref(),
+            "--reference".as_ref(),
+            output.as_os_str(),
+            path.as_os_str(),
+        ],
+    )?;
+    Ok(())
+}
+
 /// Compile `src` into `dst` using the provided compiler.
 fn compile(compiler: &str, src: &Path, dst: &str, options: &[&str]) {
     let dst = src.with_file_name(dst);
     println!("cargo:rerun-if-changed={}", src.display());
     println!("cargo:rerun-if-changed={}", dst.display());
 
-    run(
+    let () = run(
         compiler,
         options
             .iter()
             .map(OsStr::new)
             .chain([src.as_os_str(), "-o".as_ref(), dst.as_os_str()]),
     )
-    .unwrap_or_else(|err| panic!("failed to run `{compiler}`: {err}"))
+    .unwrap_or_else(|err| panic!("failed to run `{compiler}`: {err}"));
+
+    let () = adjust_mtime(&dst).unwrap();
 }
 
 /// Compile `src` into `dst` using `cc`.
@@ -124,11 +160,13 @@ fn gsym(src: &Path, dst: impl AsRef<OsStr>) {
 
     let gsymutil = env::var_os("LLVM_GSYMUTIL").unwrap_or_else(|| OsString::from("llvm-gsymutil"));
 
-    run(
+    let () = run(
         gsymutil,
         ["--convert".as_ref(), src, "--out-file".as_ref(), &dst],
     )
-    .expect("failed to run `llvm-gsymutil`")
+    .expect("failed to run `llvm-gsymutil`");
+
+    let () = adjust_mtime(&dst).unwrap();
 }
 
 /// Strip all non-debug information from an ELF binary, in an attempt to
@@ -140,7 +178,9 @@ fn dwarf_mostly(src: &Path, dst: &str) {
 
     let _bytes = copy(src, &dst).expect("failed to copy file");
 
-    run("strip", ["--only-keep-debug".as_ref(), dst.as_os_str()]).expect("failed to run `strip`")
+    let () = run("strip", ["--only-keep-debug".as_ref(), dst.as_os_str()])
+        .expect("failed to run `strip`");
+    let () = adjust_mtime(&dst).unwrap();
 }
 
 /// Unpack an xz compressed file.
@@ -164,7 +204,8 @@ fn unpack_xz(src: &Path, dst: &Path) {
         .open(dst)
         .unwrap();
 
-    copy(&mut decoder, &mut dst_file).unwrap();
+    let _bytes = copy(&mut decoder, &mut dst_file).unwrap();
+    let () = adjust_mtime(dst).unwrap();
 }
 
 #[cfg(not(feature = "xz2"))]
@@ -183,37 +224,40 @@ fn zip(files: &[PathBuf], dst: &Path) {
     use zip::CompressionMethod;
     use zip::ZipWriter;
 
-    let dst_file = File::options()
-        .create(true)
-        .truncate(true)
-        .read(false)
-        .write(true)
-        .open(dst)
-        .unwrap();
-    let dst_dir = dst.parent().unwrap();
-
-    let page_size = page_size().unwrap();
-    let options = FileOptions::default().compression_method(CompressionMethod::Stored);
-    let mut zip = ZipWriter::new(dst_file);
-    for file in files {
-        let contents = read_file(file).unwrap();
-        let path = file.strip_prefix(dst_dir).unwrap();
-        // Ensure that members are page aligned so that they can be
-        // mmap'ed directly.
-        let _align = zip
-            .start_file_aligned(
-                path.to_str().unwrap(),
-                options,
-                page_size.try_into().unwrap(),
-            )
+    {
+        let dst_file = File::options()
+            .create(true)
+            .truncate(true)
+            .read(false)
+            .write(true)
+            .open(dst)
             .unwrap();
-        let _count = zip.write(&contents).unwrap();
+        let dst_dir = dst.parent().unwrap();
+
+        let page_size = page_size().unwrap();
+        let options = FileOptions::default().compression_method(CompressionMethod::Stored);
+        let mut zip = ZipWriter::new(dst_file);
+        for file in files {
+            let contents = read_file(file).unwrap();
+            let path = file.strip_prefix(dst_dir).unwrap();
+            // Ensure that members are page aligned so that they can be
+            // mmap'ed directly.
+            let _align = zip
+                .start_file_aligned(
+                    path.to_str().unwrap(),
+                    options,
+                    page_size.try_into().unwrap(),
+                )
+                .unwrap();
+            let _count = zip.write(&contents).unwrap();
+        }
     }
 
     for file in files {
         println!("cargo:rerun-if-changed={}", file.display());
     }
     println!("cargo:rerun-if-changed={}", dst.display());
+    let () = adjust_mtime(dst).unwrap();
 }
 
 #[cfg(not(feature = "zip"))]


### PR DESCRIPTION
Our various test and benchmark artifacts are created repeatedly on every build. While not a noticeable slowdown at this point, it's unnecessary work and, over time, the cause of wear for SSDs, for example.

The problem seems to be that the generated files' mtimes are after those of Cargo's output file that they are compared against to determine staleness. This behavior is counter-intuitive: it is the build script that emits those outputs to stdout while also generating those files. Hence, the build script's outputs can only be available completely after said script has run (that is, after the files have been generated as well). Alas, this behavior seems to be fully intentional from the Cargo side [0].

With this change we work around this problem, by adjusting generated files' time stamps to those of said output file after generation. It's not perfect (the output file is more or less an implementation detail and could potentially change at some point; also, because we rely on the existence of this output file we need two builds before the mtimes are correct), but should be good enough. We also add a CI job that makes checks that we don't re-generate files for the default generate-test-files feature.

[0] https://github.com/rust-lang/cargo/blob/4a60ff78a5f03e7c9ed2399754efb62c80a8ecc8/src/cargo/core/compiler/fingerprint/mod.rs?L249#L249-L256

Fixes: #91