### PR TITLE
Use alternate format when formatting hex and bin numbers

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -40,7 +40,7 @@ pub struct Args {
     #[command(subcommand)]
     pub command: Command,
     /// Increase verbosity (can be supplied multiple times).
-    #[clap(short = 'v', long = "verbose", global = true, action = ArgAction::Count)]
+    #[arg(short = 'v', long = "verbose", global = true, action = ArgAction::Count)]
     pub verbosity: u8,
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -41,7 +41,7 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
         .context("failed to symbolize addresses")?;
 
     for (addr, syms) in addrs.iter().zip(syms) {
-        let mut addr_fmt = format!("0x{addr:016x}:");
+        let mut addr_fmt = format!("{addr:#016x}:");
         if syms.is_empty() {
             println!("{addr_fmt} <no-symbol>")
         } else {
@@ -69,7 +69,7 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
                     String::new()
                 };
 
-                println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
+                println!("{addr_fmt} {name} @ {addr:#x}{offset:#x}{src_loc}");
             }
         }
     }

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -31,10 +31,10 @@ fn main() -> Result<()> {
 
     let syms = symbolizer
         .symbolize(&src, &[addr])
-        .with_context(|| format!("failed to symbolize address 0x{addr:x}"))?;
+        .with_context(|| format!("failed to symbolize address {addr:#x}"))?;
 
     for (addr, syms) in [addr].iter().zip(syms) {
-        let mut addr_fmt = format!("0x{addr:016x}:");
+        let mut addr_fmt = format!("{addr:#016x}:");
         if syms.is_empty() {
             println!("{addr_fmt} <no-symbol>")
         } else {
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
                     String::new()
                 };
 
-                println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
+                println!("{addr_fmt} {name} @ {addr:#x}+{offset:#x}{src_loc}");
             }
         }
     }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -34,10 +34,10 @@ print its symbol, the file name of the source, and the line number.",
     let symbolizer = Symbolizer::new();
     let syms = symbolizer
         .symbolize(&src, &[addr])
-        .with_context(|| format!("failed to symbolize address 0x{addr:x}"))?;
+        .with_context(|| format!("failed to symbolize address {addr:#x}"))?;
 
     for (addr, syms) in [addr].iter().zip(syms) {
-        let mut addr_fmt = format!("0x{addr:016x}:");
+        let mut addr_fmt = format!("{addr:#016x}:");
         if syms.is_empty() {
             println!("{addr_fmt} <no-symbol>")
         } else {
@@ -65,7 +65,7 @@ print its symbol, the file name of the source, and the line number.",
                     String::new()
                 };
 
-                println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
+                println!("{addr_fmt} {name} @ {addr:#x}+{offset:#x}{src_loc}");
             }
         }
     }

--- a/examples/backtrace.rs
+++ b/examples/backtrace.rs
@@ -29,7 +29,7 @@ fn symbolize_current_bt() {
 
     let syms = symbolizer.symbolize(&src, bt).unwrap();
     for (addr, syms) in bt.iter().zip(syms) {
-        let mut addr_fmt = format!("0x{addr:016x}:");
+        let mut addr_fmt = format!("{addr:#016x}:");
         if syms.is_empty() {
             println!("{addr_fmt} <no-symbol>")
         } else {
@@ -57,7 +57,7 @@ fn symbolize_current_bt() {
                     String::new()
                 };
 
-                println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
+                println!("{addr_fmt} {name} @ {addr:#x}+{offset:#x}{src_loc}");
             }
         }
     }

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -55,7 +55,7 @@ impl ElfResolver {
 }
 
 impl SymResolver for ElfResolver {
-    #[cfg_attr(feature = "tracing", crate::log::instrument)]
+    #[cfg_attr(feature = "tracing", crate::log::instrument(fields(addr = format_args!("{addr:#x}"))))]
     fn find_syms(&self, addr: Addr) -> Result<Vec<IntSym<'_>>> {
         let parser = self.get_parser();
         if let Some((name, addr)) = parser.find_sym(addr, STT_FUNC)? {

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -90,9 +90,9 @@ impl Debug for PathMapsEntry {
         } = self;
 
         f.debug_struct(stringify!(PathMapsEntry))
-            .field(stringify!(range), &format_args!("0x{range:x?}"))
-            .field(stringify!(mode), &format_args!("b{mode:04b}"))
-            .field(stringify!(offset), &format_args!("0x{offset:x}"))
+            .field(stringify!(range), &format_args!("{range:#x?}"))
+            .field(stringify!(mode), &format_args!("{mode:#06b}"))
+            .field(stringify!(offset), &format_args!("{offset:#x}"))
             .field(stringify!(path), &path)
             .finish()
     }
@@ -299,7 +299,7 @@ mod tests {
         let dbg = format!("{entry:?}");
         assert!(
             dbg.starts_with(
-                r#"PathMapsEntry { range: 0x1000..1337, mode: b0010, offset: 0x5000, "#
+                r#"PathMapsEntry { range: 0x1000..0x1337, mode: 0b0010, offset: 0x5000, "#
             ),
             "{dbg}"
         );

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -25,7 +25,7 @@
 //! // fopen (0x7f5f8e23a790) corresponds to address 0x77790 within
 //! // Elf(Elf { path: "/usr/lib64/libc.so.6", build_id: Some([...]), ... })
 //! println!(
-//!   "fopen (0x{fopen_addr:x}) corresponds to address 0x{addr:x} within {:?}",
+//!   "fopen ({fopen_addr:#x}) corresponds to address {addr:#x} within {:?}",
 //!   norm_addrs.meta[meta_idx]
 //! );
 //! ```

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -104,7 +104,7 @@ pub(crate) fn normalize_elf_addr(virt_addr: Addr, entry: &PathMapsEntry) -> Resu
         .with_context(|| format!("failed to open map file {}", entry.path.maps_file.display()))?;
     let addr = normalize_elf_offset_with_parser(file_off, &parser)?.ok_or_invalid_input(|| {
         format!(
-            "failed to find ELF segment in {} that contains file offset 0x{:x}",
+            "failed to find ELF segment in {} that contains file offset {:#x}",
             entry.path.symbolic_path.display(),
             entry.offset,
         )
@@ -151,7 +151,7 @@ pub(crate) fn normalize_apk_addr(
     Err(Error::new(
         ErrorKind::InvalidInput,
         format!(
-            "failed to find ELF entry in {} that contains file offset 0x{:x}",
+            "failed to find ELF entry in {} that contains file offset {:#x}",
             entry.path.symbolic_path.display(),
             file_off,
         ),
@@ -289,7 +289,7 @@ impl<R> Handler for NormalizationHandler<R>
 where
     R: BuildIdReader,
 {
-    #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("0x{addr:x}"))))]
+    #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("{addr:#x}"))))]
     fn handle_unknown_addr(&mut self, addr: Addr) -> Result<()> {
         self.unknown_idx = self.normalized.add_unknown_addr(addr, self.unknown_idx);
         Ok(())

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -34,7 +34,7 @@
 //!
 //! let syms = symbolizer.symbolize(&src, bt).unwrap();
 //! for (addr, syms) in bt.iter().zip(syms) {
-//!     let mut addr_fmt = format!("0x{addr:016x}:");
+//!     let mut addr_fmt = format!("{addr:#016x}:");
 //!     if syms.is_empty() {
 //!         println!("{addr_fmt} <no-symbol>")
 //!     } else {
@@ -62,7 +62,7 @@
 //!                 String::new()
 //!             };
 //!
-//!             println!("{addr_fmt} {name} @ 0x{addr:x}+0x{offset:x}{src_loc}");
+//!             println!("{addr_fmt} {name} @ {addr:#x}+{offset:#x}{src_loc}");
 //!         }
 //!     }
 //! }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -213,7 +213,7 @@ impl Symbolizer {
     }
 
     /// Symbolize an address using the provided [`SymResolver`].
-    #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("0x{addr:x}"), resolver = ?resolver)))]
+    #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("{addr:#x}"), resolver = ?resolver)))]
     fn symbolize_with_resolver(&self, addr: Addr, resolver: &dyn SymResolver) -> Result<Vec<Sym>> {
         let syms = resolver.find_syms(addr)?;
         if syms.is_empty() {
@@ -315,7 +315,7 @@ impl Symbolizer {
                     .resolve_addr_in_elf(norm_addr, path)
                     .with_context(|| {
                         format!(
-                            "failed to symbolize normalized address 0x{norm_addr:x} in ELF file {}",
+                            "failed to symbolize normalized address {norm_addr:#x} in ELF file {}",
                             path.display()
                         )
                     })?;
@@ -325,7 +325,7 @@ impl Symbolizer {
         }
 
         impl normalize::Handler for SymbolizeHandler<'_> {
-            #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("0x{_addr:x}"))))]
+            #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("{_addr:#x}"))))]
             fn handle_unknown_addr(&mut self, _addr: Addr) -> Result<()> {
                 let () = self.all_symbols.push(Vec::new());
                 Ok(())
@@ -434,7 +434,7 @@ impl Symbolizer {
     ///
     /// Symbolize a list of addresses according to the configuration
     /// provided via `src`.
-    #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(src = ?src, addrs = format_args!("{addrs:x?}"))))]
+    #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(src = ?src, addrs = format_args!("{addrs:#x?}"))))]
     pub fn symbolize(&self, src: &Source, addrs: &[Addr]) -> Result<Vec<Vec<Sym>>> {
         match src {
             Source::Elf(Elf {


### PR DESCRIPTION
As it turns out, Rust can automatically take care of prefixing hexadecimal numbers with `0x`, as long as we use the alternate format. This has the advantage that it takes effect for all numbers in a structured type, e.g., when we print an array of addresses in hexadecimal format.
With this change we use this alternate format.