### PR TITLE
Iterating over notes to detect build ID

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -85,7 +85,6 @@ impl<'mmap> Cache<'mmap> {
                 format!("ELF section index ({idx}) out of bounds"),
             )
         })?;
-
         let data = self
             .elf_data
             .get(section.sh_offset as usize..)

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -99,6 +99,8 @@ impl Elf64_Sym {
 // SAFETY: `Elf64_Sym` is valid for any bit pattern.
 unsafe impl crate::util::Pod for Elf64_Sym {}
 
+pub(crate) const NT_GNU_BUILD_ID: Elf64_Word = 3;
+
 #[repr(C)]
 pub(crate) struct Elf64_Nhdr {
     pub n_namesz: Elf64_Word,


### PR DESCRIPTION
This PR changes the build ID detection to iterate over all ELF notes in a binary in order to find those of type `NT_GNU_BUILD_ID`.

This patch is in response to #215.