### PR TITLE
Un-ignore main KSymResolver test

### DIFF
--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -208,10 +208,8 @@ mod tests {
     use test_log::test;
 
 
-    // This test case is skipped by default for /proc/kallsyms may
-    // not available in some environment.
+    /// Check that we can use a `KSymResolver` to find symbols.
     #[test]
-    #[ignore = "system-dependent; may fail"]
     fn ksym_resolver_load_find() {
         let resolver = KSymResolver::load_file_name(PathBuf::from(KALLSYMS)).unwrap();
 


### PR DESCRIPTION
The `/proc/kallsyms` virtual file is commonly available. However, depending on kernel configuration all symbols may be reported as `0` for regular users.
Starting with commit 327f2884205d ("Use /proc/[pid]/map_files") we run our tests as root, so this should no longer a limitation that affects us. Hence, enable the main `KSymResolver` test again.