### PR TITLE
Rename more test files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -339,8 +339,8 @@ fn prepare_test_files(crate_root: &Path) {
 
     let src = crate_root.join("data").join("test-stable-addresses.bin");
     gsym(&src, "test-stable-addresses.gsym");
-    dwarf_mostly(&src, "test-dwarf.bin");
-    dwarf_only(&src, "test-dwarf-only.bin");
+    dwarf_mostly(&src, "test-stable-addresses-dwarf.bin");
+    dwarf_only(&src, "test-stable-addresses-dwarf-only.bin");
 
     let src = crate_root.join("data").join("kallsyms.xz");
     let mut dst = src.clone();
@@ -365,7 +365,9 @@ fn prepare_test_files(crate_root: &Path) {
     .unwrap();
 
     let files = [
-        crate_root.join("data").join("test-dwarf.bin"),
+        crate_root
+            .join("data")
+            .join("test-stable-addresses-dwarf.bin"),
         crate_root
             .join("data")
             .join("zip-dir")

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -284,7 +284,7 @@ mod tests {
     fn lookup_symbol() {
         let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test-dwarf.bin");
+            .join("test-stable-addresses-dwarf.bin");
         let opts = FindAddrOpts {
             offset_in_file: false,
             obj_file_name: false,
@@ -305,7 +305,7 @@ mod tests {
     fn lookup_symbol_wrong_type() {
         let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test-dwarf.bin");
+            .join("test-stable-addresses-dwarf.bin");
         let opts = FindAddrOpts {
             offset_in_file: false,
             obj_file_name: false,

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -573,7 +573,7 @@ mod tests {
     fn lookup_symbol() {
         let bin_name = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test-dwarf.bin");
+            .join("test-stable-addresses-no-dwarf.bin");
 
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let opts = FindAddrOpts::default();

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -144,7 +144,7 @@ mod tests {
     fn addr_without_offset() {
         let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test-dwarf.bin");
+            .join("test-stable-addresses-no-dwarf.bin");
         let elf = ElfParser::open(&path).unwrap();
         let backend = ElfBackend::Elf(Rc::new(elf));
         let resolver = ElfResolver::with_backend(&path, backend).unwrap();

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -95,7 +95,7 @@ fn symbolize_gsym() {
 fn symbolize_dwarf() {
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("test-dwarf.bin");
+        .join("test-stable-addresses-dwarf.bin");
     let src = symbolize::Source::Elf(symbolize::Elf::new(&test_dwarf));
     let symbolizer = Symbolizer::new();
     let results = symbolizer
@@ -222,13 +222,13 @@ fn inspect() {
 
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("test-dwarf.bin");
+        .join("test-stable-addresses-dwarf.bin");
     let src = inspect::Source::Elf(inspect::Elf::new(test_dwarf));
     let () = test(src);
 
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("test-dwarf-only.bin");
+        .join("test-stable-addresses-dwarf-only.bin");
     let src = inspect::Source::Elf(inspect::Elf::new(test_dwarf));
     let () = test(src);
 

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -58,7 +58,7 @@ fn symbolizer_creation_with_opts() {
 fn symbolize_from_elf() {
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("test-dwarf.bin");
+        .join("test-stable-addresses-no-dwarf.bin");
     let test_dwarf_c = CString::new(test_dwarf.to_str().unwrap()).unwrap();
 
     let elf_src = blaze_symbolize_src_elf {
@@ -233,7 +233,7 @@ fn inspector_creation() {
 fn lookup_dwarf() {
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("test-dwarf.bin");
+        .join("test-stable-addresses-dwarf.bin");
 
     let src = blaze_inspect_elf_src::from(inspect::Elf::new(test_dwarf));
     let factorial = CString::new("factorial").unwrap();


### PR DESCRIPTION
Rename more test files to include "stable-addresses" in their name, if they are derived from the corresponding source code file. Also, use "no-dwarf" variants when testing ELF logic specifically.