### PR TITLE
Provide rationale for *_sorted normalization APIs

### DIFF
--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -476,8 +476,11 @@ void blaze_normalizer_free(struct blaze_normalizer *normalizer);
 /**
  * Normalize a list of user space addresses.
  *
- * Contrary to `blaze_normalize_user_addrs_sorted` the provided `addrs` array
- * does not have to be sorted, but otherwise the functions behave identically.
+ * Contrary to [`blaze_normalize_user_addrs_sorted`] the provided
+ * `addrs` array does not have to be sorted, but otherwise the
+ * functions behave identically. If you happen to know that `addrs` is
+ * sorted, using [`blaze_normalize_user_addrs_sorted`] instead will
+ * result in slightly faster normalization.
  *
  * C ABI compatible version of [`Normalizer::normalize_user_addrs`].
  * Returns `NULL` on error. The resulting object should be freed using
@@ -495,12 +498,13 @@ struct blaze_normalized_user_addrs *blaze_normalize_user_addrs(const struct blaz
 /**
  * Normalize a list of user space addresses.
  *
- * The `addrs` array has to be sorted in ascending order. `pid` should describe
- * the PID of the process to which the addresses belong. It may be `0` if they
- * belong to the calling process.
+ * The `addrs` array has to be sorted in ascending order. By providing
+ * a pre-sorted array the library does not have to sort internally,
+ * which will result in quicker normalization. If you don't have sorted
+ * addresses, use [`blaze_normalize_user_addrs`] instead.
  *
- * `pid` should describe the PID of the process to which the addresses belong.
- * It may be `0` if they belong to the calling process.
+ * `pid` should describe the PID of the process to which the addresses
+ * belongs. It may be `0` if they belong to the calling process.
  *
  * C ABI compatible version of [`Normalizer::normalize_user_addrs_sorted`].
  * Returns `NULL` on error. The resulting object should be freed using

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -353,8 +353,11 @@ impl From<NormalizedUserAddrs> for blaze_normalized_user_addrs {
 
 /// Normalize a list of user space addresses.
 ///
-/// Contrary to `blaze_normalize_user_addrs_sorted` the provided `addrs` array
-/// does not have to be sorted, but otherwise the functions behave identically.
+/// Contrary to [`blaze_normalize_user_addrs_sorted`] the provided
+/// `addrs` array does not have to be sorted, but otherwise the
+/// functions behave identically. If you happen to know that `addrs` is
+/// sorted, using [`blaze_normalize_user_addrs_sorted`] instead will
+/// result in slightly faster normalization.
 ///
 /// C ABI compatible version of [`Normalizer::normalize_user_addrs`].
 /// Returns `NULL` on error. The resulting object should be freed using
@@ -389,12 +392,13 @@ pub unsafe extern "C" fn blaze_normalize_user_addrs(
 
 /// Normalize a list of user space addresses.
 ///
-/// The `addrs` array has to be sorted in ascending order. `pid` should describe
-/// the PID of the process to which the addresses belong. It may be `0` if they
-/// belong to the calling process.
+/// The `addrs` array has to be sorted in ascending order. By providing
+/// a pre-sorted array the library does not have to sort internally,
+/// which will result in quicker normalization. If you don't have sorted
+/// addresses, use [`blaze_normalize_user_addrs`] instead.
 ///
-/// `pid` should describe the PID of the process to which the addresses belong.
-/// It may be `0` if they belong to the calling process.
+/// `pid` should describe the PID of the process to which the addresses
+/// belongs. It may be `0` if they belong to the calling process.
 ///
 /// C ABI compatible version of [`Normalizer::normalize_user_addrs_sorted`].
 /// Returns `NULL` on error. The resulting object should be freed using

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -556,8 +556,12 @@ impl Normalizer {
 
     /// Normalize `addresses` belonging to a process.
     ///
-    /// Normalize all `addrs` in a given process. The `addrs` array has to
-    /// be sorted in ascending order or an error will be returned.
+    /// Normalize all `addrs` in a given process. The `addrs` array has
+    /// to be sorted in ascending order or an error will be returned. By
+    /// providing a pre-sorted array the library does not have to sort
+    /// internally, which will result in quicker normalization. If you
+    /// don't have sorted addresses, use
+    /// [`Normalizer::normalize_user_addrs`] instead.
     ///
     /// Unknown addresses are not normalized. They are reported as
     /// [`Unknown`] meta entries in the returned [`NormalizedUserAddrs`]
@@ -585,9 +589,11 @@ impl Normalizer {
     /// Normalize `addresses` belonging to a process.
     ///
     /// Normalize all `addrs` in a given process. Contrary to
-    /// [`Normalizer::normalize_user_addrs_sorted`], the provided
-    /// `addrs` array does not have to be sorted, but otherwise the
-    /// functions behave identically.
+    /// [`Normalizer::normalize_user_addrs_sorted`], the provided `addrs` array
+    /// does not have to be sorted, but otherwise the functions behave
+    /// identically. If you do happen to know that `addrs` is sorted, using
+    /// [`Normalizer::normalize_user_addrs_sorted`] instead will result in
+    /// slightly faster normalization.
     #[cfg_attr(feature = "tracing", crate::log::instrument(skip(self)))]
     pub fn normalize_user_addrs(&self, addrs: &[Addr], pid: Pid) -> Result<NormalizedUserAddrs> {
         util::with_ordered_elems(


### PR DESCRIPTION
The documentation explains the expectations of the *_sorted normalization function variants, but doesn't really explain the relevance or why one would prefer one over the other. Explain it a bit more.