### PR TITLE
Add DWARF regression test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Test and gather coverage
-      run: cargo llvm-cov --all-targets --lcov --output-path lcov.info
+      run: cargo llvm-cov --all-targets --features=generate-large-test-files --lcov --output-path lcov.info
     - name: Upload code coverage results
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
In the past (read: before commit 449db8bd00ef ("Add addr2line-based DWARF parsing logic")) we were unable to symbolize the abort_creds in our kernel test image correctly.
With this commit landed, this change adds a test making sure that we do not regress.