### PR TITLE
Adjust SymResolver::find_line_info() to return Result

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -86,22 +86,24 @@ impl SymResolver for ElfResolver {
     }
 
     #[cfg(feature = "dwarf")]
-    fn find_line_info(&self, addr: Addr) -> Option<AddrLineInfo> {
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>> {
         if let ElfBackend::Dwarf(dwarf) = &self.backend {
-            let (directory, file, line) = dwarf.find_line(addr)?;
-            Some(AddrLineInfo {
-                path: directory.join(file),
-                line,
-                column: 0,
-            })
+            let addr_line_info = dwarf
+                .find_line(addr)?
+                .map(|(dir, file, line)| AddrLineInfo {
+                    path: dir.join(file),
+                    line,
+                    column: 0,
+                });
+            Ok(addr_line_info)
         } else {
-            None
+            Ok(None)
         }
     }
 
     #[cfg(not(feature = "dwarf"))]
-    fn find_line_info(&self, addr: Addr) -> Option<AddrLineInfo> {
-        None
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>> {
+        Ok(None)
     }
 
     /// Find the file offset of the symbol at address `addr`.

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -54,10 +54,12 @@ impl SymResolver for KernelResolver {
         None
     }
 
-    fn find_line_info(&self, addr: Addr) -> Option<AddrLineInfo> {
-        self.elf_resolver
-            .as_ref()
-            .and_then(|resolver| resolver.find_line_info(addr))
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>> {
+        if let Some(resolver) = self.elf_resolver.as_ref() {
+            resolver.find_line_info(addr)
+        } else {
+            Ok(None)
+        }
     }
 
     fn addr_file_off(&self, _addr: Addr) -> Option<u64> {

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -150,8 +150,8 @@ impl SymResolver for KSymResolver {
         })
     }
 
-    fn find_line_info(&self, _addr: Addr) -> Option<AddrLineInfo> {
-        None
+    fn find_line_info(&self, _addr: Addr) -> Result<Option<AddrLineInfo>> {
+        Ok(None)
     }
 
     fn addr_file_off(&self, _addr: Addr) -> Option<u64> {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::io::Error;
 use std::path::Path;
 
 use crate::inspect::FindAddrOpts;
@@ -21,7 +22,7 @@ where
     /// Find the address and size of a symbol name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymInfo>>;
     /// Find the file name and the line number of an address.
-    fn find_line_info(&self, addr: Addr) -> Option<AddrLineInfo>;
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>, Error>;
     /// Translate an address (virtual) in a process to the file offset
     /// in the object file.
     fn addr_file_off(&self, addr: Addr) -> Option<u64>;

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -141,7 +141,8 @@ impl Symbolizer {
     ) -> Vec<SymbolizedResult> {
         let res_syms = resolver.find_syms(addr);
         let linfo = if self.src_location {
-            resolver.find_line_info(addr)
+            // TODO: Should not swallow errors.
+            resolver.find_line_info(addr).unwrap_or_default()
         } else {
             None
         };


### PR DESCRIPTION
Finding of line information cannot possibly be an infallible operation. Adjust its signature accordingly.