### PR TITLE
Move CodeInfo, InlinedFd, and Sym definitions into symbolize/mod.rs

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1,10 +1,7 @@
-use std::borrow::Cow;
 use std::ffi::OsStr;
-use std::ffi::OsString;
 use std::fmt::Debug;
 use std::mem::swap;
 use std::path::Path;
-use std::path::PathBuf;
 use std::rc::Rc;
 
 use crate::elf::ElfBackend;
@@ -39,6 +36,9 @@ use super::source::GsymFile;
 use super::source::Kernel;
 use super::source::Process;
 use super::source::Source;
+use super::CodeInfo;
+use super::InlinedFn;
+use super::Sym;
 
 
 /// Demangle a symbol name using the demangling scheme for the given language.
@@ -68,97 +68,6 @@ fn maybe_demangle(name: &str, language: SrcLang) -> String {
 fn maybe_demangle(name: &str, _language: SrcLang) -> String {
     // Demangling is disabled.
     name.to_string()
-}
-
-
-/// Source code location information for a symbol or inlined function.
-#[derive(Clone, Debug, PartialEq)]
-pub struct CodeInfo {
-    /// The directory in which the source file resides.
-    pub dir: Option<PathBuf>,
-    /// The file that defines the symbol.
-    pub file: OsString,
-    /// The line number of the symbolized instruction in the source
-    /// code.
-    ///
-    /// This is the line number of the instruction of the address being
-    /// symbolized, not the line number that defines the symbol
-    /// (function).
-    pub line: Option<u32>,
-    /// The column number of the symbolized instruction in the source
-    /// code.
-    pub column: Option<u16>,
-    /// The struct is non-exhaustive and open to extension.
-    pub(crate) _non_exhaustive: (),
-}
-
-impl CodeInfo {
-    /// Helper method to retrieve the path to the represented source file,
-    /// on a best-effort basis. It depends on the symbolization source data
-    /// whether this path is absolute or relative and, if its the latter, what
-    /// directory it is relative to. In general this path is mostly intended for
-    /// displaying purposes.
-    #[inline]
-    pub fn to_path(&self) -> Cow<'_, Path> {
-        self.dir.as_ref().map_or_else(
-            || Cow::Borrowed(Path::new(&self.file)),
-            |dir| Cow::Owned(dir.join(&self.file)),
-        )
-    }
-}
-
-
-/// A type representing an inlined function.
-#[derive(Clone, Debug, PartialEq)]
-pub struct InlinedFn {
-    /// The symbol name of the function.
-    pub name: String,
-    /// Source code location information for the call to the function.
-    pub code_info: Option<CodeInfo>,
-    /// The struct is non-exhaustive and open to extension.
-    pub(crate) _non_exhaustive: (),
-}
-
-
-/// The result of address symbolization by [`Symbolizer`].
-#[derive(Clone, Debug, PartialEq)]
-pub struct Sym {
-    /// The symbol name that an address belongs to.
-    pub name: String,
-    /// The address at which the symbol is located (i.e., its "start").
-    ///
-    /// This is the "normalized" address of the symbol, as present in
-    /// the file (and reported by tools such as `readelf(1)`,
-    /// `llvm-gsymutil`, or similar).
-    pub addr: Addr,
-    /// The byte offset of the address that got symbolized from the
-    /// start of the symbol (i.e., from `addr`).
-    ///
-    /// E.g., when normalizing address 0x1337 of a function that starts at
-    /// 0x1330, the offset will be set to 0x07 (and `addr` will be 0x1330). This
-    /// member is especially useful in contexts when input addresses are not
-    /// already normalized, such as when normalizing an address in a process
-    /// context (which may have been relocated and/or have layout randomizations
-    /// applied).
-    pub offset: usize,
-    /// The symbol's size, if available.
-    pub size: Option<usize>,
-    /// Source code location information for the symbol.
-    pub code_info: Option<CodeInfo>,
-    /// Inlined function information, if requested and available.
-    ///
-    /// Availability depends on both the underlying symbolization source (e.g.,
-    /// ELF does not contain inline information, but DWARF does) as well as
-    /// whether a function was actually inlined at the address in question.
-    ///
-    /// Inlined functions are reported in the order in which their calls are
-    /// nested. For example, if the instruction at the address to symbolize
-    /// falls into a function `f` at an inlined call to `g`, which in turn
-    /// contains an inlined call to `h`, the symbols will be reported in the
-    /// order `f`, `g`, `h`.
-    pub inlined: Box<[InlinedFn]>,
-    /// The struct is non-exhaustive and open to extension.
-    pub(crate) _non_exhaustive: (),
 }
 
 
@@ -666,7 +575,9 @@ impl Default for Symbolizer {
 mod tests {
     use super::*;
 
+    use std::ffi::OsString;
     use std::mem::transmute;
+    use std::path::PathBuf;
 
     use crate::elf::ElfParser;
     use crate::inspect::FindAddrOpts;


### PR DESCRIPTION
The CodeInfo, InlinedFd, and Sym type definitions are somewhat hard to find inside symbolize/symbolizer.rs and also conceptually don't exactly belong in there.
With this change we move them into symbolize/mod.rs.