### PR TITLE
Make `parse_line_table_header()` a `LineTableHeader` constructor

### DIFF
--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -35,6 +35,32 @@ pub struct LineTableHeader {
     pub first_line: u32,
 }
 
+impl LineTableHeader {
+    /// Parse [`AddrData`] of type [`InfoTypeLineTableInfo`].
+    ///
+    /// An `AddrData` of `InfoTypeLineTableInfo` type is a table of line numbers
+    /// for a symbol. `AddrData` is the payload of `AddrInfo`. One `AddrInfo`
+    /// may have several `AddrData` entries in its payload. Each `AddrData`
+    /// entry stores a type of data related to the symbol the `AddrInfo`
+    /// presents.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - is what [`AddrData::data`] is.
+    pub(super) fn parse(data: &mut &[u8]) -> Option<Self> {
+        let (min_delta, _bytes) = data.read_i128_leb128()?;
+        let (max_delta, _bytes) = data.read_i128_leb128()?;
+        let (first_line, _bytes) = data.read_u128_leb128()?;
+
+        let header = Self {
+            min_delta: min_delta as i64,
+            max_delta: max_delta as i64,
+            first_line: first_line as u32,
+        };
+        Some(header)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct LineTableRow {
     pub address: Addr,

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -36,9 +36,9 @@ pub struct LineTableHeader {
 }
 
 impl LineTableHeader {
-    /// Parse [`AddrData`] of type [`InfoTypeLineTableInfo`].
+    /// Parse [`AddrData`] of type [`INFO_TYPE_LINE_TABLE_INFO`].
     ///
-    /// An `AddrData` of `InfoTypeLineTableInfo` type is a table of line numbers
+    /// An `AddrData` of `INFO_TYPE_LINE_TABLE_INFO` type is a table of line numbers
     /// for a symbol. `AddrData` is the payload of `AddrInfo`. One `AddrInfo`
     /// may have several `AddrData` entries in its payload. Each `AddrData`
     /// entry stores a type of data related to the symbol the `AddrInfo`

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -48,7 +48,6 @@ use crate::Error;
 use crate::IntoError as _;
 use crate::Result;
 
-use super::linetab::LineTableHeader;
 use super::types::AddrData;
 use super::types::AddrInfo;
 use super::types::FileInfo;
@@ -245,31 +244,6 @@ pub fn parse_address_data(mut data: &[u8]) -> Option<Vec<AddrData>> {
     Some(data_objs)
 }
 
-/// Parse [`AddrData`] of type [`InfoTypeLineTableInfo`].
-///
-/// An `AddrData` of `InfoTypeLineTableInfo` type is a table of line numbers for
-/// a symbol. `AddrData` is the payload of `AddrInfo`. One `AddrInfo` may
-/// have several `AddrData` entries in its payload. Each `AddrData` entry stores
-/// a type of data relates to the symbol the `AddrInfo` presents.
-///
-/// # Arguments
-///
-/// * `data` - is what [`AddrData::data`] is.
-///
-/// Returns the `LineTableHeader` and the size of the header of a `AddrData`
-/// entry of `InfoTypeLineTableInfo` type in the payload of an `Addressinfo`.
-pub fn parse_line_table_header(data: &mut &[u8]) -> Option<LineTableHeader> {
-    let (min_delta, _bytes) = data.read_i128_leb128()?;
-    let (max_delta, _bytes) = data.read_i128_leb128()?;
-    let (first_line, _bytes) = data.read_u128_leb128()?;
-
-    let header = LineTableHeader {
-        min_delta: min_delta as i64,
-        max_delta: max_delta as i64,
-        first_line: first_line as u32,
-    };
-    Some(header)
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -52,9 +52,9 @@ use super::types::AddrData;
 use super::types::AddrInfo;
 use super::types::FileInfo;
 use super::types::Header;
-use super::types::InfoTypeEndOfList;
 use super::types::GSYM_MAGIC;
 use super::types::GSYM_VERSION;
+use super::types::INFO_TYPE_END_OF_LIST;
 
 /// Hold the major parts of a standalone GSYM file.
 ///
@@ -219,7 +219,7 @@ impl GsymContext<'_> {
 pub fn parse_address_data(mut data: &[u8]) -> impl Iterator<Item = AddrData> {
     iter::from_fn(move || {
         let typ = data.read_u32()?;
-        if typ == InfoTypeEndOfList {
+        if typ == INFO_TYPE_END_OF_LIST {
             // We are done.
             return None
         }

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -22,8 +22,8 @@ use super::linetab::LineTableRow;
 use super::linetab::RunResult;
 use super::parser::parse_address_data;
 use super::parser::GsymContext;
-use super::types::InfoTypeInlineInfo;
-use super::types::InfoTypeLineTableInfo;
+use super::types::INFO_TYPE_INLINE_INFO;
+use super::types::INFO_TYPE_LINE_TABLE_INFO;
 use crate::log::warn;
 
 
@@ -148,7 +148,7 @@ impl SymResolver for GsymResolver<'_> {
             let addrdatas = parse_address_data(addrinfo.data);
             for addr_ent in addrdatas {
                 match addr_ent.typ {
-                    InfoTypeLineTableInfo => {
+                    INFO_TYPE_LINE_TABLE_INFO => {
                         // Continue to execute all GSYM line table operations
                         // until the end of the buffer is reached or a row
                         // containing addr is located.
@@ -191,7 +191,7 @@ impl SymResolver for GsymResolver<'_> {
                             column: None,
                         })
                     }
-                    InfoTypeInlineInfo => (),
+                    INFO_TYPE_INLINE_INFO => (),
                     typ => {
                         warn!("encountered unknown info type: {typ}; ignoring...");
                         continue

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -17,8 +17,8 @@ use crate::SrcLang;
 use crate::SymResolver;
 
 use super::linetab::run_op;
-use super::linetab::LineTableRow;
 use super::linetab::LineTableHeader;
+use super::linetab::LineTableRow;
 use super::linetab::RunResult;
 use super::parser::parse_address_data;
 use super::parser::GsymContext;
@@ -143,15 +143,15 @@ impl SymResolver for GsymResolver<'_> {
                 return None
             }
 
-            let addrdatas = parse_address_data(addrinfo.data)?;
-            for adr_ent in addrdatas {
-                if adr_ent.typ != InfoTypeLineTableInfo {
+            let addrdatas = parse_address_data(addrinfo.data);
+            for addr_ent in addrdatas {
+                if addr_ent.typ != InfoTypeLineTableInfo {
                     continue
                 }
                 // Continue to execute all GSYM line table operations
                 // until the end of the buffer is reached or a row
                 // containing addr is located.
-                let mut data = adr_ent.data;
+                let mut data = addr_ent.data;
                 let lntab_hdr = LineTableHeader::parse(&mut data)?;
                 let mut lntab_row = LineTableRow::line_table_row_from(&lntab_hdr, symaddr);
                 let mut last_lntab_row = lntab_row.clone();

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -18,9 +18,9 @@ use crate::SymResolver;
 
 use super::linetab::run_op;
 use super::linetab::LineTableRow;
+use super::linetab::LineTableHeader;
 use super::linetab::RunResult;
 use super::parser::parse_address_data;
-use super::parser::parse_line_table_header;
 use super::parser::GsymContext;
 use super::types::InfoTypeLineTableInfo;
 
@@ -152,7 +152,7 @@ impl SymResolver for GsymResolver<'_> {
                 // until the end of the buffer is reached or a row
                 // containing addr is located.
                 let mut data = adr_ent.data;
-                let lntab_hdr = parse_line_table_header(&mut data)?;
+                let lntab_hdr = LineTableHeader::parse(&mut data)?;
                 let mut lntab_row = LineTableRow::line_table_row_from(&lntab_hdr, symaddr);
                 let mut last_lntab_row = lntab_row.clone();
                 let mut row_cnt = 0;

--- a/src/gsym/types.rs
+++ b/src/gsym/types.rs
@@ -34,15 +34,12 @@ pub struct AddrInfo<'a> {
 }
 
 pub struct AddrData<'a> {
-    /// The data type. Its value should be one of InfoType*.
+    /// The data type. Its value should be one of `INFO_TYPE_*`.
     pub typ: u32,
     pub length: u32,
     pub data: &'a [u8],
 }
 
-#[allow(non_upper_case_globals)]
-pub const InfoTypeEndOfList: u32 = 0;
-#[allow(non_upper_case_globals)]
-pub const InfoTypeLineTableInfo: u32 = 1;
-#[allow(non_upper_case_globals)]
-pub const InfoTypeInlineInfo: u32 = 2;
+pub const INFO_TYPE_END_OF_LIST: u32 = 0;
+pub const INFO_TYPE_LINE_TABLE_INFO: u32 = 1;
+pub const INFO_TYPE_INLINE_INFO: u32 = 2;


### PR DESCRIPTION
Co-locate the parse_line_table_header() functionality with the LineTableHeader type it work on by making it a constructor of the same.