### PR TITLE
Make DWARF support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ name = "blazesym"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [features]
-default = ["lru"]
+default = ["dwarf", "lru"]
+# Enable this feature to enable DWARF support.
+dwarf = []
 # Enable this feature to re-generate the library's C header file. An
 # up-to-date version of this header should already be available in the
 # include/ directory, so this feature is only necessary when APIs are

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -1,5 +1,7 @@
+#[cfg_attr(not(feature = "dwarf"), allow(unused_variables))]
 mod cache;
 mod parser;
+#[cfg_attr(not(feature = "dwarf"), allow(unused_variables))]
 mod resolver;
 #[allow(dead_code, non_camel_case_types)]
 pub(crate) mod types;

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -1,6 +1,7 @@
 use std::io::Result;
 use std::rc::Rc;
 
+#[cfg(feature = "dwarf")]
 use crate::dwarf::DwarfResolver;
 use crate::elf::ElfBackend;
 use crate::elf::ElfParser;
@@ -45,6 +46,7 @@ impl Inspector {
                 debug_info,
                 _non_exhaustive: (),
             }) => {
+                #[cfg(feature = "dwarf")]
                 let backend = if *debug_info {
                     let debug_line_info = true;
                     let debug_info_symbols = true;
@@ -52,6 +54,13 @@ impl Inspector {
                     let backend = ElfBackend::Dwarf(Rc::new(dwarf));
                     backend
                 } else {
+                    let elf = ElfParser::open(path)?;
+                    let backend = ElfBackend::Elf(Rc::new(elf));
+                    backend
+                };
+
+                #[cfg(not(feature = "dwarf"))]
+                let backend = {
                     let elf = ElfParser::open(path)?;
                     let backend = ElfBackend::Elf(Rc::new(elf));
                     backend

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -14,6 +14,7 @@
 //! // There probably will only be a single one.
 //! ```
 
+#[cfg_attr(not(feature = "dwarf"), allow(unused_variables))]
 mod inspector;
 mod source;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 extern crate test;
 
 pub mod c_api;
+#[cfg(feature = "dwarf")]
 mod dwarf;
 mod elf;
 mod gsym;


### PR DESCRIPTION
With upcoming changes we will use gimli for providing DWARF support, instead of hand rolling DWARF parsing and state machine handling. Some users may not need such support and/or don't want this additional dependency.
Hence, make it optional by introducing the (default enabled) `dwarf` feature.