### PR TITLE
Run all benchmarks in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,12 +52,12 @@ jobs:
       run: sudo apt-get install -y llvm-14
     - name: Check incremental rebuilds
       run: |
-        cargo check --features=generate-test-files --quiet --tests
+        cargo check --features=generate-unit-test-files --quiet --tests
         # We need another build here to have the reference `output` file
         # present. As long as we converge eventually it's probably good
         # enough...
-        cargo check --features=generate-test-files --quiet --tests
-        output=$(CARGO_LOG=cargo::core::compiler::fingerprint=info cargo check --features=generate-test-files --quiet --tests 2>&1)
+        cargo check --features=generate-unit-test-files --quiet --tests
+        output=$(CARGO_LOG=cargo::core::compiler::fingerprint=info cargo check --features=generate-unit-test-files --quiet --tests 2>&1)
         [ -z "${output}" ] || (echo "!!!! cargo check --tests rebuild was not a no-op: ${output} !!!!" && false)
   test-coverage:
     name: Test and coverage
@@ -153,7 +153,7 @@ jobs:
         toolchain: nightly
         profile: minimal
         override: true
-    - run: cargo bench --features=nightly,dont-generate-test-files
+    - run: cargo bench --features=nightly,dont-generate-unit-test-files
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest
@@ -165,7 +165,7 @@ jobs:
           profile: minimal
           components: clippy
           override: true
-      - run: cargo clippy --no-deps --bins --lib --examples --tests --features=dont-generate-test-files -- -A unknown_lints
+      - run: cargo clippy --no-deps --bins --lib --examples --tests --features=dont-generate-unit-test-files -- -A unknown_lints
   rustfmt:
     name: Check code formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,9 @@ jobs:
              (echo "!!!! CHECKED IN C HEADER IS OUTDATED !!!!" && false)
   bench:
     name: Benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    env:
+       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
@@ -153,7 +155,10 @@ jobs:
         toolchain: nightly
         profile: minimal
         override: true
-    - run: cargo bench --features=nightly,dont-generate-unit-test-files
+    - name: Install required tools
+      run: sudo apt-get install -y llvm-14
+    - uses: Swatinem/rust-cache@v2.5.1
+    - run: cargo bench --features=nightly,generate-large-test-files,dont-generate-unit-test-files
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,15 +40,15 @@ dwarf = ["gimli"]
 # include/ directory, so this feature is only necessary when APIs are
 # changed.
 generate-c-header = ["cbindgen", "which"]
-# Enable this feature to opt in to the generation of test files. Having test
-# files created is necessary for running tests.
-generate-test-files = ["xz2", "zip"]
+# Enable this feature to opt in to the generation of unit test files.
+# Having these test files created is necessary for running tests.
+generate-unit-test-files = ["xz2", "zip"]
 # Enable this feature to opt in to the generation of large benchmark
 # files (also used for regression testing).
 generate-large-test-files = ["reqwest", "xz2"]
 # Disable generation of test files. This feature takes preference over
-# `generate-test-files`.
-dont-generate-test-files = []
+# `generate-unit-test-files`.
+dont-generate-unit-test-files = []
 # Enable code paths requiring a nightly toolchain. This feature is only meant to
 # be used for testing and benchmarking purposes, not for the core library, which
 # is expected to work on stable.
@@ -75,7 +75,7 @@ tracing = {version = "0.1", default-features = false, features = ["attributes"],
 # APIs.
 addr2line = "=0.20.0"
 anyhow = "1.0.71"
-blazesym = {path = ".", features = ["generate-test-files", "tracing"]}
+blazesym = {path = ".", features = ["generate-unit-test-files", "tracing"]}
 criterion = "0.4"
 env_logger = "0.10"
 tempfile = "3.4"

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -13,8 +13,7 @@ use criterion::Criterion;
 
 fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("main");
-    group.sample_size(500);
-    group.warm_up_time(Duration::from_secs(5));
+    group.warm_up_time(Duration::from_secs(1));
     group.confidence_level(0.98);
     group.significance_level(0.02);
     inspect::benchmark(&mut group);

--- a/build.rs
+++ b/build.rs
@@ -429,7 +429,9 @@ fn prepare_bench_files(crate_root: &Path) {
 fn main() {
     let crate_dir = env!("CARGO_MANIFEST_DIR");
 
-    if cfg!(feature = "generate-test-files") && !cfg!(feature = "dont-generate-test-files") {
+    if cfg!(feature = "generate-unit-test-files")
+        && !cfg!(feature = "dont-generate-unit-test-files")
+    {
         prepare_test_files(crate_dir.as_ref());
     }
 


### PR DESCRIPTION
In the past we used Git LFS for retrieving large benchmark files and we didn't want to waste upload/download bandwidth on every CI run. In addition, we never intended to rely on CI benchmarks, for they are running in a virtualized and generally unreliable (in terms of consistent performance) environment.
Despite that, given that by now we switched to pulling said files from a GitHub hosted Git repository with commit 80f35dada75b ("Stop using Git LFS for large benchmark files"), it is still somewhat interesting to have all benchmarks run in CI, because even if the numbers are not particularly, it could be used to identify trends over time or to notice outrageous regressions more timely.
With this change we enable running of all benchmarks in CI. We cache all Rust build artifacts for this job (and only this job), to prevent it from becoming the longest running part of the overall workflow.
