### PR TITLE
Reword process ID documentation for normalize functions

### DIFF
--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -538,9 +538,7 @@ impl Normalizer {
     /// - they belonged to an ELF object that has been unmapped since the
     ///   address was captured
     ///
-    /// The process' ID should be provided in `pid`. To normalize addresses of the
-    /// calling processes, `0` can be provided as a sentinel for the current
-    /// process' ID.
+    /// The process' ID should be provided in `pid`.
     ///
     /// Normalized addresses are reported in the exact same order in which the
     /// non-normalized ones were provided.
@@ -568,9 +566,7 @@ impl Normalizer {
     /// - they belonged to an ELF object that has been unmapped since the
     ///   address was captured
     ///
-    /// The process' ID should be provided in `pid`. To normalize addresses of the
-    /// calling processes, `0` can be provided as a sentinel for the current
-    /// process' ID.
+    /// The process' ID should be provided in `pid`.
     ///
     /// Normalized addresses are reported in the exact same order in which the
     /// non-normalized ones were provided.


### PR DESCRIPTION
As of commit 06ef89ff67aa ("Make normalize functionality use Pid") the normalize functions no longer accept a u32 process ID, but rather a Pid object.
With this change we adjust the documentation accordingly.