### PR TITLE
Replace env::args().next() with env::current_exec()

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -193,6 +193,7 @@ impl Debug for DwarfResolver {
 mod tests {
     use super::*;
 
+    use std::env::current_exe;
     use std::path::PathBuf;
 
     use test_log::test;
@@ -203,7 +204,7 @@ mod tests {
     /// Exercise the `Debug` representation of various types.
     #[test]
     fn debug_repr() {
-        let bin_name = PathBuf::from(env::args().next().unwrap());
+        let bin_name = current_exe().unwrap();
         let resolver = DwarfResolver::open(&bin_name, true, true).unwrap();
         assert_ne!(format!("{resolver:?}"), "");
     }

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -422,7 +422,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_function_parsing(b: &mut Bencher) {
-        let bin_name = env::args().next().unwrap();
+        let bin_name = current_exe().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let mut load_section = |section| reader::load_section(&parser, section);
 
@@ -438,7 +438,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_function_parsing_addr2line(b: &mut Bencher) {
-        let bin_name = env::args().next().unwrap();
+        let bin_name = current_exe().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let mut load_section = |section| reader::load_section(&parser, section);
 
@@ -453,7 +453,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_line_parsing(b: &mut Bencher) {
-        let bin_name = env::args().next().unwrap();
+        let bin_name = current_exe().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let mut load_section = |section| reader::load_section(&parser, section);
 
@@ -469,7 +469,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_line_parsing_addr2line(b: &mut Bencher) {
-        let bin_name = env::args().next().unwrap();
+        let bin_name = current_exe().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let mut load_section = |section| reader::load_section(&parser, section);
 


### PR DESCRIPTION
Replace the usage of `env::args().next()` with `env::current_exec()`, which is more telling and easier to search for.