### PR TITLE
Rename generate-bench-files feature to generate-large-test-files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,9 @@ generate-c-header = ["cbindgen", "which"]
 # Enable this feature to opt in to the generation of test files. Having test
 # files created is necessary for running tests.
 generate-test-files = ["xz2", "zip"]
-# Enable this feature to opt in to the generation of benchmark files.
-# This feature is required for some of the benchmarks. Note that git-lfs
-# needs to be installed in this case.
-generate-bench-files = ["reqwest", "xz2"]
+# Enable this feature to opt in to the generation of large benchmark
+# files (also used for regression testing).
+generate-large-test-files = ["reqwest", "xz2"]
 # Disable generation of test files. This feature takes preference over
 # `generate-test-files`.
 dont-generate-test-files = []

--- a/benches/inspect.rs
+++ b/benches/inspect.rs
@@ -33,7 +33,7 @@ pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
 where
     M: Measurement,
 {
-    if cfg!(feature = "generate-bench-files") {
+    if cfg!(feature = "generate-large-test-files") {
         group.bench_function(stringify!(inspect::lookup_dwarf), |b| b.iter(lookup_dwarf));
     }
 }

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -81,7 +81,7 @@ where
     group.bench_function(stringify!(symbolize::symbolize_process), |b| {
         b.iter(symbolize_process)
     });
-    if cfg!(feature = "generate-bench-files") {
+    if cfg!(feature = "generate-large-test-files") {
         group.bench_function(stringify!(symbolize::symbolize_dwarf), |b| {
             b.iter(symbolize_dwarf)
         });

--- a/build.rs
+++ b/build.rs
@@ -433,7 +433,7 @@ fn main() {
         prepare_test_files(crate_dir.as_ref());
     }
 
-    if cfg!(feature = "generate-bench-files") {
+    if cfg!(feature = "generate-large-test-files") {
         download_bench_files(crate_dir.as_ref());
         prepare_bench_files(crate_dir.as_ref());
     }


### PR DESCRIPTION
With upcoming changes we would like to use the kernel image that we have used only for benchmarking so far for regression testing as well. As such, the generate-bench-files switch controlling the download of said kernel image and generation of derived files is no longer aptly named. Rename it to generate-large-test-files in anticipation of the new usage.