### PR TITLE
Wrap overly long documentation lines in normalize module

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -22,8 +22,12 @@
 //! assert_eq!(norm_addrs.addrs.len(), 1);
 //!
 //! let (addr, meta_idx) = norm_addrs.addrs[0];
-//! // fopen (0x7f5f8e23a790) corresponds to address 0x77790 within Elf(Elf { path: "/usr/lib64/libc.so.6", build_id: Some([...]), ... })
-//! println!("fopen (0x{fopen_addr:x}) corresponds to address 0x{addr:x} within {:?}", norm_addrs.meta[meta_idx]);
+//! // fopen (0x7f5f8e23a790) corresponds to address 0x77790 within
+//! // Elf(Elf { path: "/usr/lib64/libc.so.6", build_id: Some([...]), ... })
+//! println!(
+//!   "fopen (0x{fopen_addr:x}) corresponds to address 0x{addr:x} within {:?}",
+//!   norm_addrs.meta[meta_idx]
+//! );
 //! ```
 
 mod meta;


### PR DESCRIPTION
The documentation of the normalize module contains example code but the way it is written it causes overly long lines in the documentation, requiring people to scroll horizontally. That's not particularly nice. Wrap those long lines earlier to improve the situation.