### PR TITLE
Introduce symbolize::Sym::offset member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 - Renamed `symbolize::SymbolizedResult` to `Sym` and made it
   non-exhaustive
   - Renamed `Sym::symbol` to `name`
+  - Added `Sym::offset` member
   - Changed `Sym::line` to be of type `u32` and `Sym::column` to `u16`
 - Added additional end-to-end benchmarks
   - Added benchmark result summary to CI runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
   - Renamed `Sym::symbol` to `name`
   - Added `Sym::offset` member
   - Changed `Sym::line` to be of type `u32` and `Sym::column` to `u16`
+  - Made all source code location information optional
 - Added additional end-to-end benchmarks
   - Added benchmark result summary to CI runs
 - Fixed spurious maps file path creation for low addresses as part of

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -75,7 +75,7 @@ fn symbolize_dwarf_no_lines() {
 
     let result = results.first().unwrap();
     assert_eq!(result.name, "abort_creds");
-    assert_eq!(result.line, 0);
+    assert_eq!(result.line, None);
 }
 
 /// Symbolize an address in a DWARF file, end-to-end, i.e., including all
@@ -97,7 +97,7 @@ fn symbolize_dwarf() {
 
     let result = results.first().unwrap();
     assert_eq!(result.name, "abort_creds");
-    assert_eq!(result.line, 534);
+    assert_eq!(result.line, Some(534));
 }
 
 /// Symbolize an address in a GSYM file, end-to-end, i.e., including all

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -39,11 +39,15 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
         .context("failed to symbolize addresses")?;
 
     for (addr, syms) in addrs.into_iter().zip(syms) {
-        match syms.as_slice() {
-            [] => {
-                println!("0x{addr:x}: not found")
-            }
-            [sym] => {
+        let mut addr_fmt = format!("0x{addr:016x}:");
+        if syms.is_empty() {
+            println!("{addr_fmt} <no-symbol>")
+        } else {
+            for (i, sym) in syms.into_iter().enumerate() {
+                if i == 1 {
+                    addr_fmt = addr_fmt.replace(|_c| true, " ");
+                }
+
                 let Sym {
                     name,
                     addr: sym_addr,
@@ -51,28 +55,12 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
                     line,
                     ..
                 } = sym;
+
                 println!(
-                    "0x{addr:x}: {name}@0x{sym_addr:x}+{} {}:{line}",
+                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{:x} {}:{line}",
                     addr - sym_addr,
                     path.display(),
-                )
-            }
-            syms => {
-                println!("0x{addr:x}:");
-                for sym in syms {
-                    let Sym {
-                        name,
-                        addr: sym_addr,
-                        path,
-                        line,
-                        ..
-                    } = sym;
-                    println!(
-                        "\t0x{addr:x} {name}@0x{sym_addr:x}+{} {}:{line}",
-                        addr - sym_addr,
-                        path.display(),
-                    )
-                }
+                );
             }
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -51,14 +51,14 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
                 let Sym {
                     name,
                     addr: sym_addr,
+                    offset,
                     path,
                     line,
                     ..
                 } = sym;
 
                 println!(
-                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{:x} {}:{line}",
-                    addr - sym_addr,
+                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{offset:x} {}:{line}",
                     path.display(),
                 );
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -38,7 +38,7 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
         .symbolize(&src, &addrs)
         .context("failed to symbolize addresses")?;
 
-    for (addr, syms) in addrs.into_iter().zip(syms) {
+    for (addr, syms) in addrs.iter().zip(syms) {
         let mut addr_fmt = format!("0x{addr:016x}:");
         if syms.is_empty() {
             println!("{addr_fmt} <no-symbol>")
@@ -49,18 +49,20 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
                 }
 
                 let Sym {
-                    name,
-                    addr: sym_addr,
-                    offset,
-                    path,
-                    line,
-                    ..
+                    name, addr, offset, ..
                 } = sym;
 
-                println!(
-                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{offset:x} {}:{line}",
-                    path.display(),
-                );
+                let src_loc = if let (Some(path), Some(line)) = (sym.path, sym.line) {
+                    if let Some(col) = sym.column {
+                        format!(" {}:{line}:{col}", path.display())
+                    } else {
+                        format!(" {}:{line}", path.display())
+                    }
+                } else {
+                    String::new()
+                };
+
+                println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
             }
         }
     }

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
         .symbolize(&src, &[addr])
         .with_context(|| format!("failed to symbolize address 0x{addr:x}"))?;
 
-    for (addr, syms) in [addr].into_iter().zip(syms) {
+    for (addr, syms) in [addr].iter().zip(syms) {
         let mut addr_fmt = format!("0x{addr:016x}:");
         if syms.is_empty() {
             println!("{addr_fmt} <no-symbol>")
@@ -43,18 +43,20 @@ fn main() -> Result<()> {
                 }
 
                 let Sym {
-                    name,
-                    addr: sym_addr,
-                    offset,
-                    path,
-                    line,
-                    ..
+                    name, addr, offset, ..
                 } = sym;
 
-                println!(
-                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{offset:x} {}:{line}",
-                    path.display(),
-                );
+                let src_loc = if let (Some(path), Some(line)) = (sym.path, sym.line) {
+                    if let Some(col) = sym.column {
+                        format!(" {}:{line}:{col}", path.display())
+                    } else {
+                        format!(" {}:{line}", path.display())
+                    }
+                } else {
+                    String::new()
+                };
+
+                println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
             }
         }
     }

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -45,19 +45,18 @@ fn main() -> Result<()> {
                 let Sym {
                     name,
                     addr: sym_addr,
+                    offset,
                     path,
                     line,
                     ..
                 } = sym;
 
                 println!(
-                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{:x} {}:{line}",
-                    addr - sym_addr,
+                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{offset:x} {}:{line}",
                     path.display(),
                 );
             }
         }
     }
-
     Ok(())
 }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -35,7 +35,7 @@ print its symbol, the file name of the source, and the line number.",
         .symbolize(&src, &[addr])
         .with_context(|| format!("failed to symbolize address 0x{addr:x}"))?;
 
-    for (addr, syms) in [addr].into_iter().zip(syms) {
+    for (addr, syms) in [addr].iter().zip(syms) {
         let mut addr_fmt = format!("0x{addr:016x}:");
         if syms.is_empty() {
             println!("{addr_fmt} <no-symbol>")
@@ -46,18 +46,20 @@ print its symbol, the file name of the source, and the line number.",
                 }
 
                 let Sym {
-                    name,
-                    addr: sym_addr,
-                    offset,
-                    path,
-                    line,
-                    ..
+                    name, addr, offset, ..
                 } = sym;
 
-                println!(
-                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{offset:x} {}:{line}",
-                    path.display(),
-                );
+                let src_loc = if let (Some(path), Some(line)) = (sym.path, sym.line) {
+                    if let Some(col) = sym.column {
+                        format!(" {}:{line}:{col}", path.display())
+                    } else {
+                        format!(" {}:{line}", path.display())
+                    }
+                } else {
+                    String::new()
+                };
+
+                println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
             }
         }
     }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -48,19 +48,18 @@ print its symbol, the file name of the source, and the line number.",
                 let Sym {
                     name,
                     addr: sym_addr,
+                    offset,
                     path,
                     line,
                     ..
                 } = sym;
 
                 println!(
-                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{:x} {}:{line}",
-                    addr - sym_addr,
+                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{offset:x} {}:{line}",
                     path.display(),
                 );
             }
         }
     }
-
     Ok(())
 }

--- a/examples/backtrace.rs
+++ b/examples/backtrace.rs
@@ -27,35 +27,28 @@ fn symbolize_current_bt() {
 
     let bt_syms = symbolizer.symbolize(&src, bt).unwrap();
     for (addr, syms) in bt.iter().zip(bt_syms) {
-        match &syms[..] {
-            [] => println!("0x{addr:016x}: <no-symbols>"),
-            [sym] => {
+        let mut addr_fmt = format!("0x{addr:016x}:");
+        if syms.is_empty() {
+            println!("{addr_fmt} <no-symbol>")
+        } else {
+            for (i, sym) in syms.into_iter().enumerate() {
+                if i == 1 {
+                    addr_fmt = addr_fmt.replace(|_c| true, " ");
+                }
+
                 let Sym {
                     name,
-                    addr,
+                    addr: sym_addr,
                     path,
                     line,
                     ..
                 } = sym;
-                println!(
-                    "0x{addr:016x} {name} @ 0x{addr:x} {}:{line}",
-                    path.display()
-                );
-            }
-            syms => {
-                // One address may get several results.
-                println!("0x{addr:016x} ({} entries)", syms.len());
 
-                for sym in syms {
-                    let Sym {
-                        name,
-                        addr,
-                        path,
-                        line,
-                        ..
-                    } = sym;
-                    println!("    {name} @ 0x{addr:016x} {}:{line}", path.display());
-                }
+                println!(
+                    "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{:x} {}:{line}",
+                    addr - sym_addr,
+                    path.display(),
+                );
             }
         }
     }

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -263,12 +263,25 @@ typedef struct blaze_sym {
    */
   const char *name;
   /**
-   * The address (i.e.,the first byte) is where the symbol is located.
+   * The address at which the symbol is located (i.e., its "start").
    *
-   * The address is already relocated to the address space of
-   * the process.
+   * This is the "normalized" address of the symbol, as present in
+   * the file (and reported by tools such as `readelf(1)`,
+   * `llvm-gsymutil`, or similar).
    */
   uintptr_t addr;
+  /**
+   * The byte offset of the address that got symbolized from the
+   * start of the symbol (i.e., from `addr`).
+   *
+   * E.g., when normalizing address 0x1337 of a function that starts at
+   * 0x1330, the offset will be set to 0x07 (and `addr` will be 0x1330). This
+   * member is especially useful in contexts when input addresses are not
+   * already normalized, such as when normalizing an address in a process
+   * context (which may have been relocated and/or have layout randomizations
+   * applied).
+   */
+  size_t offset;
   /**
    * The path of the source file defining the symbol.
    */

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -96,7 +96,7 @@ impl DwarfResolver {
     /// object. This function returns a tuple of `(dir_name, file_name,
     /// line_no)`.
     // TODO: We likely want to return a more structured type.
-    pub fn find_line(&self, addr: Addr) -> Result<Option<(&Path, &OsStr, u32)>> {
+    pub fn find_line(&self, addr: Addr) -> Result<Option<(&Path, &OsStr, Option<u32>)>> {
         // TODO: This conditional logic is weird and potentially
         //       unnecessary. Consider removing it or moving it higher
         //       in the call chain.
@@ -104,7 +104,7 @@ impl DwarfResolver {
             let location = self.units.find_location(addr as u64)?.map(|location| {
                 let dir = location.dir;
                 let file = location.file;
-                let line = location.line.unwrap_or(0);
+                let line = location.line;
                 (dir, file, line)
             });
             Ok(location)
@@ -243,7 +243,7 @@ mod tests {
         let (dir, file, line) = resolver.find_line(0x2000100).unwrap().unwrap();
         assert_ne!(dir, PathBuf::new());
         assert_eq!(file, "test-stable-addresses.c");
-        assert_eq!(line, 8);
+        assert_eq!(line, Some(8));
     }
 
     /// Check that we can look up a symbol in DWARF debug information.

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -99,7 +99,7 @@ impl SymResolver for ElfResolver {
                 .map(|(dir, file, line)| AddrLineInfo {
                     path: dir.join(file),
                     line,
-                    column: 0,
+                    column: None,
                 });
             Ok(addr_line_info)
         } else {

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -187,8 +187,8 @@ impl SymResolver for GsymResolver<'_> {
                 let path = Path::new(dirname).join(filename);
                 return Some(AddrLineInfo {
                     path,
-                    line: lntab_row.file_line,
-                    column: 0,
+                    line: Some(lntab_row.file_line),
+                    column: None,
                 })
             }
             None
@@ -248,13 +248,13 @@ mod tests {
         // `main` resides at address 0x2000000, and it's located at the given
         // line.
         let info = resolver.find_line_info(0x2000000).unwrap().unwrap();
-        assert_eq!(info.line, 34);
+        assert_eq!(info.line, Some(34));
         assert!(info.path.ends_with("test-stable-addresses.c"));
 
         // `factorial` resides at address 0x2000100, and it's located at the
         // given line.
         let info = resolver.find_line_info(0x2000100).unwrap().unwrap();
-        assert_eq!(info.line, 8);
+        assert_eq!(info.line, Some(8));
         assert!(info.path.ends_with("test-stable-addresses.c"));
     }
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -79,6 +79,6 @@ pub use symbolizer::Symbolizer;
 
 pub(crate) struct AddrLineInfo {
     pub path: PathBuf,
-    pub line: u32,
-    pub column: u16,
+    pub line: Option<u32>,
+    pub column: Option<u16>,
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -32,23 +32,31 @@
 //! let symbolizer = Symbolizer::new();
 //!
 //! let bt_syms = symbolizer.symbolize(&src, bt).unwrap();
-//! for (addr, syms) in bt.iter().zip(bt_syms) {
-//!   match &syms[..] {
-//!     [] => println!("0x{addr:016x}: <no-symbols>"),
-//!     [sym] => {
-//!       let Sym {name, addr, path, line, ..} = sym;
-//!       println!("0x{addr:016x} {name} @ 0x{addr:x} {}:{line}", path.display());
-//!     },
-//!     syms => {
-//!       // One address may get several results.
-//!       println!("0x{addr:016x} ({} entries)", syms.len());
+//! for (addr, syms) in addrs.into_iter().zip(syms) {
+//!     let mut addr_fmt = format!("0x{addr:016x}:");
+//!     if syms.is_empty() {
+//!         println!("{addr_fmt} <no-symbol>")
+//!     } else {
+//!         for (i, sym) in syms.into_iter().enumerate() {
+//!             if i == 1 {
+//!                 addr_fmt = addr_fmt.replace(|_c| true, " ");
+//!             }
 //!
-//!       for sym in syms {
-//!         let Sym {name, addr, path, line, ..} = sym;
-//!         println!("    {name} @ 0x{addr:016x} {}:{line}", path.display());
-//!       }
-//!     },
-//!   }
+//!             let Sym {
+//!                 name,
+//!                 addr: sym_addr,
+//!                 path,
+//!                 line,
+//!                 ..
+//!             } = sym;
+//!
+//!             println!(
+//!                 "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{:x} {}:{line}",
+//!                 addr - sym_addr,
+//!                 path.display(),
+//!             );
+//!         }
+//!     }
 //! }
 //! ```
 

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -31,8 +31,8 @@
 //! let src = Source::Process(Process::new(Pid::Slf));
 //! let symbolizer = Symbolizer::new();
 //!
-//! let bt_syms = symbolizer.symbolize(&src, bt).unwrap();
-//! for (addr, syms) in addrs.into_iter().zip(syms) {
+//! let syms = symbolizer.symbolize(&src, bt).unwrap();
+//! for (addr, syms) in bt.iter().zip(syms) {
 //!     let mut addr_fmt = format!("0x{addr:016x}:");
 //!     if syms.is_empty() {
 //!         println!("{addr_fmt} <no-symbol>")
@@ -43,18 +43,20 @@
 //!             }
 //!
 //!             let Sym {
-//!                 name,
-//!                 addr: sym_addr,
-//!                 path,
-//!                 line,
-//!                 ..
+//!                 name, addr, offset, ..
 //!             } = sym;
 //!
-//!             println!(
-//!                 "{addr_fmt} {name} @ 0x{sym_addr:x}+0x{:x} {}:{line}",
-//!                 addr - sym_addr,
-//!                 path.display(),
-//!             );
+//!             let src_loc = if let (Some(path), Some(line)) = (sym.path, sym.line) {
+//!                 if let Some(col) = sym.column {
+//!                     format!(" {}:{line}:{col}", path.display())
+//!                 } else {
+//!                     format!(" {}:{line}", path.display())
+//!                 }
+//!             } else {
+//!                 String::new()
+//!             };
+//!
+//!             println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
 //!         }
 //!     }
 //! }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -90,17 +90,17 @@ pub struct Sym {
     /// applied).
     pub offset: usize,
     /// The source path that defines the symbol.
-    pub path: PathBuf,
+    pub path: Option<PathBuf>,
     /// The line number of the symbolized instruction in the source
     /// code.
     ///
     /// This is the line number of the instruction of the address being
     /// symbolized, not the line number that defines the symbol
     /// (function).
-    pub line: u32,
+    pub line: Option<u32>,
     /// The column number of the symbolized instruction in the source
     /// code.
-    pub column: u16,
+    pub column: Option<u16>,
     /// The struct is non-exhaustive and open to extension.
     pub(crate) _non_exhaustive: (),
 }
@@ -224,9 +224,9 @@ impl Symbolizer {
                     name: "".to_string(),
                     addr: 0,
                     offset: 0,
-                    path: linfo.path,
-                    line: linfo.line.unwrap_or(0),
-                    column: linfo.column.unwrap_or(0),
+                    path: Some(linfo.path),
+                    line: linfo.line,
+                    column: linfo.column,
                     _non_exhaustive: (),
                 }])
             } else {
@@ -245,9 +245,9 @@ impl Symbolizer {
                         name: self.maybe_demangle(name, lang),
                         addr: sym_addr,
                         offset: addr - sym_addr,
-                        path: linfo.path.clone(),
-                        line: linfo.line.unwrap_or(0),
-                        column: linfo.column.unwrap_or(0),
+                        path: Some(linfo.path.clone()),
+                        line: linfo.line,
+                        column: linfo.column,
                         _non_exhaustive: (),
                     });
                 } else {
@@ -260,9 +260,9 @@ impl Symbolizer {
                         name: self.maybe_demangle(name, lang),
                         addr: sym_addr,
                         offset: addr - sym_addr,
-                        path: PathBuf::new(),
-                        line: 0,
-                        column: 0,
+                        path: None,
+                        line: None,
+                        column: None,
                         _non_exhaustive: (),
                     });
                 }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -225,8 +225,8 @@ impl Symbolizer {
                     addr: 0,
                     offset: 0,
                     path: linfo.path,
-                    line: linfo.line,
-                    column: linfo.column,
+                    line: linfo.line.unwrap_or(0),
+                    column: linfo.column.unwrap_or(0),
                     _non_exhaustive: (),
                 }])
             } else {
@@ -246,8 +246,8 @@ impl Symbolizer {
                         addr: sym_addr,
                         offset: addr - sym_addr,
                         path: linfo.path.clone(),
-                        line: linfo.line,
-                        column: linfo.column,
+                        line: linfo.line.unwrap_or(0),
+                        column: linfo.column.unwrap_or(0),
                         _non_exhaustive: (),
                     });
                 } else {

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -67,6 +67,8 @@ fn symbolize_gsym() {
 
         let result = results.first().unwrap();
         assert_eq!(result.name, "factorial");
+        assert_eq!(result.addr, 0x2000100);
+        assert_eq!(result.offset, 0);
 
         let test_bin = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
@@ -86,6 +88,7 @@ fn symbolize_gsym() {
             let result = results.first().unwrap();
             assert_eq!(result.name, "factorial");
             assert_eq!(result.addr, 0x2000100);
+            assert_eq!(result.offset, offset);
         }
     }
 
@@ -120,6 +123,7 @@ fn symbolize_dwarf() {
     let result = results.first().unwrap();
     assert_eq!(result.name, "factorial");
     assert_eq!(result.addr, 0x2000100);
+    assert_eq!(result.offset, 0);
     assert_eq!(result.line, 8);
 
     // Inquire symbol size.
@@ -140,6 +144,7 @@ fn symbolize_dwarf() {
         let result = results.first().unwrap();
         assert_eq!(result.name, "factorial");
         assert_eq!(result.addr, 0x2000100);
+        assert_eq!(result.offset, offset);
     }
 }
 

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -124,7 +124,7 @@ fn symbolize_dwarf() {
     assert_eq!(result.name, "factorial");
     assert_eq!(result.addr, 0x2000100);
     assert_eq!(result.offset, 0);
-    assert_eq!(result.line, 8);
+    assert_eq!(result.line, Some(8));
 
     // Inquire symbol size.
     let size = find_function_size("factorial", &test_dwarf);
@@ -191,7 +191,7 @@ fn symbolize_dwarf_complex() {
     let result = results.first().unwrap();
     assert_eq!(result.name, "abort_creds");
     assert_eq!(result.addr, 0xffffffff8110ecb0);
-    assert_eq!(result.line, 534);
+    assert_eq!(result.line, Some(534));
 }
 
 /// Symbolize a normalized address inside an ELF file, with and without


### PR DESCRIPTION
The documentation of the `symbolize::Sym::addr` member is wrong: the reported address is pretty much never that of the target process, for the simple reason that there may not be a target process at all (when symbolizing an address inside an ELF file, for example). This change fixes the documentation.
Furthermore, a common use case when symbolizing stack traces, for example, is to include the offset of the instruction included in the trace in the symbolized result. Currently that is done by subtracting the input address from the "symbolized" address. However, this calculation is fundamentally broken most of the time in a process context, because process addresses are not normalized addresses, but our `Symbolizer` reports normalized addresses. Hence, when relocations are or randomizations are applied, the result of the operation is meaningless. To support such use cases, this change adds an explicit offset member to the `symbolize::Sym` type. As the name tries to convey, this member holds the byte offset of the symbolized instruction from the start of the function. Furthermore, using this member it is possible to safely calculate "process offset" of the address in question:
```
  <process offset> = <process addr> - (sym.addr + sym.offset)
```