### PR TITLE
Expose build ID reading functionality publicly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -292,7 +292,7 @@ fn prepare_test_files(crate_root: &Path) {
     cc(
         &src,
         "libtest-so-no-separate-code.so",
-        &["-shared", "-fPIC", "-Wl,--build-id=sha1,-z,noseparate-code"],
+        &["-shared", "-fPIC", "-Wl,--build-id=md5,-z,noseparate-code"],
     );
 
     let src = crate_root.join("data").join("test-exe.c");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,12 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 pub type Addr = usize;
 
 
+/// Utility functionality not specific to any overarching theme.
+pub mod helper {
+    pub use crate::normalize::buildid::read_elf_build_id;
+}
+
+
 /// An enumeration identifying a process.
 #[derive(Clone, Copy, Debug)]
 pub enum Pid {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -30,7 +30,7 @@
 //! );
 //! ```
 
-mod buildid;
+pub(crate) mod buildid;
 mod meta;
 mod normalizer;
 mod user;


### PR DESCRIPTION
Being able to read build IDs from arbitrary ELF files may be necessary in order to better work with the results of the normalization APIs, for example, when attempting to look up a file by the reported build ID. As such, it makes sense to export this functionality publicly. With this change we do just that, inside the newly introduced helper module. While at it, also add a test for md5 build IDs.