### PR TITLE
Fix maps_file path creation for low addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 - Added additional end-to-end benchmarks
   - Added benchmark result summary to CI runs
+- Fixed spurious maps file path creation for low addresses as part of
+  normalization/symbolization
 - Introduced `helper` module exposing `read_elf_build_id` function
 
 


### PR DESCRIPTION
As it turns out, when low addresses are reported inside `/proc/[pid]/maps` they may get prefixed with '0' characters in the reported range. However, this range is not actually what can be looked up below `/proc/self/map_files/`: there these leading zeroes are removed instead. So far we deliberately treated the range *as a string* to *not* have to deal with any mismatches, but this turns out to be the wrong approach. Hence, with this change we create the maps file path based on the parsed range, which takes care of removing any leading zeroes.