### PR TITLE
Introduce Elf64_Sym::type_() helper

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -422,7 +422,7 @@ impl ElfParser {
             Some(idx) => symtab[idx..]
                 .iter()
                 .find_map(|sym| {
-                    if sym.st_shndx == SHN_UNDEF || sym.st_info & 0xf != st_type {
+                    if sym.st_shndx == SHN_UNDEF || sym.type_() != st_type {
                         return None
                     }
 
@@ -516,7 +516,7 @@ impl ElfParser {
         let symtab = cache.symtab.as_ref().unwrap();
 
         let mut idx = symtab.len() / 2;
-        while symtab[idx].st_info & 0xf != STT_FUNC || symtab[idx].st_shndx == SHN_UNDEF {
+        while symtab[idx].type_() != STT_FUNC || symtab[idx].st_shndx == SHN_UNDEF {
             idx += 1;
         }
         let sym = &symtab[idx];

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -84,6 +84,11 @@ pub(crate) struct Elf64_Sym {
 }
 
 impl Elf64_Sym {
+    /// Extract the symbols type, typically represented by a STT_* constant.
+    pub fn type_(&self) -> u8 {
+        self.st_info & 0xf
+    }
+
     /// Check whether this symbols contains the provided address.
     pub fn contains(&self, addr: Elf64_Addr) -> bool {
         (self.st_size == 0 && self.st_value == addr)


### PR DESCRIPTION
As per review comment [0], introduce and use a helper function for extracting an ELF symbol's type.

[0] https://github.com/libbpf/blazesym/pull/200#discussion_r1220102437,