### PR TITLE
Rename Binary meta data variant to Elf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 - Added support for using DWARF information for symbol lookup (instead of just
   ELF symbols; so far DWARF was only used for mapping names to symbol
   information)
+- Renamed `normalize::UserAddrMeta::Binary` variant to `Elf`
 
 
 0.2.0-alpha.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 - Added support for using DWARF information for symbol lookup (instead of just
   ELF symbols; so far DWARF was only used for mapping names to symbol
   information)
+- Added support for normalizing addresses in an ELF file contained in an APK
 - Renamed `normalize::UserAddrMeta::Binary` variant to `Elf`
 
 

--- a/build.rs
+++ b/build.rs
@@ -366,6 +366,9 @@ fn prepare_test_files(crate_root: &Path) {
             .join("zip-dir")
             .join("test-no-debug.bin"),
         crate_root.join("data").join("libtest-so.so"),
+        crate_root
+            .join("data")
+            .join("libtest-so-no-separate-code.so"),
     ];
     let dst = crate_root.join("data").join("test.zip");
     zip(files.as_slice(), &dst);

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -35,6 +35,10 @@ typedef enum blaze_user_addr_meta_kind {
    */
   BLAZE_USER_ADDR_UNKNOWN,
   /**
+   * [`blaze_user_addr_meta_variant::apk_elf`] is valid.
+   */
+  BLAZE_USER_ADDR_APK_ELF,
+  /**
    * [`blaze_user_addr_meta_variant::elf`] is valid.
    */
   BLAZE_USER_ADDR_ELF,
@@ -96,6 +100,29 @@ typedef struct blaze_inspect_elf_src {
 } blaze_inspect_elf_src;
 
 /**
+ * C compatible version of [`ApkElf`].
+ */
+typedef struct blaze_user_addr_meta_apk_elf {
+  /**
+   * The canonical absolute path to the APK, including its name.
+   * This member is always present.
+   */
+  char *apk_path;
+  /**
+   * The relative path to the ELF file inside the APK.
+   */
+  char *elf_path;
+  /**
+   * The length of the build ID, in bytes.
+   */
+  size_t elf_build_id_len;
+  /**
+   * The optional build ID of the ELF file, if found.
+   */
+  uint8_t *elf_build_id;
+} blaze_user_addr_meta_apk_elf;
+
+/**
  * C compatible version of [`Elf`].
  */
 typedef struct blaze_user_addr_meta_elf {
@@ -124,6 +151,10 @@ typedef struct blaze_user_addr_meta_unknown {
  * The actual variant data in [`blaze_user_addr_meta`].
  */
 typedef union blaze_user_addr_meta_variant {
+  /**
+   * Valid on [`blaze_user_addr_meta_kind::BLAZE_USER_ADDR_APK_ELF`].
+   */
+  struct blaze_user_addr_meta_apk_elf apk_elf;
   /**
    * Valid on [`blaze_user_addr_meta_kind::BLAZE_USER_ADDR_ELF`].
    */

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -35,9 +35,9 @@ typedef enum blaze_user_addr_meta_kind {
    */
   BLAZE_USER_ADDR_UNKNOWN,
   /**
-   * [`blaze_user_addr_meta_variant::binary`] is valid.
+   * [`blaze_user_addr_meta_variant::elf`] is valid.
    */
-  BLAZE_USER_ADDR_BINARY,
+  BLAZE_USER_ADDR_ELF,
 } blaze_user_addr_meta_kind;
 
 /**
@@ -85,7 +85,7 @@ typedef struct blaze_sym_info {
  */
 typedef struct blaze_inspect_elf_src {
   /**
-   * The path to the binary. This member is always present.
+   * The path to the ELF file. This member is always present.
    */
   const char *path;
   /**
@@ -96,11 +96,11 @@ typedef struct blaze_inspect_elf_src {
 } blaze_inspect_elf_src;
 
 /**
- * C compatible version of [`Binary`].
+ * C compatible version of [`Elf`].
  */
-typedef struct blaze_user_addr_meta_binary {
+typedef struct blaze_user_addr_meta_elf {
   /**
-   * The path to the binary. This member is always present.
+   * The path to the ELF file. This member is always present.
    */
   char *path;
   /**
@@ -108,10 +108,10 @@ typedef struct blaze_user_addr_meta_binary {
    */
   size_t build_id_len;
   /**
-   * The optional build ID of the binary, if found.
+   * The optional build ID of the ELF file, if found.
    */
   uint8_t *build_id;
-} blaze_user_addr_meta_binary;
+} blaze_user_addr_meta_elf;
 
 /**
  * C compatible version of [`Unknown`].
@@ -125,9 +125,9 @@ typedef struct blaze_user_addr_meta_unknown {
  */
 typedef union blaze_user_addr_meta_variant {
   /**
-   * Valid on [`blaze_user_addr_meta_kind::BLAZE_USER_ADDR_BINARY`].
+   * Valid on [`blaze_user_addr_meta_kind::BLAZE_USER_ADDR_ELF`].
    */
-  struct blaze_user_addr_meta_binary binary;
+  struct blaze_user_addr_meta_elf elf;
   /**
    * Valid on [`blaze_user_addr_meta_kind::BLAZE_USER_ADDR_UNKNOWN`].
    */

--- a/src/c_api/inspect.rs
+++ b/src/c_api/inspect.rs
@@ -32,7 +32,7 @@ use crate::Addr;
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_inspect_elf_src {
-    /// The path to the binary. This member is always present.
+    /// The path to the ELF file. This member is always present.
     path: *const c_char,
     /// Whether or not to consult debug information to satisfy the request (if
     /// present).

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -486,8 +486,8 @@ mod tests {
     use super::*;
 
 
-    /// Check that we can convert an [`Unknown`] into a
-    /// [`blaze_user_addr_meta_unknown`] and back.
+    /// Check that we can convert a [`blaze_symbolize_src_kernel`]
+    /// reference into a [`Kernel`].
     #[test]
     fn kernel_conversion() {
         let kernel = blaze_symbolize_src_kernel {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,6 @@ pub mod normalize;
 mod resolver;
 pub mod symbolize;
 mod util;
-// TODO: Remove `allow`.
-#[allow(unused)]
 mod zip;
 
 use std::fmt::Display;

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -119,7 +119,6 @@ impl Mmap {
     /// Create a new `Mmap` object (sharing the same underlying memory mapping
     /// as the current one) that restricts its view to the provided `range`.
     /// Adjustment happens relative to the current view.
-    #[cfg(test)]
     pub fn constrain(&self, range: Range<usize>) -> Option<Self> {
         if self.view.start + range.end > self.view.end {
             return None

--- a/src/normalize/meta.rs
+++ b/src/normalize/meta.rs
@@ -5,6 +5,21 @@ use std::path::PathBuf;
 type BuildId = Vec<u8>;
 
 
+/// Meta information about an ELF file inside an APK.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ApkElf {
+    /// The canonical absolute path to the APK, including its name.
+    pub apk_path: PathBuf,
+    /// The relative path to the ELF file inside the APK.
+    pub elf_path: PathBuf,
+    /// The ELF file's build ID, if available.
+    pub elf_build_id: Option<BuildId>,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub(crate) _non_exhaustive: (),
+}
+
+
 /// Meta information about an ELF file (executable, shared object, ...).
 #[derive(Clone, Debug, PartialEq)]
 pub struct Elf {
@@ -39,16 +54,71 @@ impl From<Unknown> for UserAddrMeta {
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum UserAddrMeta {
+    ApkElf(ApkElf),
     Elf(Elf),
     Unknown(Unknown),
 }
 
 impl UserAddrMeta {
+    /// Retrieve the [`ApkElf`] of this enum, if this variant is active.
+    pub fn apk_elf(&self) -> Option<&ApkElf> {
+        match self {
+            Self::ApkElf(entry) => Some(entry),
+            _ => None,
+        }
+    }
+
     /// Retrieve the [`Elf`] of this enum, if this variant is active.
     pub fn elf(&self) -> Option<&Elf> {
         match self {
             Self::Elf(elf) => Some(elf),
             _ => None,
         }
+    }
+
+    /// Retrieve the [`Unknown`] of this enum, if this variant is active.
+    pub fn unknown(&self) -> Option<&Unknown> {
+        match self {
+            Self::Unknown(unknown) => Some(unknown),
+            _ => None,
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    /// Check that we can access individual variants of a
+    /// [`UserAddrMeta`] via the accessor functions.
+    #[test]
+    fn user_addr_meta_accessors() {
+        let meta = UserAddrMeta::ApkElf(ApkElf {
+            apk_path: PathBuf::from("/tmp/archive.apk"),
+            elf_path: PathBuf::from("object.so"),
+            elf_build_id: None,
+            _non_exhaustive: (),
+        });
+        assert!(meta.apk_elf().is_some());
+        assert!(meta.elf().is_none());
+        assert!(meta.unknown().is_none());
+
+        let meta = UserAddrMeta::Elf(Elf {
+            path: PathBuf::from("/tmp/executable.bin"),
+            build_id: None,
+            _non_exhaustive: (),
+        });
+        assert!(meta.apk_elf().is_none());
+        assert!(meta.elf().is_some());
+        assert!(meta.unknown().is_none());
+
+        let meta = UserAddrMeta::Unknown(Unknown {
+            _non_exhaustive: (),
+        });
+        assert!(meta.apk_elf().is_none());
+        assert!(meta.elf().is_none());
+        assert!(meta.unknown().is_some());
     }
 }

--- a/src/normalize/meta.rs
+++ b/src/normalize/meta.rs
@@ -5,13 +5,12 @@ use std::path::PathBuf;
 type BuildId = Vec<u8>;
 
 
-/// Meta information about a user space binary (executable, shared object, APK,
-/// ...).
+/// Meta information about an ELF file (executable, shared object, ...).
 #[derive(Clone, Debug, PartialEq)]
-pub struct Binary {
-    /// The canonical absolute path to the binary, including its name.
+pub struct Elf {
+    /// The canonical absolute path to the ELF file, including its name.
     pub path: PathBuf,
-    /// The binary's build ID, if available.
+    /// The ELF file's build ID, if available.
     pub build_id: Option<BuildId>,
     /// The struct is non-exhaustive and open to extension.
     #[doc(hidden)]
@@ -40,15 +39,15 @@ impl From<Unknown> for UserAddrMeta {
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum UserAddrMeta {
-    Binary(Binary),
+    Elf(Elf),
     Unknown(Unknown),
 }
 
 impl UserAddrMeta {
-    /// Retrieve the [`Binary`] of this enum, if this variant is active.
-    pub fn binary(&self) -> Option<&Binary> {
+    /// Retrieve the [`Elf`] of this enum, if this variant is active.
+    pub fn elf(&self) -> Option<&Elf> {
         match self {
-            Self::Binary(binary) => Some(binary),
+            Self::Elf(elf) => Some(elf),
             _ => None,
         }
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -22,14 +22,14 @@
 //! assert_eq!(norm_addrs.addrs.len(), 1);
 //!
 //! let (addr, meta_idx) = norm_addrs.addrs[0];
-//! // fopen (0x7f5f8e23a790) corresponds to address 0x77790 within Binary(Binary { path: "/usr/lib64/libc.so.6", build_id: Some([...]), ... })
+//! // fopen (0x7f5f8e23a790) corresponds to address 0x77790 within Elf(Elf { path: "/usr/lib64/libc.so.6", build_id: Some([...]), ... })
 //! println!("fopen (0x{fopen_addr:x}) corresponds to address 0x{addr:x} within {:?}", norm_addrs.meta[meta_idx]);
 //! ```
 
 mod meta;
 mod normalizer;
 
-pub use meta::Binary;
+pub use meta::Elf;
 pub use meta::Unknown;
 pub use meta::UserAddrMeta;
 pub use normalizer::NormalizedUserAddrs;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -29,6 +29,7 @@
 mod meta;
 mod normalizer;
 
+pub use meta::ApkElf;
 pub use meta::Elf;
 pub use meta::Unknown;
 pub use meta::UserAddrMeta;

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -142,6 +142,19 @@ fn normalize_elf_offset_with_parser(offset: u64, parser: &ElfParser) -> Result<O
     Ok(addr)
 }
 
+
+/// Make a [`UserAddrMeta::Elf`] variant.
+fn make_elf_meta(entry: &PathMapsEntry, get_build_id: &BuildIdFn) -> Result<UserAddrMeta> {
+    let elf = Elf {
+        path: entry.path.symbolic_path.to_path_buf(),
+        build_id: get_build_id(&entry.path.maps_file)?,
+        _non_exhaustive: (),
+    };
+    let meta = UserAddrMeta::Elf(elf);
+    Ok(meta)
+}
+
+
 /// Normalize a virtual address belonging to an ELF file represented by the
 /// provided [`PathMapsEntry`].
 pub(crate) fn normalize_elf_addr(virt_addr: Addr, entry: &PathMapsEntry) -> Result<Addr> {
@@ -239,14 +252,9 @@ where
         let meta_idx = if let Some(meta_idx) = self.meta_lookup.get(&entry.path.symbolic_path) {
             *meta_idx
         } else {
-            let elf = Elf {
-                path: entry.path.symbolic_path.to_path_buf(),
-                build_id: R::read_build_id_from_elf(&entry.path.maps_file)?,
-                _non_exhaustive: (),
-            };
-
+            let meta = make_elf_meta(entry, &R::read_build_id_from_elf)?;
             let meta_idx = self.normalized.meta.len();
-            let () = self.normalized.meta.push(UserAddrMeta::Elf(elf));
+            let () = self.normalized.meta.push(meta);
             let _ref = self
                 .meta_lookup
                 .insert(entry.path.symbolic_path.to_path_buf(), meta_idx);

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -198,7 +198,7 @@ impl Symbolizer {
             .collect()
     }
 
-    fn resolve_addr_in_binary(&self, addr: Addr, path: &Path) -> Result<Vec<SymbolizedResult>> {
+    fn resolve_addr_in_elf(&self, addr: Addr, path: &Path) -> Result<Vec<SymbolizedResult>> {
         let backend = self.elf_cache.find(path)?;
         let resolver = ElfResolver::with_backend(path, backend)?;
         let symbols = self.symbolize_with_resolver(addr, &resolver);
@@ -224,7 +224,7 @@ impl Symbolizer {
             fn handle_entry_addr(&mut self, addr: Addr, entry: &PathMapsEntry) -> Result<()> {
                 let path = &entry.path.maps_file;
                 let norm_addr = normalize_elf_addr(addr, entry)?;
-                let symbols = self.symbolizer.resolve_addr_in_binary(norm_addr, path)?;
+                let symbols = self.symbolizer.resolve_addr_in_elf(norm_addr, path)?;
                 let () = self.all_symbols.push(symbols);
                 Ok(())
             }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::io::Result;
 use std::path::Path;
@@ -215,6 +216,21 @@ impl Symbolizer {
             all_symbols: Vec<Vec<SymbolizedResult>>,
         }
 
+        impl SymbolizeHandler<'_> {
+            // TODO: Implement this functionality.
+            fn handle_apk_addr(&mut self, _addr: Addr, _entry: &PathMapsEntry) -> Result<()> {
+                todo!()
+            }
+
+            fn handle_elf_addr(&mut self, addr: Addr, entry: &PathMapsEntry) -> Result<()> {
+                let path = &entry.path.maps_file;
+                let norm_addr = normalize_elf_addr(addr, entry)?;
+                let symbols = self.symbolizer.resolve_addr_in_elf(norm_addr, path)?;
+                let () = self.all_symbols.push(symbols);
+                Ok(())
+            }
+        }
+
         impl normalize::Handler for SymbolizeHandler<'_> {
             fn handle_unknown_addr(&mut self, _addr: Addr) -> Result<()> {
                 let () = self.all_symbols.push(Vec::new());
@@ -222,11 +238,15 @@ impl Symbolizer {
             }
 
             fn handle_entry_addr(&mut self, addr: Addr, entry: &PathMapsEntry) -> Result<()> {
-                let path = &entry.path.maps_file;
-                let norm_addr = normalize_elf_addr(addr, entry)?;
-                let symbols = self.symbolizer.resolve_addr_in_elf(norm_addr, path)?;
-                let () = self.all_symbols.push(symbols);
-                Ok(())
+                let ext = entry
+                    .path
+                    .symbolic_path
+                    .extension()
+                    .unwrap_or_else(|| OsStr::new(""));
+                match ext.to_str() {
+                    Some("apk") | Some("zip") => self.handle_apk_addr(addr, entry),
+                    _ => self.handle_elf_addr(addr, entry),
+                }
             }
         }
 

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -12,14 +12,12 @@ use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
-use std::fs::File;
 use std::io::Error;
 use std::io::ErrorKind;
 use std::io::Result;
 use std::mem::size_of;
 use std::os::unix::ffi::OsStrExt as _;
 use std::path::Path;
-use std::rc::Rc;
 
 use crate::mmap::Mmap;
 use crate::util::Pod;
@@ -220,11 +218,9 @@ impl<'archive> EntryIter<'archive> {
                 )))
             }
 
-            let name = iter
+            let _name = iter
                 .cd_record_data
                 .read_slice(cdfh.file_name_length.into())?;
-            let name = OsStr::from_bytes(name);
-
             let _extra = iter
                 .cd_record_data
                 .read_slice(cdfh.extra_field_length.into())?;
@@ -498,7 +494,7 @@ mod tests {
                     - 1,
             )
             .unwrap();
-        copy(&mut partial_data, &mut corrupted_zip);
+        let _cnt = copy(&mut partial_data, &mut corrupted_zip).unwrap();
 
         // The archive only contains a corrupted central directory and no end of
         // central directory marker at all.

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -438,7 +438,7 @@ mod tests {
                 .entries()
                 .inspect(|result| assert!(result.is_ok(), "{result:?}"))
                 .count(),
-            3
+            4
         );
     }
 

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -155,9 +155,9 @@ fn symbolize_process() {
     assert!(result.symbol.contains("Symbolizer3new"), "{result:x?}");
 }
 
-/// Check that we can normalize user addresses in our own shared object.
+/// Check that we can normalize addresses in an ELF shared object.
 #[test]
-fn normalize_user_addr() {
+fn normalize_elf_addr() {
     fn test(so: &str) {
         let test_so = Path::new(&env!("CARGO_MANIFEST_DIR")).join("data").join(so);
         let so_cstr = CString::new(test_so.clone().into_os_string().into_vec()).unwrap();

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -179,7 +179,7 @@ fn normalize_user_addr() {
 
         let norm_addr = norm_addrs.addrs[0];
         let meta = &norm_addrs.meta[norm_addr.1];
-        assert_eq!(meta.binary().unwrap().path, test_so);
+        assert_eq!(meta.elf().unwrap().path, test_so);
 
         let elf = symbolize::Elf::new(test_so);
         let src = symbolize::Source::Elf(elf);


### PR DESCRIPTION
This change renames the Binary meta data variant to Elf. For the time being we decided to err on the side of having more specific variants, which may be easier to extend in a sensible way in the future (e.g., if future supported binary formats don't have a build ID it's more natural to have a new variant as opposed to fudging everything as a "binary" and then having optional fields).