### PR TITLE
Add CHANGELOG entry for blaze_user_addr_meta_unknown::__unused rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Unreleased
 - Adjusted `symbolize::Source::Gsym` variant to support symbolizing Gsym from
   user provided "raw" data
 - Renamed `normalize::UserAddrMeta::Binary` variant to `Elf`
+- Renamed `blaze_user_addr_meta_unknown::__unused` member to `_unused`
 
 
 0.2.0-alpha.2


### PR DESCRIPTION
Add a CHANGELOG entry for the blaze_user_addr_meta_unknown::__unused member rename, as it could be considered a breaking change.