### PR TITLE
Report ELF symbols with bogus size if only conceivable match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Unreleased
   - Added benchmark result summary to CI runs
 - Fixed spurious maps file path creation for low addresses as part of
   normalization/symbolization
+- Improved symbolization of addresses in ELF files with potentially
+  bogus symbol sizes
 - Introduced `blazecli` command line interface for the library
 - Introduced `helper` module exposing `read_elf_build_id` function
 

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -88,12 +88,6 @@ impl Elf64_Sym {
     pub fn type_(&self) -> u8 {
         self.st_info & 0xf
     }
-
-    /// Check whether this symbols contains the provided address.
-    pub fn contains(&self, addr: Elf64_Addr) -> bool {
-        (self.st_size == 0 && self.st_value == addr)
-            || (self.st_size != 0 && (self.st_value..self.st_value + self.st_size).contains(&addr))
-    }
 }
 
 // SAFETY: `Elf64_Sym` is valid for any bit pattern.


### PR DESCRIPTION
Starting with commit 1b6878918160 ("Use lowest match search in ElfParser::find_sym()") we honored the symbol's size when attempting to symbolize an address based on ELF information. However, it turns out that the size may not actually be reliable information: we have seen cases where a function was reported as much smaller than the actual code that it comprised at runtime (the addresses of which could show up in backtraces). Whether that is due to runtime linker tricks or other shenanigans, we should be able to handle such cases.
With this change we adjust the ELF parser symbol lookup logic to handle such cases more gracefully. Specifically, if an address falls between two symbols such as `0x29d90` in:

```
  0000000000029d00 <__libc_init_first>
     29d00:       f3 0f 1e fa             endbr64
     29d04:       c3                      ret
     29d05:       66 2e 0f 1f 84 00 00    cs nopw 0x0(%rax,%rax,1)

     [ more code that according to ELF does not belong to __libc_init_first ]

  0000000000029dc0 <__libc_start_main>
     29dc0:       f3 0f 1e fa             endbr64
     29dc4:       41 57                   push   %r15
     29dc6:       49 89 cf                mov    %rcx,%r15
```

We map it to the only possible match -- `__libc_init_first` in this case.
