### PR TITLE
Make SymResolver::find_syms() return a Result

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -42,7 +42,7 @@ impl KernelResolver {
 }
 
 impl SymResolver for KernelResolver {
-    fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)> {
+    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>> {
         if let Some(ksym_resolver) = self.ksym_resolver.as_ref() {
             ksym_resolver.find_syms(addr)
         } else {

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -126,10 +126,12 @@ impl KSymResolver {
 }
 
 impl SymResolver for KSymResolver {
-    fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)> {
-        self.find_addresses_ksym(addr)
+    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>> {
+        let syms = self
+            .find_addresses_ksym(addr)
             .map(|sym| (sym.name.as_str(), sym.addr))
-            .collect()
+            .collect();
+        Ok(syms)
     }
 
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>> {
@@ -225,27 +227,27 @@ mod tests {
         let sym = &resolver.syms[resolver.syms.len() / 2];
         let addr = sym.addr;
         let name = sym.name.clone();
-        let found = resolver.find_syms(addr);
+        let found = resolver.find_syms(addr).unwrap();
         assert!(!found.is_empty());
         assert!(found.iter().any(|x| x.0 == name));
         let addr = addr + 1;
-        let found = resolver.find_syms(addr);
+        let found = resolver.find_syms(addr).unwrap();
         assert!(!found.is_empty());
         assert!(found.iter().any(|x| x.0 == name));
 
         // 0 is an invalid address.  We remove all symbols with 0 as
         // thier address from the list.
-        let found = resolver.find_syms(0);
+        let found = resolver.find_syms(0).unwrap();
         assert!(found.is_empty());
 
         // Find the address of the last symbol
         let sym = &resolver.syms.last().unwrap();
         let addr = sym.addr;
         let name = sym.name.clone();
-        let found = resolver.find_syms(addr);
+        let found = resolver.find_syms(addr).unwrap();
         assert!(!found.is_empty());
         assert!(found.iter().any(|x| x.0 == name));
-        let found = resolver.find_syms(addr + 1);
+        let found = resolver.find_syms(addr + 1).unwrap();
         assert!(!found.is_empty());
         assert!(found.iter().any(|x| x.0 == name));
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -18,7 +18,7 @@ where
 {
     /// Find the names and the start addresses of a symbol found for
     /// the given address.
-    fn find_syms(&self, addr: Addr) -> Vec<(&str, Addr)>;
+    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>, Error>;
     /// Find the address and size of a symbol name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>, Error>;
     /// Find the file name and the line number of an address.

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -141,13 +141,13 @@ impl Symbolizer {
         addr: Addr,
         resolver: &dyn SymResolver,
     ) -> Result<Vec<SymbolizedResult>> {
-        let res_syms = resolver.find_syms(addr);
+        let syms = resolver.find_syms(addr)?;
         let linfo = if self.src_location {
             resolver.find_line_info(addr)?
         } else {
             None
         };
-        if res_syms.is_empty() {
+        if syms.is_empty() {
             if let Some(linfo) = linfo {
                 Ok(vec![SymbolizedResult {
                     symbol: "".to_string(),
@@ -161,7 +161,7 @@ impl Symbolizer {
             }
         } else {
             let mut results = vec![];
-            for sym in res_syms {
+            for sym in syms {
                 if let Some(ref linfo) = linfo {
                     let (sym, start) = sym;
                     results.push(SymbolizedResult {


### PR DESCRIPTION
As the 100th method that just swallows errors when it feels like it, this change converts SymResolver::find_syms() to correctly bubble up errors.