### PR TITLE
Add missing UserAddrMeta -> blaze_user_addr_meta conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Fixed potential panic when normalizing an APK ELF file using the C APIs
+
+
 0.2.0-alpha.5
 -------------
 - Fixed potentially incorrect reporting of symbols from ELF source

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -299,6 +299,28 @@ impl From<UserAddrMeta> for blaze_user_addr_meta {
     }
 }
 
+impl From<blaze_user_addr_meta> for UserAddrMeta {
+    fn from(other: blaze_user_addr_meta) -> Self {
+        match other.kind {
+            blaze_user_addr_meta_kind::BLAZE_USER_ADDR_APK_ELF => {
+                UserAddrMeta::ApkElf(ApkElf::from(ManuallyDrop::into_inner(unsafe {
+                    other.variant.apk_elf
+                })))
+            }
+            blaze_user_addr_meta_kind::BLAZE_USER_ADDR_ELF => {
+                UserAddrMeta::Elf(Elf::from(ManuallyDrop::into_inner(unsafe {
+                    other.variant.elf
+                })))
+            }
+            blaze_user_addr_meta_kind::BLAZE_USER_ADDR_UNKNOWN => {
+                UserAddrMeta::Unknown(Unknown::from(ManuallyDrop::into_inner(unsafe {
+                    other.variant.unknown
+                })))
+            }
+        }
+    }
+}
+
 
 /// An object representing normalized user addresses.
 ///
@@ -463,21 +485,7 @@ pub unsafe extern "C" fn blaze_user_addrs_free(addrs: *mut blaze_normalized_user
     .into_vec();
 
     for addr_meta in addr_metas {
-        match addr_meta.kind {
-            blaze_user_addr_meta_kind::BLAZE_USER_ADDR_APK_ELF => {
-                let _apk_elf = ApkElf::from(ManuallyDrop::into_inner(unsafe {
-                    addr_meta.variant.apk_elf
-                }));
-            }
-            blaze_user_addr_meta_kind::BLAZE_USER_ADDR_ELF => {
-                let _elf = Elf::from(ManuallyDrop::into_inner(unsafe { addr_meta.variant.elf }));
-            }
-            blaze_user_addr_meta_kind::BLAZE_USER_ADDR_UNKNOWN => {
-                let _unknown = Unknown::from(ManuallyDrop::into_inner(unsafe {
-                    addr_meta.variant.unknown
-                }));
-            }
-        }
+        let _meta = UserAddrMeta::from(addr_meta);
     }
 }
 

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -282,7 +282,12 @@ pub struct blaze_user_addr_meta {
 impl From<UserAddrMeta> for blaze_user_addr_meta {
     fn from(other: UserAddrMeta) -> Self {
         match other {
-            UserAddrMeta::ApkElf(_apk) => todo!(),
+            UserAddrMeta::ApkElf(apk_elf) => Self {
+                kind: blaze_user_addr_meta_kind::BLAZE_USER_ADDR_APK_ELF,
+                variant: blaze_user_addr_meta_variant {
+                    apk_elf: ManuallyDrop::new(blaze_user_addr_meta_apk_elf::from(apk_elf)),
+                },
+            },
             UserAddrMeta::Elf(elf) => Self {
                 kind: blaze_user_addr_meta_kind::BLAZE_USER_ADDR_ELF,
                 variant: blaze_user_addr_meta_variant {
@@ -570,6 +575,10 @@ mod tests {
 
         let unknown_new = Unknown::from(blaze_user_addr_meta_unknown::from(unknown.clone()));
         assert_eq!(unknown_new, unknown);
+
+        let meta = UserAddrMeta::Unknown(unknown_new);
+        let meta_new = UserAddrMeta::from(blaze_user_addr_meta::from(meta.clone()));
+        assert_eq!(meta_new, meta);
     }
 
     /// Check that we can convert an [`ApkElf`] into a
@@ -595,6 +604,10 @@ mod tests {
 
         let apk_new = ApkElf::from(blaze_user_addr_meta_apk_elf::from(apk.clone()));
         assert_eq!(apk_new, apk);
+
+        let meta = UserAddrMeta::ApkElf(apk_new);
+        let meta_new = UserAddrMeta::from(blaze_user_addr_meta::from(meta.clone()));
+        assert_eq!(meta_new, meta);
     }
 
     /// Check that we can convert an [`Elf`] into a [`blaze_user_addr_meta_elf`]
@@ -609,5 +622,9 @@ mod tests {
 
         let elf_new = Elf::from(blaze_user_addr_meta_elf::from(elf.clone()));
         assert_eq!(elf_new, elf);
+
+        let meta = UserAddrMeta::Elf(elf_new);
+        let meta_new = UserAddrMeta::from(blaze_user_addr_meta::from(meta.clone()));
+        assert_eq!(meta_new, meta);
     }
 }


### PR DESCRIPTION
We still had a todo!() in the code that could trigger when normalizing
an APK ELF file using the C APIs.
This change adds the necessary conversion to fix the potential panic.
