### PR TITLE
Rename `blaze_user_addr_meta_unknown::__unused` member to `_unused`

### DIFF
--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -144,7 +144,7 @@ typedef struct blaze_user_addr_meta_elf {
  * C compatible version of [`Unknown`].
  */
 typedef struct blaze_user_addr_meta_unknown {
-  uint8_t __unused;
+  uint8_t _unused;
 } blaze_user_addr_meta_unknown;
 
 /**

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -227,7 +227,7 @@ impl From<blaze_user_addr_meta_elf> for Elf {
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_user_addr_meta_unknown {
-    __unused: u8,
+    _unused: u8,
 }
 
 impl From<Unknown> for blaze_user_addr_meta_unknown {
@@ -235,13 +235,13 @@ impl From<Unknown> for blaze_user_addr_meta_unknown {
         let Unknown {
             _non_exhaustive: (),
         } = other;
-        Self { __unused: 0 }
+        Self { _unused: 0 }
     }
 }
 
 impl From<blaze_user_addr_meta_unknown> for Unknown {
     fn from(other: blaze_user_addr_meta_unknown) -> Self {
-        let blaze_user_addr_meta_unknown { __unused } = other;
+        let blaze_user_addr_meta_unknown { _unused } = other;
         Unknown {
             _non_exhaustive: (),
         }
@@ -534,7 +534,7 @@ mod tests {
     /// [`blaze_user_addr_meta_variant`].
     #[test]
     fn debug_meta_variant() {
-        let unknown = blaze_user_addr_meta_unknown { __unused: 0 };
+        let unknown = blaze_user_addr_meta_unknown { _unused: 0 };
         let variant = blaze_user_addr_meta_variant {
             unknown: ManuallyDrop::new(unknown),
         };


### PR DESCRIPTION
C/C++ reserves double underscore identifiers. So what can potentially happen is that `__unused` is really the name of a macro (expanding to `__attribute__((unused))` or similar) and that causes a compile error, because now the variable has no name.
Rename the `blaze_user_addr_meta_unknown::__unused` member to `_unused` to prevent such issues from popping up.

Reported-by: Salvatore Benedetto