### PR TITLE
Flatten return type of symbolization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 ----------
+- "Flattened" return type of `symbolize::Symbolizer::symbolize` method from
+  nested `Vec` to a single level `Vec`
 - Added `size` member and `to_path` helper to `symbolize::Sym` type
 
 

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -48,11 +48,10 @@ fn symbolize_elf() {
         .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
         .unwrap()
         .into_iter()
-        .flatten()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let result = results.first().unwrap();
+    let result = &results[0].0;
     assert_eq!(result.name, "abort_creds");
 }
 
@@ -69,11 +68,10 @@ fn symbolize_dwarf_no_lines() {
         .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
         .unwrap()
         .into_iter()
-        .flatten()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let result = results.first().unwrap();
+    let result = &results[0].0;
     assert_eq!(result.name, "abort_creds");
     assert_eq!(result.line, None);
 }
@@ -91,11 +89,10 @@ fn symbolize_dwarf() {
         .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
         .unwrap()
         .into_iter()
-        .flatten()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let result = results.first().unwrap();
+    let result = &results[0].0;
     assert_eq!(result.name, "abort_creds");
     assert_eq!(result.line, Some(534));
 }
@@ -113,11 +110,10 @@ fn symbolize_gsym() {
         .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
         .unwrap()
         .into_iter()
-        .flatten()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let result = results.first().unwrap();
+    let result = &results[0].0;
     assert_eq!(result.name, "abort_creds");
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -95,33 +95,53 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
         .symbolize(&src, &addrs)
         .context("failed to symbolize addresses")?;
 
-    for (addr, syms) in addrs.iter().zip(syms) {
-        let mut addr_fmt = format!("{addr:#016x}:");
-        if syms.is_empty() {
-            println!("{addr_fmt} <no-symbol>")
-        } else {
-            for (i, sym) in syms.into_iter().enumerate() {
-                if i == 1 {
-                    addr_fmt = addr_fmt.replace(|_c| true, " ");
-                }
+    let addr_width = 16;
+    let mut prev_addr_idx = None;
 
-                let symbolize::Sym {
-                    name, addr, offset, ..
-                } = &sym;
-
-                let src_loc = if let (Some(path), Some(line)) = (sym.to_path(), sym.line) {
-                    if let Some(col) = sym.column {
-                        format!(" {}:{line}:{col}", path.display())
-                    } else {
-                        format!(" {}:{line}", path.display())
-                    }
-                } else {
-                    String::new()
-                };
-
-                println!("{addr_fmt} {name} @ {addr:#x}{offset:#x}{src_loc}");
+    for (sym, addr_idx) in syms {
+        if let Some(idx) = prev_addr_idx {
+            // Print a line for all addresses that did not get symbolized.
+            for input_addr in addrs.iter().take(addr_idx).skip(idx + 1) {
+                println!("{input_addr:#0width$x}: <no-symbol>", width = addr_width)
             }
         }
+
+        let symbolize::Sym {
+            name,
+            addr,
+            offset,
+            line,
+            column,
+            ..
+        } = &sym;
+
+        let src_loc = if let (Some(path), Some(line)) = (sym.to_path(), line) {
+            if let Some(col) = column {
+                format!(" {}:{line}:{col}", path.display())
+            } else {
+                format!(" {}:{line}", path.display())
+            }
+        } else {
+            String::new()
+        };
+
+        if prev_addr_idx != Some(addr_idx) {
+            // If the address index changed we reached a new symbol.
+            println!(
+                "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{src_loc}",
+                input_addr = addrs[addr_idx],
+                width = addr_width
+            );
+        } else {
+            // Otherwise we are dealing with an inlined call.
+            println!(
+                "{:width$}  {name} @ {addr:#x}+{offset:#x}{src_loc}",
+                " ",
+                width = addr_width
+            );
+        }
+
+        prev_addr_idx = Some(addr_idx);
     }
     Ok(())
 }

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -22,43 +22,64 @@ fn main() -> Result<()> {
 
     let bin_name = &args[1];
     let addr_str = &args[2][..];
-    let src = Source::Elf(Elf::new(bin_name));
-    let symbolizer = Symbolizer::new();
 
     let addr = Addr::from_str_radix(addr_str.trim_start_matches("0x"), 16)
         .with_context(|| format!("failed to parse address: {addr_str}"))?;
 
+    let src = Source::Elf(Elf::new(bin_name));
+    let addrs = [addr];
+    let symbolizer = Symbolizer::new();
     let syms = symbolizer
-        .symbolize(&src, &[addr])
+        .symbolize(&src, &addrs)
         .with_context(|| format!("failed to symbolize address {addr:#x}"))?;
 
-    for (addr, syms) in [addr].iter().zip(syms) {
-        let mut addr_fmt = format!("{addr:#016x}:");
-        if syms.is_empty() {
-            println!("{addr_fmt} <no-symbol>")
-        } else {
-            for (i, sym) in syms.into_iter().enumerate() {
-                if i == 1 {
-                    addr_fmt = addr_fmt.replace(|_c| true, " ");
-                }
+    let addr_width = 16;
+    let mut prev_addr_idx = None;
 
-                let Sym {
-                    name, addr, offset, ..
-                } = &sym;
-
-                let src_loc = if let (Some(path), Some(line)) = (sym.to_path(), sym.line) {
-                    if let Some(col) = sym.column {
-                        format!(" {}:{line}:{col}", path.display())
-                    } else {
-                        format!(" {}:{line}", path.display())
-                    }
-                } else {
-                    String::new()
-                };
-
-                println!("{addr_fmt} {name} @ {addr:#x}+{offset:#x}{src_loc}");
+    for (sym, addr_idx) in syms {
+        if let Some(idx) = prev_addr_idx {
+            // Print a line for all addresses that did not get symbolized.
+            for input_addr in addrs.iter().take(addr_idx).skip(idx + 1) {
+                println!("{input_addr:#0width$x}: <no-symbol>", width = addr_width)
             }
         }
+
+        let Sym {
+            name,
+            addr,
+            offset,
+            line,
+            column,
+            ..
+        } = &sym;
+
+        let src_loc = if let (Some(path), Some(line)) = (sym.to_path(), line) {
+            if let Some(col) = column {
+                format!(" {}:{line}:{col}", path.display())
+            } else {
+                format!(" {}:{line}", path.display())
+            }
+        } else {
+            String::new()
+        };
+
+        if prev_addr_idx != Some(addr_idx) {
+            // If the address index changed we reached a new symbol.
+            println!(
+                "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{src_loc}",
+                input_addr = addrs[addr_idx],
+                width = addr_width
+            );
+        } else {
+            // Otherwise we are dealing with an inlined call.
+            println!(
+                "{:width$}  {name} @ {addr:#x}+{offset:#x}{src_loc}",
+                " ",
+                width = addr_width
+            );
+        }
+
+        prev_addr_idx = Some(addr_idx);
     }
     Ok(())
 }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -30,38 +30,59 @@ print its symbol, the file name of the source, and the line number.",
         .with_context(|| format!("failed to parse address: {addr_str}"))?;
 
     let src = Source::Process(Process::new(pid.into()));
+    let addrs = [addr];
     let symbolizer = Symbolizer::new();
     let syms = symbolizer
-        .symbolize(&src, &[addr])
+        .symbolize(&src, &addrs)
         .with_context(|| format!("failed to symbolize address {addr:#x}"))?;
 
-    for (addr, syms) in [addr].iter().zip(syms) {
-        let mut addr_fmt = format!("{addr:#016x}:");
-        if syms.is_empty() {
-            println!("{addr_fmt} <no-symbol>")
-        } else {
-            for (i, sym) in syms.into_iter().enumerate() {
-                if i == 1 {
-                    addr_fmt = addr_fmt.replace(|_c| true, " ");
-                }
+    let addr_width = 16;
+    let mut prev_addr_idx = None;
 
-                let Sym {
-                    name, addr, offset, ..
-                } = &sym;
-
-                let src_loc = if let (Some(path), Some(line)) = (sym.to_path(), sym.line) {
-                    if let Some(col) = sym.column {
-                        format!(" {}:{line}:{col}", path.display())
-                    } else {
-                        format!(" {}:{line}", path.display())
-                    }
-                } else {
-                    String::new()
-                };
-
-                println!("{addr_fmt} {name} @ {addr:#x}+{offset:#x}{src_loc}");
+    for (sym, addr_idx) in syms {
+        if let Some(idx) = prev_addr_idx {
+            // Print a line for all addresses that did not get symbolized.
+            for input_addr in addrs.iter().take(addr_idx).skip(idx + 1) {
+                println!("{input_addr:#0width$x}: <no-symbol>", width = addr_width)
             }
         }
+
+        let Sym {
+            name,
+            addr,
+            offset,
+            line,
+            column,
+            ..
+        } = &sym;
+
+        let src_loc = if let (Some(path), Some(line)) = (sym.to_path(), line) {
+            if let Some(col) = column {
+                format!(" {}:{line}:{col}", path.display())
+            } else {
+                format!(" {}:{line}", path.display())
+            }
+        } else {
+            String::new()
+        };
+
+        if prev_addr_idx != Some(addr_idx) {
+            // If the address index changed we reached a new symbol.
+            println!(
+                "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{src_loc}",
+                input_addr = addrs[addr_idx],
+                width = addr_width
+            );
+        } else {
+            // Otherwise we are dealing with an inlined call.
+            println!(
+                "{:width$}  {name} @ {addr:#x}+{offset:#x}{src_loc}",
+                " ",
+                width = addr_width
+            );
+        }
+
+        prev_addr_idx = Some(addr_idx);
     }
     Ok(())
 }

--- a/examples/backtrace.rs
+++ b/examples/backtrace.rs
@@ -27,33 +27,54 @@ fn symbolize_current_bt() {
     let symbolizer = Symbolizer::new();
 
     let syms = symbolizer.symbolize(&src, bt).unwrap();
-    for (addr, syms) in bt.iter().zip(syms) {
-        let mut addr_fmt = format!("{addr:#016x}:");
-        if syms.is_empty() {
-            println!("{addr_fmt} <no-symbol>")
-        } else {
-            for (i, sym) in syms.into_iter().enumerate() {
-                if i == 1 {
-                    addr_fmt = addr_fmt.replace(|_c| true, " ");
-                }
+    let addrs = bt;
+    let addr_width = 16;
+    let mut prev_addr_idx = None;
 
-                let Sym {
-                    name, addr, offset, ..
-                } = &sym;
-
-                let src_loc = if let (Some(path), Some(line)) = (sym.to_path(), sym.line) {
-                    if let Some(col) = sym.column {
-                        format!(" {}:{line}:{col}", path.display())
-                    } else {
-                        format!(" {}:{line}", path.display())
-                    }
-                } else {
-                    String::new()
-                };
-
-                println!("{addr_fmt} {name} @ {addr:#x}+{offset:#x}{src_loc}");
+    for (sym, addr_idx) in syms {
+        if let Some(idx) = prev_addr_idx {
+            // Print a line for all addresses that did not get symbolized.
+            for input_addr in addrs.iter().take(addr_idx).skip(idx + 1) {
+                println!("{input_addr:#0width$x}: <no-symbol>", width = addr_width)
             }
         }
+
+        let Sym {
+            name,
+            addr,
+            offset,
+            line,
+            column,
+            ..
+        } = &sym;
+
+        let src_loc = if let (Some(path), Some(line)) = (sym.to_path(), line) {
+            if let Some(col) = column {
+                format!(" {}:{line}:{col}", path.display())
+            } else {
+                format!(" {}:{line}", path.display())
+            }
+        } else {
+            String::new()
+        };
+
+        if prev_addr_idx != Some(addr_idx) {
+            // If the address index changed we reached a new symbol.
+            println!(
+                "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{src_loc}",
+                input_addr = addrs[addr_idx],
+                width = addr_width
+            );
+        } else {
+            // Otherwise we are dealing with an inlined call.
+            println!(
+                "{:width$}  {name} @ {addr:#x}+{offset:#x}{src_loc}",
+                " ",
+                width = addr_width
+            );
+        }
+
+        prev_addr_idx = Some(addr_idx);
     }
 }
 

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -328,22 +328,18 @@ typedef struct blaze_sym {
 } blaze_sym;
 
 /**
- * `blaze_entry` is the output of symbolization for an address for C API.
- *
- * Every address has an `blaze_entry` in
- * [`blaze_result::entries`] to collect symbols found.
+ * `blaze_entry` is the output of symbolization for a call frame.
  */
 typedef struct blaze_entry {
   /**
-   * The number of symbols found for an address.
+   * The symbol.
    */
-  size_t size;
+  struct blaze_sym sym;
   /**
-   * All symbols found.
-   *
-   * `syms` is an array of [`blaze_sym`] in the size `size`.
+   * The index of the input address to which this symbolization result
+   * belongs.
    */
-  const struct blaze_sym *syms;
+  size_t addr_idx;
 } blaze_entry;
 
 /**
@@ -354,9 +350,9 @@ typedef struct blaze_entry {
  */
 typedef struct blaze_result {
   /**
-   * The number of addresses being symbolized.
+   * The number of symbols being reported.
    */
-  size_t size;
+  size_t cnt;
   /**
    * The entries for addresses.
    *

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fmt::Debug;
+use std::mem::swap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -273,11 +274,17 @@ impl Symbolizer {
     }
 
     /// Symbolize a list of addresses using the provided [`SymResolver`].
-    fn symbolize_addrs(&self, addrs: &[Addr], resolver: &dyn SymResolver) -> Result<Vec<Vec<Sym>>> {
-        addrs
-            .iter()
-            .map(|addr| self.symbolize_with_resolver(*addr, resolver))
-            .collect()
+    fn symbolize_addrs(
+        &self,
+        addrs: &[Addr],
+        resolver: &dyn SymResolver,
+    ) -> Result<Vec<(Sym, usize)>> {
+        let mut syms = Vec::with_capacity(addrs.len());
+        for (i, addr) in addrs.iter().enumerate() {
+            let resolved = self.symbolize_with_resolver(*addr, resolver)?;
+            let () = syms.extend(resolved.into_iter().map(|sym| (sym, i)));
+        }
+        Ok(syms)
     }
 
     fn resolve_addr_in_elf(&self, addr: Addr, path: &Path) -> Result<Vec<Sym>> {
@@ -289,12 +296,14 @@ impl Symbolizer {
 
     /// Symbolize the given list of user space addresses in the provided
     /// process.
-    fn symbolize_user_addrs(&self, addrs: &[Addr], pid: Pid) -> Result<Vec<Vec<Sym>>> {
+    fn symbolize_user_addrs(&self, addrs: &[Addr], pid: Pid) -> Result<Vec<(Sym, usize)>> {
         struct SymbolizeHandler<'sym> {
             /// The "outer" `Symbolizer` instance.
             symbolizer: &'sym Symbolizer,
+            /// Running index of the address being symbolized.
+            addr_idx: usize,
             /// Symbols representing the symbolized addresses.
-            all_symbols: Vec<Vec<Sym>>,
+            all_symbols: Vec<(Sym, usize)>,
         }
 
         impl SymbolizeHandler<'_> {
@@ -310,7 +319,9 @@ impl Symbolizer {
                 let symbols = self
                     .symbolizer
                     .symbolize_with_resolver(norm_addr, &resolver)?;
-                let () = self.all_symbols.push(symbols);
+                let () = self
+                    .all_symbols
+                    .extend(symbols.into_iter().map(|sym| (sym, self.addr_idx)));
                 Ok(())
             }
 
@@ -326,7 +337,9 @@ impl Symbolizer {
                             path.display()
                         )
                     })?;
-                let () = self.all_symbols.push(symbols);
+                let () = self
+                    .all_symbols
+                    .extend(symbols.into_iter().map(|sym| (sym, self.addr_idx)));
                 Ok(())
             }
         }
@@ -334,7 +347,7 @@ impl Symbolizer {
         impl normalize::Handler for SymbolizeHandler<'_> {
             #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("{_addr:#x}"))))]
             fn handle_unknown_addr(&mut self, _addr: Addr) -> Result<()> {
-                let () = self.all_symbols.push(Vec::new());
+                self.addr_idx += 1;
                 Ok(())
             }
 
@@ -344,28 +357,37 @@ impl Symbolizer {
                     .symbolic_path
                     .extension()
                     .unwrap_or_else(|| OsStr::new(""));
-                match ext.to_str() {
+                let result = match ext.to_str() {
                     Some("apk") | Some("zip") => self.handle_apk_addr(addr, entry),
                     _ => self.handle_elf_addr(addr, entry),
-                }
+                };
+                self.addr_idx += 1;
+                result
             }
         }
 
         let entries = maps::parse(pid)?;
         let handler = SymbolizeHandler {
             symbolizer: self,
+            addr_idx: 0,
             all_symbols: Vec::with_capacity(addrs.len()),
         };
 
-        let handler = util::with_ordered_elems(
+        let handler = util::with_ordered_elems_with_swap(
             addrs,
             |handler: &mut SymbolizeHandler<'_>| handler.all_symbols.as_mut_slice(),
             |sorted_addrs| normalize_sorted_user_addrs_with_entries(sorted_addrs, entries, handler),
+            |symbols: &mut [(Sym, usize)], i, j| {
+                let syms = symbols.as_mut_ptr();
+                let symi = unsafe { &mut *syms.add(i) };
+                let symj = unsafe { &mut *syms.add(j) };
+                swap(&mut symi.0, &mut symj.0)
+            },
         )?;
         Ok(handler.all_symbols)
     }
 
-    fn symbolize_kernel_addrs(&self, addrs: &[Addr], src: &Kernel) -> Result<Vec<Vec<Sym>>> {
+    fn symbolize_kernel_addrs(&self, addrs: &[Addr], src: &Kernel) -> Result<Vec<(Sym, usize)>> {
         let Kernel {
             kallsyms,
             kernel_image,
@@ -439,10 +461,31 @@ impl Symbolizer {
 
     /// Symbolize a list of addresses.
     ///
-    /// Symbolize a list of addresses according to the configuration
-    /// provided via `src`.
+    /// Symbolize a list of addresses using the provided symbolization
+    /// [`Source`][Source].
+    ///
+    /// This function returns zero, one or more [`Sym`] objects per input
+    /// address:
+    /// - zero symbols are returned in case the address could not be symbolized
+    /// - more than one symbol is returned in case inlined function reporting is
+    ///   enabled, supported by the underlying source (e.g., ELF does not
+    ///   contain inline information, but DWARF does), and if inlined calls are
+    ///   available
+    /// - in all other cases a single symbol should be returned
+    ///
+    /// Each symbols is accompanied by the index of the input address (the
+    /// second member in each tuple). These indices are guaranteed to be
+    /// ascending. When an input address could not be symbolized, there won't be
+    /// a symbol with the corresponding index reported. If inlined functions the
+    /// corresponding [`Sym`] objects will will have the same index associated.
+    ///
+    /// If present, inlined functions are reported in the order in which their
+    /// calls are nested. For example, if the instruction at the address to
+    /// symbolize falls into a function `f` at an inlined call to `g`, which in
+    /// turn contains an inlined call to `h`, the symbols will be reported in
+    /// the order `f`, `g`, `h`.
     #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(src = ?src, addrs = format_args!("{addrs:#x?}"))))]
-    pub fn symbolize(&self, src: &Source, addrs: &[Addr]) -> Result<Vec<Vec<Sym>>> {
+    pub fn symbolize(&self, src: &Source, addrs: &[Addr]) -> Result<Vec<(Sym, usize)>> {
         match src {
             Source::Elf(Elf {
                 path,
@@ -581,11 +624,11 @@ mod tests {
             .symbolize(&src, &[the_answer_addr as Addr])
             .unwrap()
             .into_iter()
-            .flatten()
             .collect::<Vec<_>>();
         assert_eq!(results.len(), 1);
 
-        let result = results.first().unwrap();
+        let (result, addr_idx) = &results[0];
+        assert_eq!(*addr_idx, 0);
         assert_eq!(result.name, "the_answer");
         assert_eq!(result.addr, sym.addr);
     }

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -61,11 +61,10 @@ fn symbolize_elf_dwarf_gsym() {
             .symbolize(&src, &[0x2000100])
             .unwrap()
             .into_iter()
-            .flatten()
             .collect::<Vec<_>>();
         assert_eq!(results.len(), 1);
 
-        let result = results.first().unwrap();
+        let (result, _addr_idx) = &results[0];
         assert_eq!(result.name, "factorial");
         assert_eq!(result.addr, 0x2000100);
         assert_eq!(result.offset, 0);
@@ -97,11 +96,10 @@ fn symbolize_elf_dwarf_gsym() {
                 .symbolize(&src, &[0x2000100 + offset])
                 .unwrap()
                 .into_iter()
-                .flatten()
                 .collect::<Vec<_>>();
             assert_eq!(results.len(), 1);
 
-            let result = results.first().unwrap();
+            let (result, _addr_idx) = &results[0];
             assert_eq!(result.name, "factorial");
             assert_eq!(result.addr, 0x2000100);
             assert_eq!(result.offset, offset);
@@ -180,11 +178,10 @@ fn symbolize_dwarf_complex() {
         .symbolize(&src, &[0xffffffff8110ecb0])
         .unwrap()
         .into_iter()
-        .flatten()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let result = results.first().unwrap();
+    let (result, _addr_idx) = &results[0];
     assert_eq!(result.name, "abort_creds");
     assert_eq!(result.addr, 0xffffffff8110ecb0);
     assert_eq!(result.line, Some(534));
@@ -208,11 +205,10 @@ fn symbolize_elf_demangle() {
         .symbolize(&src, &[addr])
         .unwrap()
         .into_iter()
-        .flatten()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let result = &results[0];
+    let result = &results[0].0;
     assert!(
         result
             .name
@@ -226,11 +222,10 @@ fn symbolize_elf_demangle() {
         .symbolize(&src, &[addr])
         .unwrap()
         .into_iter()
-        .flatten()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let result = &results[0];
+    let result = &results[0].0;
     assert!(
         result.name == "blazesym::normalize::normalizer::Normalizer::normalize_user_addrs_sorted"
             || result.name
@@ -250,14 +245,15 @@ fn symbolize_process() {
         .symbolize(&src, &addrs)
         .unwrap()
         .into_iter()
-        .flatten()
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 2);
 
-    let result = &results[0];
+    let (result, addr_idx) = &results[0];
+    assert_eq!(*addr_idx, 0);
     assert!(result.name.contains("symbolize_process"), "{result:x?}");
 
-    let result = &results[1];
+    let (result, addr_idx) = &results[1];
+    assert_eq!(*addr_idx, 1);
     // It's not entirely clear why we have seen two different demangled
     // symbols, but they both seem legit.
     assert!(
@@ -301,11 +297,10 @@ fn normalize_elf_addr() {
             .symbolize(&src, &[norm_addr.0])
             .unwrap()
             .into_iter()
-            .flatten()
             .collect::<Vec<_>>();
         assert_eq!(results.len(), 1);
 
-        let result = results.first().unwrap();
+        let (result, _addr_idx) = &results[0];
         assert_eq!(result.name, "the_answer");
     }
 
@@ -327,7 +322,7 @@ fn inspect() {
             .collect::<Vec<_>>();
         assert_eq!(results.len(), 1);
 
-        let result = results.first().unwrap();
+        let result = &results[0];
         assert_eq!(result.addr, 0x2000100);
         assert_ne!(result.file_offset, 0);
         assert_eq!(
@@ -380,7 +375,7 @@ fn inspect_file_offset_elf() {
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let result = results.first().unwrap();
+    let result = &results[0];
     assert_ne!(result.file_offset, 0);
     let bytes = read_4bytes_at(src.path().unwrap(), result.file_offset);
     assert_eq!(bytes, [0xde, 0xad, 0xbe, 0xef]);

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -74,13 +74,12 @@ fn symbolize_elf_dwarf_gsym() {
         assert!(!result.is_null());
 
         let result = unsafe { &*result };
-        assert_eq!(result.size, 1);
-        let entries = unsafe { slice::from_raw_parts(result.entries.as_ptr(), result.size) };
+        assert_eq!(result.cnt, 1);
+        let entries = unsafe { slice::from_raw_parts(result.entries.as_ptr(), result.cnt) };
         let entry = &entries[0];
-        assert_eq!(entry.size, 1);
+        assert_eq!(entry.addr_idx, 0);
 
-        let syms = unsafe { slice::from_raw_parts(entry.syms, entry.size) };
-        let sym = &syms[0];
+        let sym = &entry.sym;
         assert_eq!(
             unsafe { CStr::from_ptr(sym.name) },
             CStr::from_bytes_with_nul(b"factorial\0").unwrap()
@@ -170,13 +169,12 @@ fn symbolize_in_process() {
     assert!(!result.is_null());
 
     let result = unsafe { &*result };
-    assert_eq!(result.size, 1);
-    let entries = unsafe { slice::from_raw_parts(result.entries.as_ptr(), result.size) };
+    assert_eq!(result.cnt, 1);
+    let entries = unsafe { slice::from_raw_parts(result.entries.as_ptr(), result.cnt) };
     let entry = &entries[0];
-    assert_eq!(entry.size, 1);
+    assert_eq!(entry.addr_idx, 0);
 
-    let syms = unsafe { slice::from_raw_parts(entry.syms, entry.size) };
-    let sym = &syms[0];
+    let sym = &entry.sym;
     assert_eq!(
         unsafe { CStr::from_ptr(sym.name) },
         CStr::from_bytes_with_nul(b"blaze_symbolizer_new\0").unwrap()


### PR DESCRIPTION
The doubly nested Vec<Vec<>> construct being returned from the Symbolizer::symbolize() method has basically been there since the beginning of time. However, it was also shown to be one of the least understood aspects of the library for users.

This change reworks the return type. We are now returning a single level of symbols, but associate each with an index of the input address it corresponds to. In so doing we can express both the lack of symbolization as well as the presence of one or more inlined functions at the address in question.
