### PR TITLE
Update criterion dependency to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tracing = {version = "0.1", default-features = false, features = ["attributes"],
 addr2line = "=0.20.0"
 anyhow = "1.0.71"
 blazesym = {path = ".", features = ["generate-unit-test-files", "tracing"]}
-criterion = "0.4"
+criterion = {version = "0.5.1", default-features = false, features = ["rayon", "cargo_bench_support"]}
 env_logger = "0.10"
 tempfile = "3.4"
 test-log = {version = "0.2", default-features = false, features = ["trace"]}


### PR DESCRIPTION
Update the criterion dependency that we rely on to version 0.5, to get the latest and greatest.