### PR TITLE
Add workflow for building statically linked binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build statically linked binary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get install musl-tools
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: x86_64-unknown-linux-musl
+      - run: |
+          cargo install --path=cli --root=. --target x86_64-unknown-linux-musl
+          strip bin/blazecli
+      - uses: actions/upload-artifact@v3
+        with:
+          name: blazecli
+          path: bin/blazecli


### PR DESCRIPTION
Sometimes no suitable build environment is at hand but a binary of the program desired. For such cases it makes sense to have access to a statically linked binary that essentially is able to run on any Linux. This change introduces a workflow that can be used to produce such a binary. It can be triggered on-demand and will produce such a binary and make it available as a downloadable artifact.