### PR TITLE
Add "test" for Debug representation of various C API symbolize types

### DIFF
--- a/src/c_api/inspect.rs
+++ b/src/c_api/inspect.rs
@@ -318,6 +318,32 @@ mod tests {
     use test_log::test;
 
 
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let elf = blaze_inspect_elf_src {
+            path: ptr::null(),
+            debug_info: true,
+        };
+        assert_eq!(
+            format!("{elf:?}"),
+            "blaze_inspect_elf_src { path: 0x0, debug_info: true }"
+        );
+
+        let info = blaze_sym_info {
+            name: ptr::null(),
+            addr: 42,
+            size: 1337,
+            file_offset: 31,
+            obj_file_name: ptr::null(),
+            sym_type: blaze_sym_type::BLAZE_SYM_VAR,
+        };
+        assert_eq!(
+            format!("{info:?}"),
+            "blaze_sym_info { name: 0x0, addr: 42, size: 1337, file_offset: 31, obj_file_name: 0x0, sym_type: BLAZE_SYM_VAR }"
+        );
+    }
+
     /// Check that we can properly convert a "syms list" into the corresponding
     /// C representation.
     #[test]

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -486,6 +486,71 @@ mod tests {
     use super::*;
 
 
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let norm_addr = blaze_normalized_addr {
+            addr: 0x1337,
+            meta_idx: 1,
+        };
+        assert_eq!(
+            format!("{norm_addr:?}"),
+            "blaze_normalized_addr { addr: 4919, meta_idx: 1 }"
+        );
+
+        let meta_kind = blaze_user_addr_meta_kind::BLAZE_USER_ADDR_APK_ELF;
+        assert_eq!(format!("{meta_kind:?}"), "BLAZE_USER_ADDR_APK_ELF");
+
+        let apk_elf = blaze_user_addr_meta_apk_elf {
+            apk_path: ptr::null_mut(),
+            elf_path: ptr::null_mut(),
+            elf_build_id_len: 0,
+            elf_build_id: ptr::null_mut(),
+        };
+        assert_eq!(
+            format!("{apk_elf:?}"),
+            "blaze_user_addr_meta_apk_elf { apk_path: 0x0, elf_path: 0x0, elf_build_id_len: 0, elf_build_id: 0x0 }",
+        );
+
+        let elf = blaze_user_addr_meta_elf {
+            path: ptr::null_mut(),
+            build_id_len: 0,
+            build_id: ptr::null_mut(),
+        };
+        assert_eq!(
+            format!("{elf:?}"),
+            "blaze_user_addr_meta_elf { path: 0x0, build_id_len: 0, build_id: 0x0 }",
+        );
+
+        let unknown = blaze_user_addr_meta_unknown { _unused: 42 };
+        assert_eq!(
+            format!("{unknown:?}"),
+            "blaze_user_addr_meta_unknown { _unused: 42 }",
+        );
+
+        let meta = blaze_user_addr_meta {
+            kind: blaze_user_addr_meta_kind::BLAZE_USER_ADDR_UNKNOWN,
+            variant: blaze_user_addr_meta_variant {
+                unknown: ManuallyDrop::new(blaze_user_addr_meta_unknown { _unused: 42 }),
+            },
+        };
+        assert_eq!(
+            format!("{meta:?}"),
+            "blaze_user_addr_meta { kind: BLAZE_USER_ADDR_UNKNOWN, variant: blaze_user_addr_meta_variant }",
+        );
+
+        let user_addrs = blaze_normalized_user_addrs {
+            meta_count: 0,
+            metas: ptr::null_mut(),
+            addr_count: 0,
+            addrs: ptr::null_mut(),
+        };
+        assert_eq!(
+            format!("{user_addrs:?}"),
+            "blaze_normalized_user_addrs { meta_count: 0, metas: 0x0, addr_count: 0, addrs: 0x0 }",
+        );
+    }
+
     /// Check that we can convert an [`Unknown`] into a
     /// [`blaze_user_addr_meta_unknown`] and back.
     #[test]
@@ -535,16 +600,5 @@ mod tests {
 
         let elf_new = Elf::from(blaze_user_addr_meta_elf::from(elf.clone()));
         assert_eq!(elf_new, elf);
-    }
-
-    /// Check that we correctly format the debug representation of a
-    /// [`blaze_user_addr_meta_variant`].
-    #[test]
-    fn debug_meta_variant() {
-        let unknown = blaze_user_addr_meta_unknown { _unused: 0 };
-        let variant = blaze_user_addr_meta_variant {
-            unknown: ManuallyDrop::new(unknown),
-        };
-        assert_eq!(format!("{variant:?}"), "blaze_user_addr_meta_variant");
     }
 }

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -534,6 +534,79 @@ mod tests {
     use super::*;
 
 
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let elf = blaze_symbolize_src_elf { path: ptr::null() };
+        assert_eq!(format!("{elf:?}"), "blaze_symbolize_src_elf { path: 0x0 }");
+
+        let kernel = blaze_symbolize_src_kernel {
+            kallsyms: ptr::null(),
+            kernel_image: ptr::null(),
+        };
+        assert_eq!(
+            format!("{kernel:?}"),
+            "blaze_symbolize_src_kernel { kallsyms: 0x0, kernel_image: 0x0 }"
+        );
+
+        let process = blaze_symbolize_src_process { pid: 1337 };
+        assert_eq!(
+            format!("{process:?}"),
+            "blaze_symbolize_src_process { pid: 1337 }"
+        );
+
+        let gsym_data = blaze_symbolize_src_gsym_data {
+            data: ptr::null(),
+            data_len: 0,
+        };
+        assert_eq!(
+            format!("{gsym_data:?}"),
+            "blaze_symbolize_src_gsym_data { data: 0x0, data_len: 0 }"
+        );
+
+        let gsym_file = blaze_symbolize_src_gsym_file { path: ptr::null() };
+        assert_eq!(
+            format!("{gsym_file:?}"),
+            "blaze_symbolize_src_gsym_file { path: 0x0 }"
+        );
+
+        let sym = blaze_sym {
+            symbol: ptr::null(),
+            addr: 0x1337,
+            path: ptr::null(),
+            line: 42,
+            column: 1,
+        };
+        assert_eq!(
+            format!("{sym:?}"),
+            "blaze_sym { symbol: 0x0, addr: 4919, path: 0x0, line: 42, column: 1 }"
+        );
+
+        let entry = blaze_entry {
+            size: 0,
+            syms: ptr::null(),
+        };
+        assert_eq!(format!("{entry:?}"), "blaze_entry { size: 0, syms: 0x0 }");
+
+        let result = blaze_result {
+            size: 0,
+            entries: [],
+        };
+        assert_eq!(
+            format!("{result:?}"),
+            "blaze_result { size: 0, entries: [] }"
+        );
+
+        let opts = blaze_symbolizer_opts {
+            debug_syms: true,
+            src_location: false,
+        };
+        assert_eq!(
+            format!("{opts:?}"),
+            "blaze_symbolizer_opts { debug_syms: true, src_location: false }"
+        );
+    }
+
     /// Check that we can convert a [`blaze_symbolize_src_kernel`]
     /// reference into a [`Kernel`].
     #[test]


### PR DESCRIPTION
Code coverage is highlighting a bunch of "red" on the #[derive(Debug)] annotations on the various C API symbolize types. Add tests for them.