### PR TITLE
Use codecov in informational mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        # We don't gate anything based on flaky code coverage reports.
+        informational: true
+    patch:
+      default:
+        informational: true
 github_checks:
     annotations: false


### PR DESCRIPTION
Codecov coverage reporting is unstable, most likely due to https://github.com/taiki-e/cargo-llvm-cov/issues/276. In any event, we do not want to gate pull requests by changes in coverage. Run it in informational mode [0] instead.

[0]: https://docs.codecov.com/docs/commit-status#informational