### PR TITLE
Fix documentation of normalization API in C API

### DIFF
--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -476,9 +476,8 @@ void blaze_normalizer_free(struct blaze_normalizer *normalizer);
 /**
  * Normalize a list of user space addresses.
  *
- * The `addrs` array has to be sorted in ascending order. `pid` should
- * describe the PID of the process to which the addresses belong. It
- * may be `0` if they belong to the calling process.
+ * Contrary to `blaze_normalize_user_addrs_sorted` the provided `addrs` array
+ * does not have to be sorted, but otherwise the functions behave identically.
  *
  * C ABI compatible version of [`Normalizer::normalize_user_addrs`].
  * Returns `NULL` on error. The resulting object should be freed using
@@ -495,6 +494,10 @@ struct blaze_normalized_user_addrs *blaze_normalize_user_addrs(const struct blaz
 
 /**
  * Normalize a list of user space addresses.
+ *
+ * The `addrs` array has to be sorted in ascending order. `pid` should describe
+ * the PID of the process to which the addresses belong. It may be `0` if they
+ * belong to the calling process.
  *
  * `pid` should describe the PID of the process to which the addresses belong.
  * It may be `0` if they belong to the calling process.

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -353,9 +353,8 @@ impl From<NormalizedUserAddrs> for blaze_normalized_user_addrs {
 
 /// Normalize a list of user space addresses.
 ///
-/// The `addrs` array has to be sorted in ascending order. `pid` should
-/// describe the PID of the process to which the addresses belong. It
-/// may be `0` if they belong to the calling process.
+/// Contrary to `blaze_normalize_user_addrs_sorted` the provided `addrs` array
+/// does not have to be sorted, but otherwise the functions behave identically.
 ///
 /// C ABI compatible version of [`Normalizer::normalize_user_addrs`].
 /// Returns `NULL` on error. The resulting object should be freed using
@@ -389,6 +388,10 @@ pub unsafe extern "C" fn blaze_normalize_user_addrs(
 
 
 /// Normalize a list of user space addresses.
+///
+/// The `addrs` array has to be sorted in ascending order. `pid` should describe
+/// the PID of the process to which the addresses belong. It may be `0` if they
+/// belong to the calling process.
 ///
 /// `pid` should describe the PID of the process to which the addresses belong.
 /// It may be `0` if they belong to the calling process.


### PR DESCRIPTION
The documentation for the normalization APIs of the C bindings mixed up wording for the blaze_normalize_user_addrs and
blaze_normalize_user_addrs_sorted variants. Fix it.

Reported-by: Salvatore Benedetto