### PR TITLE
Remove `cond` argument from debug_info_parse_symbols() function

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -133,7 +133,7 @@ impl DwarfResolver {
             if dis_ref.is_some() {
                 return Ok(())
             }
-            let mut debug_info_syms = debug_info_parse_symbols(&self.parser, None)?;
+            let mut debug_info_syms = debug_info_parse_symbols(&self.parser)?;
             debug_info_syms.sort_by_key(|v: &DWSymInfo| -> &str { v.name });
             *dis_ref = Some(unsafe { mem::transmute(debug_info_syms) });
             Ok(())


### PR DESCRIPTION
The `cond` argument to the debug_info_parse_symbols() function is always `None`. Remove it.