### PR TITLE
Improve benchmark mechanics

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [target.x86_64-unknown-linux-gnu]
-runner = "sudo --preserve-env"
+runner = "sudo --preserve-env .cargo/runner.sh"

--- a/.cargo/runner.sh
+++ b/.cargo/runner.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Eliminate as much background work as possible by flushing caches that
+# could cause IO and with that background work that may disturb the system.
+sync
+echo 3 > /proc/sys/vm/drop_caches
+
+# Niceness adjustments are mostly done for benchmarking.
+nice --adjustment=-20 ionice --class=realtime "$@"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ harness = false
 
 [profile.bench]
 debug = true
+opt-level = 3
+lto = true
+codegen-units = 1
 
 [dependencies]
 libc = "0.2.137"

--- a/benches/inspect.rs
+++ b/benches/inspect.rs
@@ -1,3 +1,4 @@
+use std::hint::black_box;
 use std::path::Path;
 
 use blazesym::inspect;
@@ -17,7 +18,7 @@ fn lookup_dwarf() {
 
     let inspector = Inspector::new();
     let results = inspector
-        .lookup(&["abort_creds"], &src)
+        .lookup(black_box(&["abort_creds"]), black_box(&src))
         .unwrap()
         .into_iter()
         .flatten()

--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -1,3 +1,5 @@
+use std::hint::black_box;
+
 use blazesym::c_api;
 use blazesym::normalize::Normalizer;
 use blazesym::Addr;
@@ -19,7 +21,7 @@ fn normalize_process() {
 
     let normalizer = Normalizer::new();
     let norm_addrs = normalizer
-        .normalize_user_addrs_sorted(addrs.as_slice(), 0.into())
+        .normalize_user_addrs_sorted(black_box(addrs.as_slice()), black_box(0.into()))
         .unwrap();
     assert_eq!(norm_addrs.addrs.len(), 5);
 }

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -1,3 +1,4 @@
+use std::hint::black_box;
 use std::path::Path;
 
 use blazesym::c_api;
@@ -25,7 +26,9 @@ fn symbolize_process() {
     ];
 
     let symbolizer = Symbolizer::new();
-    let results = symbolizer.symbolize(&src, &addrs).unwrap();
+    let results = symbolizer
+        .symbolize(black_box(&src), black_box(&addrs))
+        .unwrap();
     assert_eq!(results.len(), addrs.len());
 }
 
@@ -39,7 +42,7 @@ fn symbolize_dwarf() {
     let symbolizer = Symbolizer::new();
 
     let results = symbolizer
-        .symbolize(&src, &[0xffffffff8110ecb0])
+        .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
         .unwrap()
         .into_iter()
         .flatten()
@@ -60,7 +63,7 @@ fn symbolize_gsym() {
     let symbolizer = Symbolizer::new();
 
     let results = symbolizer
-        .symbolize(&src, &[0xffffffff8110ecb0])
+        .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
         .unwrap()
         .into_iter()
         .flatten()

--- a/src/dwarf/parser.rs
+++ b/src/dwarf/parser.rs
@@ -898,6 +898,9 @@ pub(crate) fn debug_info_parse_symbols(parser: &ElfParser) -> Result<Vec<DWSymIn
 mod tests {
     use super::*;
 
+    #[cfg(feature = "nightly")]
+    use std::hint::black_box;
+
     use test_log::test;
 
     #[cfg(feature = "nightly")]
@@ -1053,6 +1056,6 @@ mod tests {
         let bin_name = env::args().next().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
 
-        let () = b.iter(|| debug_info_parse_symbols(&parser).unwrap());
+        let () = b.iter(|| debug_info_parse_symbols(black_box(&parser)).unwrap());
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -700,9 +700,9 @@ mod tests {
         assert_eq!(slice.read_cstr(), None);
     }
 
-    /// Test that we correctly binary search for a lower bound.
+    /// Test that we correctly binary search for a lowest match.
     #[test]
-    fn search_lower_bound() {
+    fn search_lowest_match() {
         fn test(f: impl Fn(&[u16], &u16) -> Option<usize>) {
             let data = [];
             assert_eq!(f(&data, &0), None);


### PR DESCRIPTION
Improve benchmarking mechanics a bit by:
1) compiling with LTO enabled and -O3
2) increasing niceness values of benchmarks
3) flushing system caches before running
4) make sure to use std::hint::black_box in the hope that it prevents
   too many optimizations specific to the benchmark and not generally
   applicable

Note that 2) & 3) require root, but we already require that anyway, so there is no impact.