### PR TITLE
Adjust SymResolver::find_addr() to return Result

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -66,22 +66,19 @@ impl SymResolver for ElfResolver {
         }
     }
 
-    // TODO: Need to better handle errors.
-    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymInfo>> {
+    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>> {
         let parser = self.get_parser();
-        let result = parser.find_addr(name, opts);
-        if let Ok(syms) = result {
-            if !syms.is_empty() {
-                // We found symbols in ELF and DWARF wouldn't add information on
-                // top. So just roll with that.
-                return Some(syms)
-            }
+        let syms = parser.find_addr(name, opts)?;
+        if !syms.is_empty() {
+            // We found symbols in ELF and DWARF wouldn't add information on
+            // top. So just roll with that.
+            return Ok(syms)
         }
 
         match &self.backend {
             #[cfg(feature = "dwarf")]
-            ElfBackend::Dwarf(dwarf) => dwarf.find_addr(name, opts).ok(),
-            ElfBackend::Elf(_) => Some(Vec::new()),
+            ElfBackend::Dwarf(dwarf) => dwarf.find_addr(name, opts),
+            ElfBackend::Elf(_) => Ok(Vec::new()),
         }
     }
 

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -66,10 +66,10 @@ impl SymResolver for GsymResolver {
         find_addr_impl(self, addr).unwrap_or_default()
     }
 
-    fn find_addr(&self, _name: &str, _opts: &FindAddrOpts) -> Option<Vec<SymInfo>> {
+    fn find_addr(&self, _name: &str, _opts: &FindAddrOpts) -> Result<Vec<SymInfo>, Error> {
         // It is inefficient to find the address of a symbol with
         // GSYM.  We may support it in the future if needed.
-        None
+        Ok(Vec::new())
     }
 
     /// Finds the source code location for a given address.

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -50,8 +50,8 @@ impl SymResolver for KernelResolver {
         }
     }
 
-    fn find_addr(&self, _name: &str, _opts: &FindAddrOpts) -> Option<Vec<SymInfo>> {
-        None
+    fn find_addr(&self, _name: &str, _opts: &FindAddrOpts) -> Result<Vec<SymInfo>> {
+        Ok(Vec::new())
     }
 
     fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>> {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -20,7 +20,7 @@ where
     /// the given address.
     fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)>;
     /// Find the address and size of a symbol name.
-    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Option<Vec<SymInfo>>;
+    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>, Error>;
     /// Find the file name and the line number of an address.
     fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>, Error>;
     /// Translate an address (virtual) in a process to the file offset


### PR DESCRIPTION
Finding of symbol information for an address cannot in general possibly be an infallible operation. Adjust its signature accordingly.