### PR TITLE
Fix nightly benchmark builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,6 +159,7 @@ jobs:
       run: sudo apt-get install -y llvm-14
     - uses: Swatinem/rust-cache@v2.5.1
     - name: Run benchmarks
+      shell: bash
       run: |
         echo '```' >> $GITHUB_STEP_SUMMARY
         cargo bench --features=nightly -- bench_ | tee --append $GITHUB_STEP_SUMMARY

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -422,7 +422,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_function_parsing(b: &mut Bencher) {
-        let bin_name = current_exe().unwrap();
+        let bin_name = env::current_exe().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let mut load_section = |section| reader::load_section(&parser, section);
 
@@ -438,7 +438,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_function_parsing_addr2line(b: &mut Bencher) {
-        let bin_name = current_exe().unwrap();
+        let bin_name = env::current_exe().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let mut load_section = |section| reader::load_section(&parser, section);
 
@@ -453,7 +453,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_line_parsing(b: &mut Bencher) {
-        let bin_name = current_exe().unwrap();
+        let bin_name = env::current_exe().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let mut load_section = |section| reader::load_section(&parser, section);
 
@@ -469,7 +469,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_line_parsing_addr2line(b: &mut Bencher) {
-        let bin_name = current_exe().unwrap();
+        let bin_name = env::current_exe().unwrap();
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let mut load_section = |section| reader::load_section(&parser, section);
 


### PR DESCRIPTION
Commit cdd5b9c1a057 ("Replace env::args().next() with env::current_exec()") broke the nightly benchmarks and that was not caught because...GitHub Actions uses some more than questionable defaults for the default shell, which supposedly is bash, but it is invoked with fewer error reporting options than if we explicitly asked for it [0]. Make. It. Stop.
Explicitly specify the shell and fix the build.

[0] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell