### PR TITLE
Properly align benchmark output

### DIFF
--- a/benches/inspect.rs
+++ b/benches/inspect.rs
@@ -34,6 +34,6 @@ where
     M: Measurement,
 {
     if cfg!(feature = "generate-large-test-files") {
-        group.bench_function(stringify!(inspect::lookup_dwarf), |b| b.iter(lookup_dwarf));
+        bench_fn!(group, lookup_dwarf);
     }
 }

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,5 +1,14 @@
 #![allow(clippy::let_and_return, clippy::let_unit_value)]
 
+macro_rules! bench_fn {
+    ($group:expr, $bench_fn:ident) => {
+        $group.bench_function(crate::bench_fn_name(stringify!($bench_fn)), |b| {
+            b.iter($bench_fn)
+        });
+    };
+}
+
+
 mod inspect;
 mod normalize;
 mod symbolize;
@@ -9,6 +18,14 @@ use std::time::Duration;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
+
+
+const BENCH_NAME_WIDTH: usize = 42;
+
+
+fn bench_fn_name(name: &str) -> String {
+    format!("{name:<width$}", width = BENCH_NAME_WIDTH)
+}
 
 
 fn benchmark(c: &mut Criterion) {

--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -30,7 +30,5 @@ pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
 where
     M: Measurement,
 {
-    group.bench_function(stringify!(normalize::normalize_process), |b| {
-        b.iter(normalize_process)
-    });
+    bench_fn!(group, normalize_process);
 }

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -78,15 +78,9 @@ pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
 where
     M: Measurement,
 {
-    group.bench_function(stringify!(symbolize::symbolize_process), |b| {
-        b.iter(symbolize_process)
-    });
+    bench_fn!(group, symbolize_process);
     if cfg!(feature = "generate-large-test-files") {
-        group.bench_function(stringify!(symbolize::symbolize_dwarf), |b| {
-            b.iter(symbolize_dwarf)
-        });
-        group.bench_function(stringify!(symbolize::symbolize_gsym), |b| {
-            b.iter(symbolize_gsym)
-        });
+        bench_fn!(group, symbolize_dwarf);
+        bench_fn!(group, symbolize_gsym);
     }
 }


### PR DESCRIPTION
Unfortunately criterion with the bencher output format does not align benchmark results properly ([0]). As a result it is quite hard to read the summary from a glimpse.
To work around this problem, this change "manually" adjusts the names of our benchmark functions so that the corresponding results in the summary report are aligned properly.

[0]: https://github.com/bheisler/criterion.rs/issues/704