### PR TITLE
Rename SymResolver::find_symbols() to find_syms

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -404,7 +404,7 @@ impl ElfParser {
         Ok(index)
     }
 
-    pub fn find_symbol(&self, addr: Addr, st_type: u8) -> Result<(&str, Addr), Error> {
+    pub fn find_sym(&self, addr: Addr, st_type: u8) -> Result<(&str, Addr), Error> {
         let mut cache = self.cache.borrow_mut();
         let () = cache.ensure_symtab()?;
         // SANITY: The above `ensure_symtab` ensures we have `symtab`
@@ -547,7 +547,7 @@ mod tests {
 
         let (sym_name, addr) = parser.pick_symtab_addr();
 
-        let sym_r = parser.find_symbol(addr, STT_FUNC);
+        let sym_r = parser.find_sym(addr, STT_FUNC);
         assert!(sym_r.is_ok());
         let (sym_name_ret, addr_ret) = sym_r.unwrap();
         assert_eq!(addr_ret, addr);

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -52,7 +52,7 @@ impl SymResolver for ElfResolver {
     fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)> {
         let parser = self.get_parser();
 
-        match parser.find_symbol(addr, STT_FUNC) {
+        match parser.find_sym(addr, STT_FUNC) {
             Ok((name, start_addr)) => {
                 vec![(name, start_addr)]
             }

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -49,7 +49,7 @@ impl ElfResolver {
 }
 
 impl SymResolver for ElfResolver {
-    fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)> {
+    fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)> {
         let parser = self.get_parser();
 
         match parser.find_symbol(addr, STT_FUNC) {

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -48,7 +48,7 @@ impl GsymResolver {
 }
 
 impl SymResolver for GsymResolver {
-    fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)> {
+    fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)> {
         fn find_addr_impl(gsym: &GsymResolver, addr: Addr) -> Option<Vec<(&str, Addr)>> {
             let idx = gsym.ctx.find_addr(addr)?;
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -42,11 +42,11 @@ impl KernelResolver {
 }
 
 impl SymResolver for KernelResolver {
-    fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)> {
+    fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)> {
         if let Some(ksym_resolver) = self.ksym_resolver.as_ref() {
-            ksym_resolver.find_symbols(addr)
+            ksym_resolver.find_syms(addr)
         } else {
-            self.elf_resolver.as_ref().unwrap().find_symbols(addr)
+            self.elf_resolver.as_ref().unwrap().find_syms(addr)
         }
     }
 

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -126,7 +126,7 @@ impl KSymResolver {
 }
 
 impl SymResolver for KSymResolver {
-    fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)> {
+    fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)> {
         self.find_addresses_ksym(addr)
             .map(|sym| (sym.name.as_str(), sym.addr))
             .collect()
@@ -224,27 +224,27 @@ mod tests {
         let sym = &resolver.syms[resolver.syms.len() / 2];
         let addr = sym.addr;
         let name = sym.name.clone();
-        let found = resolver.find_symbols(addr);
+        let found = resolver.find_syms(addr);
         assert!(!found.is_empty());
         assert!(found.iter().any(|x| x.0 == name));
         let addr = addr + 1;
-        let found = resolver.find_symbols(addr);
+        let found = resolver.find_syms(addr);
         assert!(!found.is_empty());
         assert!(found.iter().any(|x| x.0 == name));
 
         // 0 is an invalid address.  We remove all symbols with 0 as
         // thier address from the list.
-        let found = resolver.find_symbols(0);
+        let found = resolver.find_syms(0);
         assert!(found.is_empty());
 
         // Find the address of the last symbol
         let sym = &resolver.syms.last().unwrap();
         let addr = sym.addr;
         let name = sym.name.clone();
-        let found = resolver.find_symbols(addr);
+        let found = resolver.find_syms(addr);
         assert!(!found.is_empty());
         assert!(found.iter().any(|x| x.0 == name));
-        let found = resolver.find_symbols(addr + 1);
+        let found = resolver.find_syms(addr + 1);
         assert!(!found.is_empty());
         assert!(found.iter().any(|x| x.0 == name));
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -17,7 +17,7 @@ where
 {
     /// Find the names and the start addresses of a symbol found for
     /// the given address.
-    fn find_symbols(&self, addr: Addr) -> Vec<(&str, Addr)>;
+    fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)>;
     /// Find the address and size of a symbol name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymInfo>>;
     /// Find the file name and the line number of an address.

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -139,7 +139,7 @@ impl Symbolizer {
         addr: Addr,
         resolver: &dyn SymResolver,
     ) -> Vec<SymbolizedResult> {
-        let res_syms = resolver.find_symbols(addr);
+        let res_syms = resolver.find_syms(addr);
         let linfo = if self.src_location {
             resolver.find_line_info(addr)
         } else {


### PR DESCRIPTION
Rename the `SymResolver::find_symbols()` method to `find_syms`, to be more in line with the naming established throughout the crate.