### PR TITLE
Replace rlib crate-type with lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ autobenches = false
 
 [lib]
 name = "blazesym"
-crate-type = ["cdylib", "rlib", "staticlib"]
+crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
 default = ["demangle", "dwarf", "lru"]

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -209,7 +209,7 @@ impl<'dwarf> Units<'dwarf> {
             res_units.push(Unit::new(dw_unit, lang, lines))
         }
 
-        // Sort this for faster lookup in `find_unit_and_address` below.
+        // Sort this for faster lookups.
         unit_ranges.sort_by_key(|i| i.range.begin);
 
         // Calculate the `max_end` field now that we've determined the order of


### PR DESCRIPTION
We don't really need the library to be an rlib from what I gather. We need it to be available as:
- a static library (staticlib)
- a dynamic library (cdynlib)
- and as a Rust library

For the latter, lib is the default [0] (which likely is just an alias for rlib) and I don't think we have any good reason to overwrite this default. Also sneak in a comment fix while at it.

[0]: https://doc.rust-lang.org/reference/linkage.html