### PR TITLE
Use io::Result in elf::parser module

### DIFF
--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -37,6 +37,7 @@
 
 use std::io::Error;
 use std::io::ErrorKind;
+use std::io::Result;
 use std::mem::align_of;
 
 use crate::log::warn;
@@ -82,8 +83,8 @@ impl GsymContext<'_> {
     /// * `data` - is the content of a standalone GSYM.
     ///
     /// Returns a GsymContext, which includes the Header and other important tables.
-    pub fn parse_header(data: &[u8]) -> Result<GsymContext, Error> {
-        fn parse_header_impl(mut data: &[u8]) -> Option<Result<GsymContext, Error>> {
+    pub fn parse_header(data: &[u8]) -> Result<GsymContext> {
+        fn parse_header_impl(mut data: &[u8]) -> Option<Result<GsymContext>> {
             let head = data;
             let magic = data.read_u32()?;
             if magic != GSYM_MAGIC {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::io::Error;
+use std::io::Result;
 
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
@@ -17,11 +17,11 @@ where
 {
     /// Find the names and the start addresses of a symbol found for
     /// the given address.
-    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>, Error>;
+    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>>;
     /// Find the address and size of a symbol name.
-    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>, Error>;
+    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>>;
     /// Find the file name and the line number of an address.
-    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>, Error>;
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>>;
     /// Translate an address (virtual) in a process to the file offset
     /// in the object file.
     fn addr_file_off(&self, addr: Addr) -> Option<u64>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -67,7 +67,7 @@ pub(crate) unsafe fn slice_from_user_array<'t, T>(items: *const T, num_items: us
     unsafe { slice::from_raw_parts(items, num_items) }
 }
 
-pub(crate) fn fstat(fd: RawFd) -> Result<libc::stat, io::Error> {
+pub(crate) fn fstat(fd: RawFd) -> io::Result<libc::stat> {
     let mut dst = MaybeUninit::uninit();
     let rc = unsafe { libc::fstat(fd, dst.as_mut_ptr()) };
     if rc < 0 {
@@ -78,7 +78,7 @@ pub(crate) fn fstat(fd: RawFd) -> Result<libc::stat, io::Error> {
     Ok(unsafe { dst.assume_init() })
 }
 
-pub(crate) fn uname_release() -> Result<CString, io::Error> {
+pub(crate) fn uname_release() -> io::Result<CString> {
     let mut dst = MaybeUninit::uninit();
     let rc = unsafe { libc::uname(dst.as_mut_ptr()) };
     if rc < 0 {


### PR DESCRIPTION
Use the io::Result typedef instead of Result<T, io::Error> throughout the elf::parser module.