### PR TITLE
Remove 'addresses' argument from various debug line information parsi…

### DIFF
--- a/src/elf/cache.rs
+++ b/src/elf/cache.rs
@@ -63,12 +63,9 @@ impl ElfCacheEntry {
         let parser = Rc::new(ElfParser::open_file(file)?);
 
         #[cfg(feature = "dwarf")]
-        let backend = if let Ok(dwarf) = DwarfResolver::from_parser_for_addresses(
-            Rc::clone(&parser),
-            &[],
-            line_number_info,
-            debug_info_symbols,
-        ) {
+        let backend = if let Ok(dwarf) =
+            DwarfResolver::from_parser(Rc::clone(&parser), line_number_info, debug_info_symbols)
+        {
             ElfBackend::Dwarf(Rc::new(dwarf))
         } else {
             ElfBackend::Elf(parser)


### PR DESCRIPTION
…ng functions

We don't have cases where we have a set of addresses ahead of time for which we then gather line information. Yet, logic for doing just that convolutes the source code and adds complexity. Remove it.