### PR TITLE
Adjust return type of ElfParser::find_sym()

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -53,8 +53,12 @@ impl SymResolver for ElfResolver {
         let parser = self.get_parser();
 
         match parser.find_sym(addr, STT_FUNC) {
-            Ok((name, start_addr)) => {
+            Ok(Some((name, start_addr))) => {
                 vec![(name, start_addr)]
+            }
+            Ok(None) => {
+                warn!("no symbol found for address 0x{addr:x}");
+                vec![]
             }
             Err(err) => {
                 warn!("no symbol found for address 0x{addr:x}: {err}");


### PR DESCRIPTION
Similar to what we did in commit cf14376d6796 ("Adjust return type of ElfParser::find_section()"), adjust the return value of `ElfParser::find_sym` to handle the symbol-not-found case via an `Option` instead of fudging everything with a true error.