### PR TITLE
Add more benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Added additional end-to-end benchmarks
+  - Added benchmark result summary to CI runs
+
+
 0.2.0-alpha.3
 -------------
 - Introduced custom `Error` type instead of relying solely on

--- a/benches/inspect.rs
+++ b/benches/inspect.rs
@@ -8,12 +8,33 @@ use criterion::measurement::Measurement;
 use criterion::BenchmarkGroup;
 
 
+/// Lookup an address in an ELF file, end-to-end, i.e., including all
+/// necessary setup.
+fn lookup_elf() {
+    let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("vmlinux-5.17.12-100.fc34.x86_64.elf");
+    let src = inspect::Source::Elf(inspect::Elf::new(dwarf_vmlinux));
+
+    let inspector = Inspector::new();
+    let results = inspector
+        .lookup(black_box(&["abort_creds"]), black_box(&src))
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
+
+    let result = results.first().unwrap();
+    assert_eq!(result.addr, 0xffffffff8110ecb0);
+}
+
 /// Lookup an address in a DWARF file, end-to-end, i.e., including all necessary
 /// setup.
 fn lookup_dwarf() {
     let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("vmlinux-5.17.12-100.fc34.x86_64");
+        .join("vmlinux-5.17.12-100.fc34.x86_64.dwarf");
     let src = inspect::Source::Elf(inspect::Elf::new(dwarf_vmlinux));
 
     let inspector = Inspector::new();
@@ -35,5 +56,6 @@ where
 {
     if cfg!(feature = "generate-large-test-files") {
         bench_fn!(group, lookup_dwarf);
+        bench_fn!(group, lookup_elf);
     }
 }


### PR DESCRIPTION
This change adds two more benchmarks to our suite. The first one measures symbolization time using the ELF symbolizer and the second one using the DWARF symbolizer, but without querying line information. Compared to before, we make sure to actually generate an ELF file without DWARF information and a DWARF file without ELF symbols, respectively.