### PR TITLE
Factor out `R` typedef into `dwarf::reader` module

### DIFF
--- a/src/dwarf/mod.rs
+++ b/src/dwarf/mod.rs
@@ -1,4 +1,5 @@
 mod parser;
+mod reader;
 mod resolver;
 
 pub(crate) use self::resolver::DwarfResolver;

--- a/src/dwarf/parser.rs
+++ b/src/dwarf/parser.rs
@@ -15,22 +15,14 @@ use gimli::SectionId;
 use gimli::Unit;
 use gimli::UnitSectionOffset;
 
+use super::reader::R;
+
 use crate::elf::ElfParser;
 use crate::inspect::SymType;
 use crate::log::warn;
 use crate::Addr;
 use crate::ErrorExt as _;
 use crate::Result;
-
-
-#[cfg(target_endian = "little")]
-type Endianess = gimli::LittleEndian;
-#[cfg(target_endian = "big")]
-type Endianess = gimli::BigEndian;
-
-/// The gimli reader type we currently use. Could be made generic if
-/// need be, but we keep things simple while we can.
-type R<'dat> = EndianSlice<'dat, Endianess>;
 
 
 fn format_offset(offset: UnitSectionOffset<usize>) -> String {

--- a/src/dwarf/reader.rs
+++ b/src/dwarf/reader.rs
@@ -1,0 +1,10 @@
+use gimli::EndianSlice;
+
+#[cfg(target_endian = "little")]
+type Endianess = gimli::LittleEndian;
+#[cfg(target_endian = "big")]
+type Endianess = gimli::BigEndian;
+
+/// The gimli reader type we currently use. Could be made generic if
+/// need be, but we keep things simple while we can.
+pub(crate) type R<'dat> = EndianSlice<'dat, Endianess>;


### PR DESCRIPTION
This change moves the `R` typedef and associated functionality into the newly introduced `dwarf::reader` module.