### PR TITLE
Fix potentially incorrect reporting of symbols from ELF resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Fixed potentially incorrect reporting of symbols from ELF source
+
+
 0.2.0-alpha.4
 -------------
 - Added support for automatic demangling of symbols, controlled by


### PR DESCRIPTION
When we search for a symbol by address in ELF, we were missing an additional check that the symbols we iterate over are still within the desired address range. That's necessary because we effectively filter by symbol type and such filtering may advance to symbols that are no longer matching from an address perspective.
This change fixes the problem by adding the necessary address check.