### PR TITLE
Bump version to 0.2.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.2.0-alpha.6
+-------------
 - Fixed potential panic when normalizing an APK ELF file using the C APIs
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "=0.2.0-alpha.5"
+blazesym = "=0.2.0-alpha.6"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).

--- a/cli/README.md
+++ b/cli/README.md
@@ -56,5 +56,5 @@ refer to the help text (`--help`) of the `shell-complete` program for
 the list of supported shells.
 
 [blazesym]: https://crates.io/crates/blazesym
-[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.5/blazesym/symbolize/struct.Symbolizer.html
-[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.5/blazesym/symbolize/enum.Source.html#variant.Elf
+[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.6/blazesym/symbolize/struct.Symbolizer.html
+[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.6/blazesym/symbolize/enum.Source.html#variant.Elf


### PR DESCRIPTION
This change bumps the version of the crate to `0.2.0-alpha.6`.