### PR TITLE
Rename `src_location` -> `code_info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
 - Introduced `symbolize::Symbolizer::symbolize_single` for more convenient
   symbolization of a single address
 - Adjusted ELF symbolization code to honor symbol sizes
+- Renamed `symbolize::Builder::enable_src_location` to `enable_code_info`
 
 
 0.2.0-alpha.6

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -41,7 +41,7 @@ fn symbolize_elf() {
     let src = Source::Elf(Elf::new(elf_vmlinux));
     let symbolizer = Symbolizer::builder()
         .enable_debug_syms(false)
-        .enable_src_location(false)
+        .enable_code_info(false)
         .build();
 
     let results = symbolizer
@@ -62,7 +62,7 @@ fn symbolize_dwarf_no_lines() {
         .join("data")
         .join("vmlinux-5.17.12-100.fc34.x86_64.dwarf");
     let src = Source::Elf(Elf::new(dwarf_vmlinux));
-    let symbolizer = Symbolizer::builder().enable_src_location(false).build();
+    let symbolizer = Symbolizer::builder().enable_code_info(false).build();
 
     let results = symbolizer
         .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -261,7 +261,7 @@ typedef struct blaze_symbolizer_opts {
    *
    * This setting implies `debug_syms` (and forces it to `true`).
    */
-  bool src_location;
+  bool code_info;
   /**
    * Whether or not to transparently demangle symbols.
    *

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -261,7 +261,7 @@ pub struct blaze_symbolizer_opts {
     /// Whether to attempt to gather source code location information.
     ///
     /// This setting implies `debug_syms` (and forces it to `true`).
-    pub src_location: bool,
+    pub code_info: bool,
     /// Whether or not to transparently demangle symbols.
     ///
     /// Demangling happens on a best-effort basis. Currently supported
@@ -291,13 +291,13 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
     let opts = unsafe { &*opts };
     let blaze_symbolizer_opts {
         debug_syms,
-        src_location,
+        code_info,
         demangle,
     } = opts;
 
     let symbolizer = Symbolizer::builder()
         .enable_debug_syms(*debug_syms)
-        .enable_src_location(*src_location)
+        .enable_code_info(*code_info)
         .enable_demangling(*demangle)
         .build();
     let symbolizer_box = Box::new(symbolizer);
@@ -649,12 +649,12 @@ mod tests {
 
         let opts = blaze_symbolizer_opts {
             debug_syms: true,
-            src_location: false,
+            code_info: false,
             demangle: true,
         };
         assert_eq!(
             format!("{opts:?}"),
-            "blaze_symbolizer_opts { debug_syms: true, src_location: false, demangle: true }"
+            "blaze_symbolizer_opts { debug_syms: true, code_info: false, demangle: true }"
         );
     }
 

--- a/src/elf/cache.rs
+++ b/src/elf/cache.rs
@@ -179,9 +179,9 @@ mod tests {
             .join("data")
             .join("test-no-debug.bin");
 
-        let src_locations = true;
+        let code_info = true;
         let debug_syms = false;
-        let cache = ElfCache::new(src_locations, debug_syms);
+        let cache = ElfCache::new(code_info, debug_syms);
         let backend_first = cache.find(Path::new(&bin_name));
         let backend_second = cache.find(Path::new(&bin_name));
         assert!(backend_first.is_ok());

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -51,7 +51,7 @@ fn symbolizer_creation() {
 fn symbolizer_creation_with_opts() {
     let opts = blaze_symbolizer_opts {
         debug_syms: true,
-        src_location: false,
+        code_info: false,
         demangle: true,
     };
     let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };


### PR DESCRIPTION
We started using the terminology "code info" rather than "source location" for everything pertaining, well, source code location information, because "source" is ambiguous in the blazesym code base as it's already used to denominate the symbolization source. With this change we whole-sale adjust the corresponding terminology in the `Builder` type and everywhere else where it is still present.