### PR TITLE
Adjust mtime of downloaded files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -396,12 +396,9 @@ fn download_bench_files(crate_root: &Path) {
     let large_file_url =
         Url::parse("https://github.com/danielocfb/blazesym-data/raw/main/").unwrap();
     let file = "vmlinux-5.17.12-100.fc34.x86_64.xz";
-
-    download_multi_part(
-        &large_file_url.join(file).unwrap(),
-        2,
-        &crate_root.join("data").join(file),
-    );
+    let dst = crate_root.join("data").join(file);
+    let () = download_multi_part(&large_file_url.join(file).unwrap(), 2, &dst);
+    let () = adjust_mtime(&dst).unwrap();
 }
 
 #[cfg(not(feature = "reqwest"))]


### PR DESCRIPTION
Since commit c0c3afb38d67 ("Eliminate unnecessary rebuilds in build script") we started adjusting the mtime of generated files, in an attempt to prevent unnecessary rebuilds from occurring. Since then we have added supported for downloading large test files, but the corresponding code does not sport such an mtime adjustment. Add it, to prevent rebuilds when using the generate-large-test-files feature.