### PR TITLE
Provide custom Debug impl for symbolize::Elf

### DIFF
--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -192,7 +192,7 @@ impl From<GsymFile> for Source<'static> {
 ///
 /// The source of symbols and debug information can be an ELF file, kernel
 /// image, or process.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub enum Source<'dat> {
     /// A single ELF file
@@ -203,6 +203,17 @@ pub enum Source<'dat> {
     Process(Process),
     /// A Gsym file.
     Gsym(Gsym<'dat>),
+}
+
+impl Debug for Source<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Elf(elf) => Debug::fmt(elf, f),
+            Self::Kernel(kernel) => Debug::fmt(kernel, f),
+            Self::Process(process) => Debug::fmt(process, f),
+            Self::Gsym(gsym) => Debug::fmt(gsym, f),
+        }
+    }
 }
 
 
@@ -216,11 +227,14 @@ mod tests {
     fn debug_repr() {
         let elf = Elf::new("/a-path/with/components.elf");
         assert_eq!(format!("{elf:?}"), "Elf(\"/a-path/with/components.elf\")");
+        let src = Source::Elf(elf);
+        assert_eq!(format!("{src:?}"), "Elf(\"/a-path/with/components.elf\")");
 
         let process = Process::new(Pid::Slf);
         assert_eq!(format!("{process:?}"), "Process(self)");
-
         let process = Process::new(Pid::from(1234));
         assert_eq!(format!("{process:?}"), "Process(1234)");
+        let src = Source::Process(process);
+        assert_eq!(format!("{src:?}"), "Process(1234)");
     }
 }

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -10,7 +10,7 @@ use super::Symbolizer;
 
 
 /// A single ELF file.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Elf {
     /// The name of ELF file.
     ///
@@ -36,6 +36,17 @@ impl Elf {
 impl From<Elf> for Source<'static> {
     fn from(elf: Elf) -> Self {
         Source::Elf(elf)
+    }
+}
+
+impl Debug for Elf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let Elf {
+            path,
+            _non_exhaustive: (),
+        } = self;
+
+        f.debug_tuple(stringify!(Elf)).field(path).finish()
     }
 }
 
@@ -200,9 +211,12 @@ mod tests {
     use super::*;
 
 
-    /// Check that the `Debug` representation of [`Entry`] is as expected.
+    /// Exercise the `Debug` representation of various types.
     #[test]
-    fn process_debug() {
+    fn debug_repr() {
+        let elf = Elf::new("/a-path/with/components.elf");
+        assert_eq!(format!("{elf:?}"), "Elf(\"/a-path/with/components.elf\")");
+
         let process = Process::new(Pid::Slf);
         assert_eq!(format!("{process:?}"), "Process(self)");
 


### PR DESCRIPTION
We may end up including symbolize::Elf objects in traces. Right now their Debug representation is very verbose, making said traces unnecessarily hard to read.
This change provides a custom Debug impl that shortens the output reasonably.

Refs: #223