### PR TITLE
Bench with debug information present

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ nightly = []
 name = "main"
 harness = false
 
+[profile.bench]
+debug = true
+
 [dependencies]
 libc = "0.2.137"
 log = {version = "0.4.17", optional = true}


### PR DESCRIPTION
The debug_info_parse_single_threaded() benchmark requires debug information to be present in the benchmark binary or it won't do much. Make sure to enable it.