### PR TITLE
cli: Add support for symbolizing ELF addresses

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Context as _;
 use anyhow::Result;
 
@@ -54,7 +56,22 @@ pub enum Command {
 /// An type representing the `backup` command.
 #[derive(Debug, Subcommand)]
 pub enum Symbolize {
+    Elf(Elf),
     Process(Process),
+}
+
+#[derive(Debug, Arguments)]
+pub struct Elf {
+    /// The path to the ELF file.
+    #[clap(short, long)]
+    pub path: PathBuf,
+    /// The addresses to symbolize.
+    ///
+    /// Addresses are assumed to already be normalized to the file
+    /// itself (i.e., with relocation and address randomization effects
+    /// removed).
+    #[arg(value_parser = parse_addr)]
+    pub addrs: Vec<Addr>,
 }
 
 #[derive(Debug, Arguments)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@ mod args;
 use anyhow::Context;
 use anyhow::Result;
 
+use blazesym::symbolize::Elf;
 use blazesym::symbolize::Process;
 use blazesym::symbolize::Source;
 use blazesym::symbolize::Sym;
@@ -22,6 +23,10 @@ use tracing_subscriber::FmtSubscriber;
 fn symbolize(symbolize: args::Symbolize) -> Result<()> {
     let symbolizer = Symbolizer::new();
     let (src, addrs) = match symbolize {
+        args::Symbolize::Elf(args::Elf { path, addrs }) => {
+            let src = Source::from(Elf::new(path));
+            (src, addrs)
+        }
         args::Symbolize::Process(args::Process { pid, addrs }) => {
             let src = Source::from(Process::new(pid));
             (src, addrs)


### PR DESCRIPTION
This change adds support for symbolizing ELF addresses to blazecli.
```
      $ cargo run -p blazecli -- symbolize elf --path /tmp/test/libc.so.6 0x29d90
      > 0x29d90: __libc_init_first@0x29d00+144 :0
```