### PR TITLE
Rename find_match_or_lower_bound_by to find_match_or_lower_bound_by_key

### DIFF
--- a/src/dwarf/parser.rs
+++ b/src/dwarf/parser.rs
@@ -32,7 +32,7 @@ use crate::util::decode_leb128_s;
 use crate::util::decode_udword;
 use crate::util::decode_uhalf;
 use crate::util::decode_uword;
-use crate::util::find_match_or_lower_bound_by;
+use crate::util::find_match_or_lower_bound_by_key;
 use crate::util::Pod;
 use crate::util::ReadRaw as _;
 use crate::Addr;
@@ -124,7 +124,7 @@ pub(crate) struct DebugLineCU {
 
 impl DebugLineCU {
     pub(crate) fn find_line(&self, addr: Addr) -> Option<(&Path, &OsStr, usize)> {
-        let idx = find_match_or_lower_bound_by(&self.matrix, addr, |dls| dls.addr)?;
+        let idx = find_match_or_lower_bound_by_key(&self.matrix, addr, |dls| dls.addr)?;
         let states = &self.matrix[idx];
         if states.end_sequence {
             // This is the first byte after the last instruction

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -13,7 +13,7 @@ use crate::elf::ElfParser;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::inspect::SymType;
-use crate::util::find_match_or_lower_bound_by;
+use crate::util::find_match_or_lower_bound_by_key;
 use crate::Addr;
 
 use super::parser::debug_info_parse_symbols;
@@ -108,7 +108,7 @@ impl DwarfResolver {
 
     fn find_dlcu_index(&self, addr: Addr) -> Option<usize> {
         let a2a = &self.addr_to_dlcu;
-        let a2a_idx = find_match_or_lower_bound_by(a2a, addr, |a2dlcu| a2dlcu.0)?;
+        let a2a_idx = find_match_or_lower_bound_by_key(a2a, addr, |a2dlcu| a2dlcu.0)?;
         let dlcu_idx = a2a[a2a_idx].1 as usize;
 
         Some(dlcu_idx)

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -13,7 +13,7 @@ use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::inspect::SymType;
 use crate::mmap::Mmap;
-use crate::util::find_match_or_lower_bound_by;
+use crate::util::find_match_or_lower_bound_by_key;
 use crate::util::search_address_opt_key;
 use crate::util::ReadRaw as _;
 use crate::Addr;
@@ -446,7 +446,7 @@ impl ElfParser {
         //         `str2symtab` available.
         let str2symtab = cache.str2symtab.as_ref().unwrap();
 
-        let r = find_match_or_lower_bound_by(str2symtab, name, |&(name, _i)| name);
+        let r = find_match_or_lower_bound_by_key(str2symtab, name, |&(name, _i)| name);
         match r {
             Some(idx) => {
                 let mut found = vec![];

--- a/src/util.rs
+++ b/src/util.rs
@@ -91,7 +91,11 @@ pub(crate) fn uname_release() -> Result<CString> {
 
 /// See `find_match_or_lower_bound`, but allow the user to pass in a comparison
 /// function for increased flexibility.
-pub(crate) fn find_match_or_lower_bound_by<T, U, F>(slice: &[T], item: U, mut f: F) -> Option<usize>
+pub(crate) fn find_match_or_lower_bound_by_key<T, U, F>(
+    slice: &[T],
+    item: U,
+    mut f: F,
+) -> Option<usize>
 where
     U: Ord,
     F: FnMut(&T) -> U,
@@ -135,7 +139,7 @@ pub(crate) fn find_match_or_lower_bound<T>(slice: &[T], item: T) -> Option<usize
 where
     T: Copy + Ord,
 {
-    find_match_or_lower_bound_by(slice, item, |e| *e)
+    find_match_or_lower_bound_by_key(slice, item, |e| *e)
 }
 
 


### PR DESCRIPTION
In the standard library, sort/find *_by functions generally accept a closure that returns an `Ordering` (e.g., [0]). That's not the case for our `find_match_or_lower_bound_by`. Rather, it better mimics the signature of *_by_key variants. Rename it accordingly.

[0] https://doc.rust-lang.org/std/primitive.slice.html#method.binary_search_by