### PR TITLE
Remove SymResolver::get_obj_file_name() method

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -45,6 +45,11 @@ impl ElfResolver {
             ElfBackend::Elf(parser) => parser,
         }
     }
+
+    /// Retrieve the path to the ELF file represented by this resolver.
+    pub(crate) fn file_name(&self) -> &Path {
+        &self.file_name
+    }
 }
 
 impl SymResolver for ElfResolver {
@@ -121,10 +126,6 @@ impl SymResolver for ElfResolver {
         })?;
         Some(offset)
     }
-
-    fn get_obj_file_name(&self) -> &Path {
-        &self.file_name
-    }
 }
 
 impl Debug for ElfResolver {
@@ -159,5 +160,6 @@ mod tests {
 
         assert_eq!(resolver.addr_file_off(0x0), None);
         assert_eq!(resolver.addr_file_off(0xffffffffffffffff), None);
+        assert_eq!(resolver.file_name(), path);
     }
 }

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -171,10 +171,6 @@ impl SymResolver for GsymResolver {
         // Unavailable
         None
     }
-
-    fn get_obj_file_name(&self) -> &Path {
-        &self.file_name
-    }
 }
 
 impl Debug for GsymResolver {

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -78,8 +78,7 @@ impl Inspector {
                                 }
                             }
                             if opts.obj_file_name {
-                                sym.obj_file_name =
-                                    Some(resolver.get_obj_file_name().to_path_buf());
+                                sym.obj_file_name = Some(path.to_path_buf())
                             }
                         });
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -4,7 +4,6 @@ use std::fmt::Result as FmtResult;
 use std::io::Error;
 use std::io::ErrorKind;
 use std::io::Result;
-use std::ops::Deref as _;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -65,22 +64,6 @@ impl SymResolver for KernelResolver {
     fn addr_file_off(&self, _addr: Addr) -> Option<u64> {
         None
     }
-
-    fn get_obj_file_name(&self) -> &Path {
-        let ksym_resolver = self
-            .ksym_resolver
-            .as_ref()
-            .map(|resolver| resolver.deref() as &dyn SymResolver);
-        let elf_resolver = self
-            .elf_resolver
-            .as_ref()
-            .map(|resolver| resolver as &dyn SymResolver);
-
-        ksym_resolver
-            .or(elf_resolver)
-            .map(|resolver| resolver.get_obj_file_name())
-            .unwrap_or_else(|| Path::new(""))
-    }
 }
 
 impl Debug for KernelResolver {
@@ -90,13 +73,13 @@ impl Debug for KernelResolver {
             "KernelResolver {} {}",
             self.ksym_resolver
                 .as_ref()
-                .map(|resolver| resolver.get_obj_file_name().to_path_buf())
-                .unwrap_or_default()
+                .map(|resolver| resolver.file_name())
+                .unwrap_or_else(|| Path::new(""))
                 .display(),
             self.elf_resolver
                 .as_ref()
-                .map(|resolver| resolver.get_obj_file_name().to_path_buf())
-                .unwrap_or_default()
+                .map(|resolver| resolver.file_name())
+                .unwrap_or_else(|| Path::new(""))
                 .display(),
         )
     }

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -123,6 +123,11 @@ impl KSymResolver {
             .rev()
             .take_while(move |x| x.addr == self.syms[i - 1].addr)
     }
+
+    /// Retrieve the path to the kallsyms file used by this resolver.
+    pub(crate) fn file_name(&self) -> &Path {
+        &self.file_name
+    }
 }
 
 impl SymResolver for KSymResolver {
@@ -161,10 +166,6 @@ impl SymResolver for KSymResolver {
 
     fn addr_file_off(&self, _addr: Addr) -> Option<u64> {
         None
-    }
-
-    fn get_obj_file_name(&self) -> &Path {
-        &self.file_name
     }
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 use std::io::Error;
-use std::path::Path;
 
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
@@ -26,6 +25,4 @@ where
     /// Translate an address (virtual) in a process to the file offset
     /// in the object file.
     fn addr_file_off(&self, addr: Addr) -> Option<u64>;
-    /// Get the file name of the shared object.
-    fn get_obj_file_name(&self) -> &Path;
 }


### PR DESCRIPTION
We don't really want to require association of a file name with a resolver. It is entirely reasonable to have a resolver that just works on allocated/mmap'ed data that was just handed to us and for which we don't (and in the general case: cannot) know what file it belongs to.

We don't really need the method. Inside the `Inspector` we can just use the path being provided and used for instantiation of the corresponding resolvers, and elsewhere we just use the file name to spice up the debug representation or similar. Remove it.