### PR TITLE
Fully trust ELF reported sizes aside from 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added `size` member and `to_path` helper to `symbolize::Sym` type
+- Adjusted ELF symbolization code to honor symbol sizes
 
 
 0.2.0-alpha.6


### PR DESCRIPTION
When we landed da913a1f488c ("Report ELF symbols with bogus size if only conceivable match"), which effectively caused us to ignore ELF reported symbol sizes as part of symbol lookup, we were not considering the possibility of "partly available" symbols. Specifically, the "bogus size" that we saw believed to have seen was actually a misinterpretation of an instruction-to-symbolize residing in a stripped function that was located between two non-stripped symbols.
Given this new understanding of the situation, this change adjusts the ELF parser code to honor symbol sizes. The only exception is for size 0, which is treated specially by ELF and used for symbols with "no size or an unknown size".

Refs: #269