### PR TITLE
Rename data/test.gsym -> test-stable-addresses.gsym

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -338,7 +338,7 @@ fn prepare_test_files(crate_root: &Path) {
     );
 
     let src = crate_root.join("data").join("test-stable-addresses.bin");
-    gsym(&src, "test.gsym");
+    gsym(&src, "test-stable-addresses.gsym");
     dwarf_mostly(&src, "test-dwarf.bin");
     dwarf_only(&src, "test-dwarf-only.bin");
 

--- a/data/test-stable-addresses.c
+++ b/data/test-stable-addresses.c
@@ -1,4 +1,4 @@
-/* The sample program is used to generate test.gsym.
+/* The sample program is used to generate test-stable-addresses*.
  *
  * Chosen functions are placed in dedicated sections to allow for control placement.
  */

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -294,7 +294,7 @@ mod tests {
     fn test_parse_context() {
         let test_gsym = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test.gsym");
+            .join("test-stable-addresses.gsym");
         let mut gsym_fo = File::open(test_gsym).unwrap();
         let mut data = vec![];
 
@@ -314,7 +314,7 @@ mod tests {
     fn test_find_addr() {
         let test_gsym = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test.gsym");
+            .join("test-stable-addresses.gsym");
         let mut gsym_fo = File::open(test_gsym).unwrap();
         let mut data = vec![];
 

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -177,7 +177,7 @@ mod tests {
     fn test_find_line_info() {
         let test_gsym = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test.gsym");
+            .join("test-stable-addresses.gsym");
         let resolver = GsymResolver::new(test_gsym).unwrap();
 
         // `main` resides at address 0x2000000, and it's located at the given

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -53,7 +53,7 @@ fn find_function_size(name: &str, elf: &Path) -> usize {
 fn symbolize_gsym() {
     let test_gsym = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("test.gsym");
+        .join("test-stable-addresses.gsym");
 
     let src = symbolize::Source::Gsym(symbolize::Gsym::new(test_gsym));
     let symbolizer = Symbolizer::new();

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -94,7 +94,7 @@ fn symbolize_from_elf() {
 fn symbolize_from_gsym() {
     let test_gsym = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("test.gsym");
+        .join("test-stable-addresses.gsym");
     let test_gsym_c = CString::new(test_gsym.to_str().unwrap()).unwrap();
     let gsym_src = blaze_symbolize_src_gsym {
         path: test_gsym_c.as_ptr(),


### PR DESCRIPTION
This change renames the `data/test.gsym` file to
`test-stable-addresses.gsym`, which is a tad more expressive.