### PR TITLE
Add symbol size to Sym type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `size` member to `symbolize::Sym` type
+
+
 0.2.0-alpha.6
 -------------
 - Fixed potential panic when normalizing an APK ELF file using the C APIs

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -142,9 +142,13 @@ impl DwarfResolver {
                 .range
                 .map(|range| range.begin as usize)
                 .unwrap_or(0);
+            let size = function
+                .range
+                .map(|range| usize::try_from(range.end - range.begin).unwrap_or(usize::MAX));
             let sym = IntSym {
                 name,
                 addr,
+                size,
                 lang: language.into(),
             };
             Ok(vec![sym])
@@ -191,7 +195,7 @@ impl DwarfResolver {
                             .range
                             .as_ref()
                             .and_then(|range| range.end.checked_sub(range.begin))
-                            .map(|size| size as usize)
+                            .map(|size| usize::try_from(size).unwrap_or(usize::MAX))
                             .unwrap_or(0);
                         let info = SymInfo {
                             name,

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -58,14 +58,19 @@ impl SymResolver for ElfResolver {
     #[cfg_attr(feature = "tracing", crate::log::instrument(fields(addr = format_args!("{addr:#x}"))))]
     fn find_syms(&self, addr: Addr) -> Result<Vec<IntSym<'_>>> {
         let parser = self.get_parser();
-        if let Some((name, addr)) = parser.find_sym(addr, STT_FUNC)? {
+        if let Some((name, addr, size)) = parser.find_sym(addr, STT_FUNC)? {
             // ELF does not carry any source code language information.
             let lang = SrcLang::Unknown;
             // We found the address in ELF.
             // TODO: Long term we probably want a different heuristic here, as
             //       there can be valid differences between the two formats
             //       (e.g., DWARF could contain more symbols).
-            return Ok(vec![IntSym { name, addr, lang }])
+            return Ok(vec![IntSym {
+                name,
+                addr,
+                size: Some(size),
+                lang,
+            }])
         }
 
         match &self.backend {

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -100,6 +100,7 @@ impl SymResolver for GsymResolver<'_> {
             let sym = IntSym {
                 name,
                 addr: found,
+                size: Some(usize::try_from(info.size).unwrap_or(usize::MAX)),
                 lang,
             };
 

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -35,6 +35,8 @@ impl<'ksym> From<&'ksym Ksym> for IntSym<'ksym> {
         IntSym {
             name,
             addr: *addr,
+            // There is no size information in kallsyms.
+            size: None,
             // Kernel symbols don't carry any source code language
             // information.
             lang: SrcLang::Unknown,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -26,6 +26,8 @@ pub(crate) struct IntSym<'src> {
     pub(crate) name: &'src str,
     /// The symbol's normalized address.
     pub(crate) addr: Addr,
+    /// The symbol's size, if available.
+    pub(crate) size: Option<usize>,
     /// The source code language from which the symbol originates.
     pub(crate) lang: SrcLang,
 }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -90,6 +90,8 @@ pub struct Sym {
     /// context (which may have been relocated and/or have layout randomizations
     /// applied).
     pub offset: usize,
+    /// The symbol's size, if available.
+    pub size: Option<usize>,
     /// The directory in which the source file resides.
     pub dir: Option<PathBuf>,
     /// The file that defines the symbol.
@@ -232,12 +234,14 @@ impl Symbolizer {
                 let IntSym {
                     name,
                     addr: sym_addr,
+                    size: sym_size,
                     lang,
                 } = sym;
                 results.push(Sym {
                     name: self.maybe_demangle(name, lang),
                     addr: sym_addr,
                     offset: addr - sym_addr,
+                    size: sym_size,
                     dir: Some(linfo.dir.to_path_buf()),
                     file: Some(linfo.file.to_os_string()),
                     line: linfo.line,
@@ -248,12 +252,14 @@ impl Symbolizer {
                 let IntSym {
                     name,
                     addr: sym_addr,
+                    size: sym_size,
                     lang,
                 } = sym;
                 results.push(Sym {
                     name: self.maybe_demangle(name, lang),
                     addr: sym_addr,
                     offset: addr - sym_addr,
+                    size: sym_size,
                     dir: None,
                     file: None,
                     line: None,

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -195,7 +195,7 @@ fn symbolize_dwarf_complex() {
 #[test]
 fn symbolize_elf_demangle() {
     let test_elf = current_exe().unwrap();
-    let addr = Normalizer::new as Addr;
+    let addr = Normalizer::normalize_user_addrs_sorted as Addr;
     let normalizer = Normalizer::new();
     let norm_addrs = normalizer
         .normalize_user_addrs_sorted(&[addr], Pid::Slf)
@@ -213,7 +213,12 @@ fn symbolize_elf_demangle() {
     assert_eq!(results.len(), 1);
 
     let result = &results[0];
-    assert!(result.name.contains("Normalizer3new"), "{result:x?}");
+    assert!(
+        result
+            .name
+            .contains("Normalizer27normalize_user_addrs_sorted"),
+        "{result:x?}"
+    );
 
     // Do it again, this time with demangling enabled.
     let symbolizer = Symbolizer::new();
@@ -227,8 +232,9 @@ fn symbolize_elf_demangle() {
 
     let result = &results[0];
     assert!(
-        result.name == "blazesym::normalize::normalizer::Normalizer::new"
-            || result.name == "<blazesym::normalize::normalizer::Normalizer>::new",
+        result.name == "blazesym::normalize::normalizer::Normalizer::normalize_user_addrs_sorted"
+            || result.name
+                == "<blazesym::normalize::normalizer::Normalizer>::normalize_user_addrs_sorted",
         "{}",
         result.name
     );


### PR DESCRIPTION
With this change we expose the symbol's size in the form of the newly added Sym::size member, if it is available. Currently the only symbolization source that does not expose the size is kallsyms.