### PR TITLE
Provide runnable example for symbolize module

### DIFF
--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -3,42 +3,51 @@
 //! This module contains functionality for symbolizing addresses, i.e., finding
 //! symbol names and other information based on "raw" addresses.
 //!
-//! Here an example illustrating usage of the symbolization functionality:
+//! For example, here we symbolize the backtrace captured via `libc`'s
+//! `backtrace` function:
 //! ```no_run
-//! use blazesym::Addr;
-//! use blazesym::symbolize::Symbolizer;
+//! # use std::cmp::min;
+//! # use std::mem::size_of;
+//! # use std::mem::transmute;
+//! # use std::ptr;
 //! use blazesym::symbolize::Source;
 //! use blazesym::symbolize::Process;
+//! use blazesym::symbolize::Symbolizer;
 //! use blazesym::symbolize::SymbolizedResult;
+//! use blazesym::Addr;
+//! use blazesym::Pid;
 //!
-//! let process_id: u32 = std::process::id(); // <some process id>
-//! // Load all symbols of loaded files of the given process.
-//! let src = Source::Process(Process::new(process_id.into()));
+//! # assert_eq!(size_of::<*mut libc::c_void>(), size_of::<Addr>());
+//! // Retrieve up to 64 stack frames of the calling thread.
+//! const MAX_CNT: usize = 64;
+//!
+//! let mut bt_buf = [ptr::null_mut::<libc::c_void>(); MAX_CNT];
+//! let bt_cnt = unsafe { libc::backtrace(bt_buf.as_mut_ptr(), MAX_CNT as _) } as usize;
+//! let bt = &bt_buf[0..min(bt_cnt, MAX_CNT)];
+//! # let bt = unsafe { transmute::<&[*mut libc::c_void], &[Addr]>(bt) };
+//!
+//! // Symbolize the addresses for the current process, as that's where
+//! // they were captured.
+//! let src = Source::Process(Process::new(Pid::Slf));
 //! let symbolizer = Symbolizer::new();
 //!
-//! let stack: [Addr; 2] = [0xff023, 0x17ff93b];  // Addresses of instructions
-//! let symlist = symbolizer.symbolize(&src,      // Pass this configuration every time
-//!                                    &stack).unwrap();
-//! for i in 0..stack.len() {
-//!   let addr = stack[i];
+//! let bt_syms = symbolizer.symbolize(&src, bt).unwrap();
+//! for (addr, syms) in bt.iter().zip(bt_syms) {
+//!   match &syms[..] {
+//!     [] => println!("0x{addr:016x}: <no-symbols>"),
+//!     [sym] => {
+//!       let SymbolizedResult {symbol, addr, path, line, ..} = sym;
+//!       println!("0x{addr:016x} {symbol} @ 0x{addr:x} {}:{line}", path.display());
+//!     },
+//!     syms => {
+//!       // One address may get several results.
+//!       println!("0x{addr:016x} ({} entries)", syms.len());
 //!
-//!   if symlist.len() <= i || symlist[i].len() == 0 {  // Unknown address
-//!     println!("0x{addr:016x}");
-//!     continue;
-//!   }
-//!
-//!   let sym_results = &symlist[i];
-//!   if sym_results.len() > 1 {
-//!     // One address may get several results.
-//!     println!("0x{addr:016x} ({} entries)", sym_results.len());
-//!
-//!     for result in sym_results {
-//!       let SymbolizedResult {symbol, addr, path, line, column} = result;
-//!       println!("    {symbol}@0x{addr:016x} {}:{line}", path.display());
-//!     }
-//!   } else {
-//!     let SymbolizedResult {symbol, addr, path, line, column} = &sym_results[0];
-//!     println!("0x{addr:016x} {symbol}@0x{addr:016x} {}:{line}", path.display());
+//!       for sym in syms {
+//!         let SymbolizedResult {symbol, addr, path, line, ..} = sym;
+//!         println!("    {symbol} @ 0x{addr:016x} {}:{line}", path.display());
+//!       }
+//!     },
 //!   }
 //! }
 //! ```


### PR DESCRIPTION
This change updates the example we provide as part of the documentation for the symbolize module to something that can be run properly. Right now it requires root, but we could change that eventually.