### PR TITLE
Add support for demangling symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Unreleased
 ----------
+- Added support for automatic demangling of symbols, controlled by
+  `demangle` feature (at compile time) and corresponding flag in
+  `symbolize::Builder` (at runtime)
 - Renamed `symbolize::SymbolizedResult` to `Sym` and made it
   non-exhaustive
   - Renamed `Sym::symbol` to `name`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,11 @@ name = "blazesym"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [features]
-default = ["dwarf", "lru"]
+default = ["demangle", "dwarf", "lru"]
 # Enable this feature to enable DWARF support.
 dwarf = ["gimli"]
+# Enable this feature to get transparent symbol demangling.
+demangle = ["cpp_demangle", "rustc-demangle"]
 # Enable this feature to re-generate the library's C header file. An
 # up-to-date version of this header should already be available in the
 # include/ directory, so this feature is only necessary when APIs are
@@ -71,9 +73,11 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-libc = "0.2.137"
+cpp_demangle = {version = "0.4", optional = true}
 gimli = {version = "0.27.2", optional = true}
+libc = "0.2.137"
 lru = {version = "0.10", optional = true}
+rustc-demangle = {version = "0.1", optional = true}
 tracing = {version = "0.1", default-features = false, features = ["attributes"], optional = true}
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here is rough roadmap of currently planned features (in no particular order):
     - [ ] Support inlined function lookup (https://github.com/libbpf/blazesym/issues/192)
 - [x] Support symbolization of addresses in APKs (relevant for Android) (https://github.com/libbpf/blazesym/pull/222 & https://github.com/libbpf/blazesym/pull/227)
 - [ ] Support ELF32 binaries (https://github.com/libbpf/blazesym/issues/53)
-- [ ] Support demangling of Rust & C++ symbol names (https://github.com/libbpf/blazesym/issues/50)
+- [x] Support demangling of Rust & C++ symbol names (https://github.com/libbpf/blazesym/issues/50)
 - [ ] Support remote symbolization (https://github.com/libbpf/blazesym/issues/61)
   - [x] Add APIs for address normalization (https://github.com/libbpf/blazesym/pull/114, https://github.com/libbpf/blazesym/pull/128, ...)
 - [ ] Support advanced symbolization use cases involving [`debuginfod`](https://sourceware.org/elfutils/Debuginfod.html) (https://github.com/libbpf/blazesym/issues/203)

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -241,6 +241,14 @@ typedef struct blaze_symbolizer_opts {
    * This setting implies `debug_syms` (and forces it to `true`).
    */
   bool src_location;
+  /**
+   * Whether or not to transparently demangle symbols.
+   *
+   * Demangling happens on a best-effort basis. Currently supported
+   * languages are Rust and C++ and the flag will have no effect if
+   * the underlying language does not mangle symbols (such as C).
+   */
+  bool demangle;
 } blaze_symbolizer_opts;
 
 /**

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -238,6 +238,12 @@ pub struct blaze_symbolizer_opts {
     ///
     /// This setting implies `debug_syms` (and forces it to `true`).
     pub src_location: bool,
+    /// Whether or not to transparently demangle symbols.
+    ///
+    /// Demangling happens on a best-effort basis. Currently supported
+    /// languages are Rust and C++ and the flag will have no effect if
+    /// the underlying language does not mangle symbols (such as C).
+    pub demangle: bool,
 }
 
 
@@ -262,11 +268,13 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
     let blaze_symbolizer_opts {
         debug_syms,
         src_location,
+        demangle,
     } = opts;
 
     let symbolizer = Symbolizer::builder()
         .enable_debug_syms(*debug_syms)
         .enable_src_location(*src_location)
+        .enable_demangling(*demangle)
         .build();
     let symbolizer_box = Box::new(symbolizer);
     Box::into_raw(symbolizer_box)
@@ -599,10 +607,11 @@ mod tests {
         let opts = blaze_symbolizer_opts {
             debug_syms: true,
             src_location: false,
+            demangle: true,
         };
         assert_eq!(
             format!("{opts:?}"),
-            "blaze_symbolizer_opts { debug_syms: true, src_location: false }"
+            "blaze_symbolizer_opts { debug_syms: true, src_location: false, demangle: true }"
         );
     }
 

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -17,6 +17,7 @@ use crate::inspect::SymInfo;
 use crate::inspect::SymType;
 use crate::Addr;
 use crate::Error;
+use crate::IntSym;
 use crate::Result;
 
 use super::reader;
@@ -96,7 +97,7 @@ impl DwarfResolver {
     }
 
     /// Lookup the symbol(s) at an address.
-    pub(crate) fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>, Error> {
+    pub(crate) fn find_syms(&self, addr: Addr) -> Result<Vec<IntSym<'_>>, Error> {
         // TODO: This conditional logic is weird and potentially
         //       unnecessary. Consider removing it or moving it higher
         //       in the call chain.
@@ -117,7 +118,8 @@ impl DwarfResolver {
                 .range
                 .map(|range| range.begin as usize)
                 .unwrap_or(0);
-            Ok(vec![(name, addr)])
+            let sym = IntSym { name, addr };
+            Ok(vec![sym])
         } else {
             Ok(Vec::new())
         }

--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -152,4 +152,10 @@ impl<'dwarf> Unit<'dwarf> {
         }
         Ok(None)
     }
+
+    /// Attempt to retrieve the compilation unit's source code language.
+    #[inline]
+    pub(super) fn language(&self) -> Option<gimli::DwLang> {
+        self.lang
+    }
 }

--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -43,6 +43,7 @@ pub(super) struct UnitRange {
 
 pub(super) struct Unit<'dwarf> {
     dw_unit: gimli::Unit<R<'dwarf>>,
+    lang: Option<gimli::DwLang>,
     lines: LazyCell<Result<Lines<'dwarf>, gimli::Error>>,
     funcs: LazyCell<Result<Functions<'dwarf>, gimli::Error>>,
 }
@@ -50,10 +51,12 @@ pub(super) struct Unit<'dwarf> {
 impl<'dwarf> Unit<'dwarf> {
     pub(super) fn new(
         unit: gimli::Unit<R<'dwarf>>,
+        lang: Option<gimli::DwLang>,
         lines: LazyCell<Result<Lines<'dwarf>, gimli::Error>>,
     ) -> Self {
         Self {
             dw_unit: unit,
+            lang,
             lines,
             funcs: LazyCell::new(),
         }

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -93,6 +93,7 @@ impl<'dwarf> Units<'dwarf> {
                 )
             })?;
 
+            let mut lang = None;
             let mut have_unit_range = false;
             {
                 let mut entries = dw_unit.entries_raw(None)?;
@@ -124,6 +125,11 @@ impl<'dwarf> Units<'dwarf> {
                         gimli::DW_AT_ranges => {
                             ranges.ranges_offset =
                                 sections.attr_ranges_offset(&dw_unit, attr.value())?;
+                        }
+                        gimli::DW_AT_language => {
+                            if let gimli::AttributeValue::Language(val) = attr.value() {
+                                lang = Some(val);
+                            }
                         }
                         _ => {}
                     }
@@ -200,7 +206,7 @@ impl<'dwarf> Units<'dwarf> {
                 }
             }
 
-            res_units.push(Unit::new(dw_unit, lines))
+            res_units.push(Unit::new(dw_unit, lang, lines))
         }
 
         // Sort this for faster lookup in `find_unit_and_address` below.

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -295,12 +295,15 @@ impl<'dwarf> Units<'dwarf> {
             })
     }
 
-    pub fn find_function(&self, probe: u64) -> Result<Option<&Function<'dwarf>>, gimli::Error> {
+    pub fn find_function(
+        &self,
+        probe: u64,
+    ) -> Result<Option<(&Function<'dwarf>, Option<gimli::DwLang>)>, gimli::Error> {
         let units_iter = self.find_units(probe);
         for unit in units_iter {
             let result = unit.find_function_or_location(probe, &self.dwarf)?;
             match result {
-                (Some(function), _) => return Ok(Some(function)),
+                (Some(function), _) => return Ok(Some((function, unit.language()))),
                 (None, Some(_location)) => {
                     // We found the address in the unit, we just couldn't get
                     // any symbol information.

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -8,6 +8,7 @@ use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::symbolize::AddrLineInfo;
 use crate::Addr;
+use crate::IntSym;
 use crate::Result;
 use crate::SymResolver;
 
@@ -54,14 +55,14 @@ impl ElfResolver {
 
 impl SymResolver for ElfResolver {
     #[cfg_attr(feature = "tracing", crate::log::instrument)]
-    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>> {
+    fn find_syms(&self, addr: Addr) -> Result<Vec<IntSym<'_>>> {
         let parser = self.get_parser();
-        if let Some((name, start_addr)) = parser.find_sym(addr, STT_FUNC)? {
+        if let Some((name, addr)) = parser.find_sym(addr, STT_FUNC)? {
             // We found the address in ELF.
             // TODO: Long term we probably want a different heuristic here, as
             //       there can be valid differences between the two formats
             //       (e.g., DWARF could contain more symbols).
-            return Ok(vec![(name, start_addr)])
+            return Ok(vec![IntSym { name, addr }])
         }
 
         match &self.backend {

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -10,6 +10,7 @@ use crate::symbolize::AddrLineInfo;
 use crate::Addr;
 use crate::IntSym;
 use crate::Result;
+use crate::SrcLang;
 use crate::SymResolver;
 
 use super::cache::ElfBackend;
@@ -58,11 +59,13 @@ impl SymResolver for ElfResolver {
     fn find_syms(&self, addr: Addr) -> Result<Vec<IntSym<'_>>> {
         let parser = self.get_parser();
         if let Some((name, addr)) = parser.find_sym(addr, STT_FUNC)? {
+            // ELF does not carry any source code language information.
+            let lang = SrcLang::Unknown;
             // We found the address in ELF.
             // TODO: Long term we probably want a different heuristic here, as
             //       there can be valid differences between the two formats
             //       (e.g., DWARF could contain more symbols).
-            return Ok(vec![IntSym { name, addr }])
+            return Ok(vec![IntSym { name, addr, lang }])
         }
 
         match &self.backend {

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -14,6 +14,7 @@ use crate::symbolize::AddrLineInfo;
 use crate::Addr;
 use crate::IntSym;
 use crate::Result;
+use crate::SrcLang;
 use crate::SymResolver;
 
 use super::linetab::run_op;
@@ -96,7 +97,13 @@ impl SymResolver for GsymResolver<'_> {
                     format!("failed to read string table entry at offset {}", info.name),
                 )
             })?;
-            let sym = IntSym { name, addr: found };
+            // Gsym does not carry any source code language information.
+            let lang = SrcLang::Unknown;
+            let sym = IntSym {
+                name,
+                addr: found,
+                lang,
+            };
 
             Ok(vec![sym])
         } else {

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -12,6 +12,7 @@ use crate::inspect::SymInfo;
 use crate::mmap::Mmap;
 use crate::symbolize::AddrLineInfo;
 use crate::Addr;
+use crate::IntSym;
 use crate::Result;
 use crate::SymResolver;
 
@@ -71,7 +72,7 @@ impl<'dat> GsymResolver<'dat> {
 }
 
 impl SymResolver for GsymResolver<'_> {
-    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>> {
+    fn find_syms(&self, addr: Addr) -> Result<Vec<IntSym<'_>>> {
         if let Some(idx) = self.ctx.find_addr(addr) {
             let found = self.ctx.addr_at(idx).ok_or_else(|| {
                 Error::new(
@@ -95,8 +96,9 @@ impl SymResolver for GsymResolver<'_> {
                     format!("failed to read string table entry at offset {}", info.name),
                 )
             })?;
+            let sym = IntSym { name, addr: found };
 
-            Ok(vec![(name, found)])
+            Ok(vec![sym])
         } else {
             Ok(Vec::new())
         }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -11,6 +11,7 @@ use crate::ksym::KSymResolver;
 use crate::symbolize::AddrLineInfo;
 use crate::Addr;
 use crate::Error;
+use crate::IntSym;
 use crate::Result;
 use crate::SymResolver;
 
@@ -39,7 +40,7 @@ impl KernelResolver {
 }
 
 impl SymResolver for KernelResolver {
-    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>> {
+    fn find_syms(&self, addr: Addr) -> Result<Vec<IntSym<'_>>> {
         if let Some(ksym_resolver) = self.ksym_resolver.as_ref() {
             ksym_resolver.find_syms(addr)
         } else {

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -17,6 +17,7 @@ use crate::symbolize::AddrLineInfo;
 use crate::Addr;
 use crate::IntSym;
 use crate::Result;
+use crate::SrcLang;
 use crate::SymResolver;
 
 pub const KALLSYMS: &str = "/proc/kallsyms";
@@ -31,7 +32,13 @@ pub struct Ksym {
 impl<'ksym> From<&'ksym Ksym> for IntSym<'ksym> {
     fn from(other: &'ksym Ksym) -> Self {
         let Ksym { name, addr } = other;
-        IntSym { name, addr: *addr }
+        IntSym {
+            name,
+            addr: *addr,
+            // Kernel symbols don't carry any source code language
+            // information.
+            lang: SrcLang::Unknown,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ use std::fmt::Result as FmtResult;
 use std::num::NonZeroU32;
 use std::result;
 
+use resolver::IntSym;
 use resolver::SymResolver;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ use std::num::NonZeroU32;
 use std::result;
 
 use resolver::IntSym;
+use resolver::SrcLang;
 use resolver::SymResolver;
 
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -7,12 +7,27 @@ use crate::Addr;
 use crate::Result;
 
 
+/// The source code language from which a symbol originates.
+#[derive(Clone, Copy, Default, Debug)]
+pub(crate) enum SrcLang {
+    /// The language is unknown.
+    #[default]
+    Unknown,
+    /// The language is C++.
+    Cpp,
+    /// The language is Rust.
+    Rust,
+}
+
+
 /// Our internal representation of a symbol.
 pub(crate) struct IntSym<'src> {
     /// The name of the symbol.
     pub(crate) name: &'src str,
     /// The symbol's normalized address.
     pub(crate) addr: Addr,
+    /// The source code language from which the symbol originates.
+    pub(crate) lang: SrcLang,
 }
 
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -7,6 +7,15 @@ use crate::Addr;
 use crate::Result;
 
 
+/// Our internal representation of a symbol.
+pub(crate) struct IntSym<'src> {
+    /// The name of the symbol.
+    pub(crate) name: &'src str,
+    /// The symbol's normalized address.
+    pub(crate) addr: Addr,
+}
+
+
 /// The trait of symbol resolvers.
 ///
 /// An symbol resolver usually provides information from one symbol
@@ -17,7 +26,7 @@ where
 {
     /// Find the names and the start addresses of a symbol found for
     /// the given address.
-    fn find_syms(&self, addr: Addr) -> Result<Vec<(&str, Addr)>>;
+    fn find_syms(&self, addr: Addr) -> Result<Vec<IntSym<'_>>>;
     /// Find the address and size of a symbol name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>>;
     /// Find the file name and the line number of an address.

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -166,7 +166,11 @@ impl Symbolizer {
             let mut results = vec![];
             for sym in syms {
                 if let Some(ref linfo) = linfo {
-                    let IntSym { name, addr } = sym;
+                    let IntSym {
+                        name,
+                        addr,
+                        lang: _lang,
+                    } = sym;
                     results.push(Sym {
                         name: String::from(name),
                         addr,
@@ -176,7 +180,11 @@ impl Symbolizer {
                         _non_exhaustive: (),
                     });
                 } else {
-                    let IntSym { name, addr } = sym;
+                    let IntSym {
+                        name,
+                        addr,
+                        lang: _lang,
+                    } = sym;
                     results.push(Sym {
                         name: String::from(name),
                         addr,

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -23,6 +23,7 @@ use crate::util;
 use crate::util::uname_release;
 use crate::Addr;
 use crate::ErrorExt as _;
+use crate::IntSym;
 use crate::Pid;
 use crate::Result;
 use crate::SymResolver;
@@ -165,20 +166,20 @@ impl Symbolizer {
             let mut results = vec![];
             for sym in syms {
                 if let Some(ref linfo) = linfo {
-                    let (sym, start) = sym;
+                    let IntSym { name, addr } = sym;
                     results.push(Sym {
-                        name: String::from(sym),
-                        addr: start,
+                        name: String::from(name),
+                        addr,
                         path: linfo.path.clone(),
                         line: linfo.line,
                         column: linfo.column,
                         _non_exhaustive: (),
                     });
                 } else {
-                    let (sym, start) = sym;
+                    let IntSym { name, addr } = sym;
                     results.push(Sym {
-                        name: String::from(sym),
-                        addr: start,
+                        name: String::from(name),
+                        addr,
                         path: PathBuf::new(),
                         line: 0,
                         column: 0,

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -76,6 +76,12 @@ pub struct Builder {
     /// This setting implies usage of debug symbols and forces the corresponding
     /// flag to `true`.
     src_location: bool,
+    /// Whether or not to transparently demangle symbols.
+    ///
+    /// Demangling happens on a best-effort basis. Currently supported
+    /// languages are Rust and C++ and the flag will have no effect if
+    /// the underlying language does not mangle symbols (such as C).
+    demangle: bool,
 }
 
 impl Builder {
@@ -93,11 +99,20 @@ impl Builder {
         self
     }
 
+    /// Enable/disable usage of debug symbols.
+    ///
+    /// That can be useful in cases where ELF symbol information is stripped.
+    pub fn enable_demangling(mut self, enable: bool) -> Builder {
+        self.demangle = enable;
+        self
+    }
+
     /// Create the [`Symbolizer`] object.
     pub fn build(self) -> Symbolizer {
         let Builder {
             debug_syms,
             src_location,
+            demangle,
         } = self;
         let ksym_cache = KSymCache::new();
         let elf_cache = ElfCache::new(src_location, debug_syms);
@@ -115,6 +130,7 @@ impl Default for Builder {
         Self {
             src_location: true,
             debug_syms: true,
+            demangle: true,
         }
     }
 }

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -50,6 +50,7 @@ fn symbolizer_creation_with_opts() {
     let opts = blaze_symbolizer_opts {
         debug_syms: true,
         src_location: false,
+        demangle: true,
     };
     let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };
     let () = unsafe { blaze_symbolizer_free(symbolizer) };


### PR DESCRIPTION
This PR adds support for transparent demangling of symbols. Demangling is generally runtime configurable (via the previously added Builder flag), but because it involves additional dependencies there is also the option to disable it at compile time. If disabled at compile time, the runtime option becomes a no-op.
Demangling currently happens in a single location inside the Symbolizer type. This has the advantage of concentrating the feature's implementation. However, it means that we need to bubble up the inferred language from all resolvers -- something that the recently added IntSym type helps us with.
