### PR TITLE
Rename AddrLineInfo -> AddrSrcInfo

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -14,7 +14,7 @@ use crate::elf::ElfParser;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::inspect::SymType;
-use crate::symbolize::AddrLineInfo;
+use crate::symbolize::AddrSrcInfo;
 use crate::Addr;
 use crate::Error;
 use crate::IntSym;
@@ -94,7 +94,7 @@ impl DwarfResolver {
     /// Find line information of an address.
     ///
     /// `addr` is a normalized address.
-    pub fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo<'_>>> {
+    pub fn find_line_info(&self, addr: Addr) -> Result<Option<AddrSrcInfo<'_>>> {
         // TODO: This conditional logic is weird and potentially
         //       unnecessary. Consider removing it or moving it higher
         //       in the call chain.
@@ -107,7 +107,7 @@ impl DwarfResolver {
                     column,
                 } = location;
 
-                AddrLineInfo {
+                AddrSrcInfo {
                     dir,
                     file,
                     line,

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
-use crate::symbolize::AddrLineInfo;
+use crate::symbolize::AddrSrcInfo;
 use crate::Addr;
 use crate::IntSym;
 use crate::Result;
@@ -92,7 +92,7 @@ impl SymResolver for ElfResolver {
     }
 
     #[cfg(feature = "dwarf")]
-    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo<'_>>> {
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrSrcInfo<'_>>> {
         if let ElfBackend::Dwarf(dwarf) = &self.backend {
             dwarf.find_line_info(addr)
         } else {
@@ -101,7 +101,7 @@ impl SymResolver for ElfResolver {
     }
 
     #[cfg(not(feature = "dwarf"))]
-    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>> {
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrSrcInfo>> {
         Ok(None)
     }
 

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::mmap::Mmap;
-use crate::symbolize::AddrLineInfo;
+use crate::symbolize::AddrSrcInfo;
 use crate::Addr;
 use crate::IntSym;
 use crate::IntoError as _;
@@ -128,9 +128,9 @@ impl SymResolver for GsymResolver<'_> {
     ///
     /// # Returns
     ///
-    /// The `AddrLineInfo` corresponding to the address or `None`.
+    /// The `AddrSrcInfo` corresponding to the address or `None`.
     #[cfg_attr(feature = "tracing", crate::log::instrument(skip(self), fields(file = debug(&self.file_name))))]
-    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo<'_>>> {
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrSrcInfo<'_>>> {
         let idx = match self.ctx.find_addr(addr) {
             Some(idx) => idx,
             None => return Ok(None),
@@ -205,7 +205,7 @@ impl SymResolver for GsymResolver<'_> {
                         .ok_or_invalid_data(|| {
                             format!("failed to retrieve file name string @ {}", finfo.filename)
                         })?;
-                    return Ok(Some(AddrLineInfo {
+                    return Ok(Some(AddrSrcInfo {
                         dir: Path::new(dir),
                         file,
                         line: Some(lntab_row.file_line),

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -8,7 +8,7 @@ use crate::elf::ElfResolver;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::ksym::KSymResolver;
-use crate::symbolize::AddrLineInfo;
+use crate::symbolize::AddrSrcInfo;
 use crate::Addr;
 use crate::Error;
 use crate::IntSym;
@@ -52,7 +52,7 @@ impl SymResolver for KernelResolver {
         Ok(Vec::new())
     }
 
-    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>> {
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrSrcInfo>> {
         if let Some(resolver) = self.elf_resolver.as_ref() {
             resolver.find_line_info(addr)
         } else {

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::inspect::SymType;
-use crate::symbolize::AddrLineInfo;
+use crate::symbolize::AddrSrcInfo;
 use crate::Addr;
 use crate::IntSym;
 use crate::Result;
@@ -172,7 +172,7 @@ impl SymResolver for KSymResolver {
         }
     }
 
-    fn find_line_info(&self, _addr: Addr) -> Result<Option<AddrLineInfo>> {
+    fn find_line_info(&self, _addr: Addr) -> Result<Option<AddrSrcInfo>> {
         Ok(None)
     }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
-use crate::symbolize::AddrLineInfo;
+use crate::symbolize::AddrSrcInfo;
 use crate::Addr;
 use crate::Result;
 
@@ -45,7 +45,7 @@ where
     /// Find the address and size of a symbol name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo>>;
     /// Find the file name and the line number of an address.
-    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrLineInfo>>;
+    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrSrcInfo>>;
     /// Translate an address (virtual) in a process to the file offset
     /// in the object file.
     fn addr_file_off(&self, addr: Addr) -> Option<u64>;

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -86,7 +86,7 @@ pub use symbolizer::Sym;
 pub use symbolizer::Symbolizer;
 
 
-pub(crate) struct AddrLineInfo<'src> {
+pub(crate) struct AddrSrcInfo<'src> {
     pub dir: &'src Path,
     pub file: &'src OsStr,
     pub line: Option<u32>,


### PR DESCRIPTION
Rename the internal `AddrLineInfo` type to `AddrSrcInfo`. There is more information contained in its objects than just the line.