### PR TITLE
Build libtest-so-no-separate-code.so with build ID

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -286,7 +286,7 @@ fn prepare_test_files(crate_root: &Path) {
     cc(
         &src,
         "libtest-so-no-separate-code.so",
-        &["-shared", "-fPIC", "-Wl,-z,noseparate-code"],
+        &["-shared", "-fPIC", "-Wl,--build-id=sha1,-z,noseparate-code"],
     );
 
     let src = crate_root.join("data").join("test-exe.c");


### PR DESCRIPTION
On a system that is configured to not emit build IDs by default we fail the `address_normalization_custom_so_in_zip()` test, which assumes build IDs present in both `libtest-so.so` and `libtest-so-no-separate-code.so`. Make sure that the latter also contains a build ID.