### PR TITLE
Rename LineTableRow::line_table_row_from()

### DIFF
--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -78,7 +78,7 @@ impl LineTableRow {
     ///
     /// * `header` - is a [`LineTableHeader`] returned by [`parse_line_table_header()`].
     /// * `symaddr` - the address of the symbol that `header` belongs to.
-    pub fn line_table_row_from(header: &LineTableHeader, symaddr: Addr) -> LineTableRow {
+    pub fn from_header(header: &LineTableHeader, symaddr: Addr) -> Self {
         Self {
             address: symaddr,
             file_idx: 1,
@@ -93,8 +93,8 @@ impl LineTableRow {
 /// # Arguments
 ///
 /// * `ctx` - a line table row to present the current states of the virtual
-///           machine. [`line_table_row_from()`] can create a `LineTableRow` to
-///           keep the states of a virtual machine.
+///           machine. [`LineTableRow::from_header`] can create a `LineTableRow`
+///           to keep the states of a virtual machine.
 /// * `header` - is a `LineTableHeader`.
 /// * `ops` - is the buffer of the operators following the `LineTableHeader` in
 ///           a GSYM file.

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -154,7 +154,7 @@ impl SymResolver for GsymResolver<'_> {
                         // containing addr is located.
                         let mut data = addr_ent.data;
                         let lntab_hdr = LineTableHeader::parse(&mut data)?;
-                        let mut lntab_row = LineTableRow::line_table_row_from(&lntab_hdr, symaddr);
+                        let mut lntab_row = LineTableRow::from_header(&lntab_hdr, symaddr);
                         let mut last_lntab_row = lntab_row.clone();
                         let mut row_cnt = 0;
                         while !data.is_empty() {


### PR DESCRIPTION
Rename the LineTableRow::line_table_row_from() constructor to from_header(). The existing naming goes against any conceivable convention.