### PR TITLE
Migrate from `log` to `tracing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ debug = true
 libc = "0.2.137"
 gimli = {version = "0.27.2", optional = true}
 log = {version = "0.4.17", optional = true}
+tracing = {version = "0.1", default-features = false,optional = true}
 lru = {version = "0.10", optional = true}
 
 [dev-dependencies]
@@ -73,8 +74,9 @@ anyhow = "1.0.71"
 blazesym = {path = ".", features = ["generate-test-files", "log"]}
 criterion = "0.4"
 env_logger = "0.10"
+tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
+test-log = {version = "0.2", features = ["tracing"]}
 tempfile = "3.4"
-test-log = "0.2"
 
 [build-dependencies]
 cbindgen = {version = "0.24", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ debug = true
 libc = "0.2.137"
 gimli = {version = "0.27.2", optional = true}
 # log = {version = "0.4.17", optional = true}
-tracing = {version = "0.1", default-features = false,optional = true}
+tracing = {version = "0.1", default-features = false,features = ["attributes"],optional = true}
 lru = {version = "0.10", optional = true}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,17 +65,17 @@ debug = true
 [dependencies]
 libc = "0.2.137"
 gimli = {version = "0.27.2", optional = true}
-log = {version = "0.4.17", optional = true}
+# log = {version = "0.4.17", optional = true}
 tracing = {version = "0.1", default-features = false,optional = true}
 lru = {version = "0.10", optional = true}
 
 [dev-dependencies]
 anyhow = "1.0.71"
-blazesym = {path = ".", features = ["generate-test-files", "log"]}
+blazesym = {path = ".", features = ["generate-test-files", "tracing"]}
 criterion = "0.4"
 env_logger = "0.10"
 tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
-test-log = {version = "0.2", features = ["tracing"]}
+test-log = "0.2"
 tempfile = "3.4"
 
 [build-dependencies]

--- a/src/c_api/inspect.rs
+++ b/src/c_api/inspect.rs
@@ -21,7 +21,7 @@ use crate::inspect::Inspector;
 use crate::inspect::Source;
 use crate::inspect::SymInfo;
 use crate::inspect::SymType;
-use crate::log::error;
+use crate::tracing::error;
 use crate::util::slice_from_user_array;
 use crate::Addr;
 

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::ptr;
 use std::slice;
 
-use crate::log::error;
+use crate::tracing::error;
 use crate::normalize::Binary;
 use crate::normalize::NormalizedUserAddrs;
 use crate::normalize::Normalizer;

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -11,8 +11,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::ptr;
 
-use crate::log::error;
-use crate::log::warn;
+use crate::tracing::error;
+use crate::tracing::warn;
 use crate::symbolize::Elf;
 use crate::symbolize::Gsym;
 use crate::symbolize::Kernel;

--- a/src/dwarf/parser.rs
+++ b/src/dwarf/parser.rs
@@ -26,7 +26,7 @@ use gimli::UnitSectionOffset;
 
 use crate::elf::ElfParser;
 use crate::inspect::SymType;
-use crate::log::warn;
+use crate::tracing::warn;
 use crate::util::decode_leb128;
 use crate::util::decode_leb128_s;
 use crate::util::decode_udword;

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
-use crate::log::warn;
+use crate::tracing::warn;
 use crate::symbolize::AddrLineInfo;
 use crate::Addr;
 use crate::SymResolver;

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -39,7 +39,7 @@ use std::io::Error;
 use std::io::ErrorKind;
 use std::mem::align_of;
 
-use crate::log::warn;
+use crate::tracing::warn;
 use crate::util::find_match_or_lower_bound;
 use crate::util::Pod;
 use crate::util::ReadRaw as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,21 +91,38 @@ impl From<u32> for Pid {
 }
 
 
-#[cfg(feature = "log")]
+#[cfg(feature = "tracing")]
 #[macro_use]
-mod log {
+mod tracing {
     #[allow(unused)]
-    pub(crate) use log::debug;
-    pub(crate) use log::error;
+    pub(crate) use tracing::debug;
+    pub(crate) use tracing::error;
     #[allow(unused)]
-    pub(crate) use log::info;
+    pub(crate) use tracing::info;
     #[allow(unused)]
-    pub(crate) use log::trace;
-    pub(crate) use log::warn;
+    pub(crate) use tracing::trace;
+    pub(crate) use tracing::warn;
+
+    #[allow(unused)]
+    pub(crate) use tracing::debug_span;
+
+    #[allow(unused)]
+    pub(crate) use tracing::error_span;
+
+    #[allow(unused)]
+    pub(crate) use tracing::info_span;
+
+    #[allow(unused)]
+    pub(crate) use tracing::trace_span;
+
+    #[allow(unused)]
+    pub(crate) use tracing::warn_span;
 }
-#[cfg(not(feature = "log"))]
+
+
+#[cfg(not(feature = "tracing"))]
 #[macro_use]
-mod log {
+mod tracing {
     macro_rules! debug {
         ($($args:tt)*) => {{
           if false {

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use crate::elf;
 use crate::elf::types::Elf64_Nhdr;
 use crate::elf::ElfParser;
-use crate::log::warn;
+use crate::tracing::warn;
 use crate::maps;
 use crate::maps::PathMapsEntry;
 use crate::util;

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -9,7 +9,7 @@ use crate::gsym::GsymResolver;
 use crate::kernel::KernelResolver;
 use crate::ksym::KSymCache;
 use crate::ksym::KALLSYMS;
-use crate::log;
+use crate::tracing;
 use crate::maps;
 use crate::maps::PathMapsEntry;
 use crate::normalize;
@@ -262,7 +262,7 @@ impl Symbolizer {
             match result {
                 Ok(resolver) => Some(resolver),
                 Err(err) => {
-                    log::warn!(
+                    tracing::warn!(
                         "failed to load kallsyms from {}: {err}; ignoring...",
                         kallsyms.display()
                     );
@@ -292,13 +292,13 @@ impl Symbolizer {
                         match result {
                             Ok(resolver) => Some(resolver),
                             Err(err) => {
-                                log::warn!("failed to create ELF resolver for kernel image {}: {err}; ignoring...", image.display());
+                                tracing::warn!("failed to create ELF resolver for kernel image {}: {err}; ignoring...", image.display());
                                 None
                             }
                         }
                     }
                     Err(err) => {
-                        log::warn!(
+                        tracing::warn!(
                             "failed to load kernel image {}: {err}; ignoring...",
                             image.display()
                         );


### PR DESCRIPTION
# Changes

- add `tracing-subscriber` to support tracing in `log-test` 
- add `tracing` with attributes feature
- change log mod to tracing with re exports
- replace all log references to tracing

# Todo

- [ ] add instrument macro to relevant call sites
- [ ] mock the macro when `tracing` is not in use