### PR TITLE
Introduce and use Symbolized enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Unreleased
 ----------
 - "Flattened" return type of `symbolize::Symbolizer::symbolize` method from
-  nested `Vec` to a single level `Vec` with indices of corresponding input
-  address
+  nested `Vec` to a single level `Vec` of newly introduced
+  `symbolize::Symbolized` enum
 - Further changes to `symbolize::Sym`:
   - Added `size` member and `to_path` helper method
   - Factored out `CodeInfo` type capturing all source code location information

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -44,14 +44,12 @@ fn symbolize_elf() {
         .enable_code_info(false)
         .build();
 
-    let results = symbolizer
-        .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
+    let result = symbolizer
+        .symbolize_single(black_box(&src), black_box(0xffffffff8110ecb0))
         .unwrap()
-        .into_iter()
-        .collect::<Vec<_>>();
-    assert_eq!(results.len(), 1);
+        .into_sym()
+        .unwrap();
 
-    let result = &results[0].0;
     assert_eq!(result.name, "abort_creds");
 }
 
@@ -64,14 +62,12 @@ fn symbolize_dwarf_no_lines() {
     let src = Source::Elf(Elf::new(dwarf_vmlinux));
     let symbolizer = Symbolizer::builder().enable_code_info(false).build();
 
-    let results = symbolizer
-        .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
+    let result = symbolizer
+        .symbolize_single(black_box(&src), black_box(0xffffffff8110ecb0))
         .unwrap()
-        .into_iter()
-        .collect::<Vec<_>>();
-    assert_eq!(results.len(), 1);
+        .into_sym()
+        .unwrap();
 
-    let result = &results[0].0;
     assert_eq!(result.name, "abort_creds");
     assert_eq!(result.code_info.as_ref(), None);
 }
@@ -85,14 +81,12 @@ fn symbolize_dwarf() {
     let src = Source::Elf(Elf::new(dwarf_vmlinux));
     let symbolizer = Symbolizer::new();
 
-    let results = symbolizer
-        .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
+    let result = symbolizer
+        .symbolize_single(black_box(&src), black_box(0xffffffff8110ecb0))
         .unwrap()
-        .into_iter()
-        .collect::<Vec<_>>();
-    assert_eq!(results.len(), 1);
+        .into_sym()
+        .unwrap();
 
-    let result = &results[0].0;
     assert_eq!(result.name, "abort_creds");
     assert_eq!(result.code_info.as_ref().unwrap().line, Some(534));
 }
@@ -106,14 +100,12 @@ fn symbolize_gsym() {
     let src = Source::from(GsymFile::new(gsym_vmlinux));
     let symbolizer = Symbolizer::new();
 
-    let results = symbolizer
-        .symbolize(black_box(&src), black_box(&[0xffffffff8110ecb0]))
+    let result = symbolizer
+        .symbolize_single(black_box(&src), black_box(0xffffffff8110ecb0))
         .unwrap()
-        .into_iter()
-        .collect::<Vec<_>>();
-    assert_eq!(results.len(), 1);
+        .into_sym()
+        .unwrap();
 
-    let result = &results[0].0;
     assert_eq!(result.name, "abort_creds");
 }
 

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -4,11 +4,47 @@ use anyhow::bail;
 use anyhow::Context as _;
 use anyhow::Result;
 
+use blazesym::symbolize::CodeInfo;
 use blazesym::symbolize::Elf;
 use blazesym::symbolize::Source;
 use blazesym::symbolize::Sym;
+use blazesym::symbolize::Symbolized;
 use blazesym::symbolize::Symbolizer;
 use blazesym::Addr;
+
+const ADDR_WIDTH: usize = 16;
+
+
+fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &Option<CodeInfo>) {
+    let code_info = if let Some(code_info) = code_info {
+        let path = code_info.to_path();
+        let path = path.display();
+
+        match (code_info.line, code_info.column) {
+            (Some(line), Some(col)) => format!(" {path}:{line}:{col}"),
+            (Some(line), None) => format!(" {path}:{line}"),
+            (None, _) => format!(" {path}"),
+        }
+    } else {
+        String::new()
+    };
+
+    if let Some((input_addr, addr, offset)) = addr_info {
+        // If we have various address information bits we have a new symbol.
+        println!(
+            "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            width = ADDR_WIDTH
+        )
+    } else {
+        // Otherwise we are dealing with an inlined call.
+        println!(
+            "{:width$}  {name} @ {code_info} [inlined]",
+            " ",
+            width = ADDR_WIDTH
+        )
+    }
+}
+
 
 fn main() -> Result<()> {
     let args = env::args().collect::<Vec<_>>();
@@ -33,55 +69,25 @@ fn main() -> Result<()> {
         .symbolize(&src, &addrs)
         .with_context(|| format!("failed to symbolize address {addr:#x}"))?;
 
-    let addr_width = 16;
-    let mut prev_addr_idx = None;
-
-    for (sym, addr_idx) in syms {
-        if let Some(idx) = prev_addr_idx {
-            // Print a line for all addresses that did not get symbolized.
-            for input_addr in addrs.iter().take(addr_idx).skip(idx + 1) {
-                println!("{input_addr:#0width$x}: <no-symbol>", width = addr_width)
+    for (input_addr, sym) in addrs.iter().copied().zip(syms) {
+        match sym {
+            Symbolized::Sym(Sym {
+                name,
+                addr,
+                offset,
+                code_info,
+                inlined,
+                ..
+            }) => {
+                print_frame(&name, Some((input_addr, addr, offset)), &code_info);
+                for frame in inlined.iter() {
+                    print_frame(&frame.name, None, &frame.code_info);
+                }
+            }
+            Symbolized::Unknown => {
+                println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
             }
         }
-
-        let Sym {
-            name,
-            addr,
-            offset,
-            code_info,
-            ..
-        } = &sym;
-
-        let src_loc = if let Some(code_info) = code_info {
-            let path = code_info.to_path();
-            let path = path.display();
-
-            match (code_info.line, code_info.column) {
-                (Some(line), Some(col)) => format!(" {path}:{line}:{col}"),
-                (Some(line), None) => format!(" {path}:{line}"),
-                (None, _) => format!(" {path}"),
-            }
-        } else {
-            String::new()
-        };
-
-        if prev_addr_idx != Some(addr_idx) {
-            // If the address index changed we reached a new symbol.
-            println!(
-                "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{src_loc}",
-                input_addr = addrs[addr_idx],
-                width = addr_width
-            );
-        } else {
-            // Otherwise we are dealing with an inlined call.
-            println!(
-                "{:width$}  {name} @ {addr:#x}+{offset:#x}{src_loc}",
-                " ",
-                width = addr_width
-            );
-        }
-
-        prev_addr_idx = Some(addr_idx);
     }
     Ok(())
 }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -4,11 +4,47 @@ use anyhow::bail;
 use anyhow::Context as _;
 use anyhow::Result;
 
+use blazesym::symbolize::CodeInfo;
 use blazesym::symbolize::Process;
 use blazesym::symbolize::Source;
 use blazesym::symbolize::Sym;
+use blazesym::symbolize::Symbolized;
 use blazesym::symbolize::Symbolizer;
 use blazesym::Addr;
+
+const ADDR_WIDTH: usize = 16;
+
+
+fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &Option<CodeInfo>) {
+    let code_info = if let Some(code_info) = code_info {
+        let path = code_info.to_path();
+        let path = path.display();
+
+        match (code_info.line, code_info.column) {
+            (Some(line), Some(col)) => format!(" {path}:{line}:{col}"),
+            (Some(line), None) => format!(" {path}:{line}"),
+            (None, _) => format!(" {path}"),
+        }
+    } else {
+        String::new()
+    };
+
+    if let Some((input_addr, addr, offset)) = addr_info {
+        // If we have various address information bits we have a new symbol.
+        println!(
+            "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            width = ADDR_WIDTH
+        )
+    } else {
+        // Otherwise we are dealing with an inlined call.
+        println!(
+            "{:width$}  {name} @ {code_info} [inlined]",
+            " ",
+            width = ADDR_WIDTH
+        )
+    }
+}
+
 
 fn main() -> Result<()> {
     let args = env::args().collect::<Vec<_>>();
@@ -36,55 +72,25 @@ print its symbol, the file name of the source, and the line number.",
         .symbolize(&src, &addrs)
         .with_context(|| format!("failed to symbolize address {addr:#x}"))?;
 
-    let addr_width = 16;
-    let mut prev_addr_idx = None;
-
-    for (sym, addr_idx) in syms {
-        if let Some(idx) = prev_addr_idx {
-            // Print a line for all addresses that did not get symbolized.
-            for input_addr in addrs.iter().take(addr_idx).skip(idx + 1) {
-                println!("{input_addr:#0width$x}: <no-symbol>", width = addr_width)
+    for (input_addr, sym) in addrs.iter().copied().zip(syms) {
+        match sym {
+            Symbolized::Sym(Sym {
+                name,
+                addr,
+                offset,
+                code_info,
+                inlined,
+                ..
+            }) => {
+                print_frame(&name, Some((input_addr, addr, offset)), &code_info);
+                for frame in inlined.iter() {
+                    print_frame(&frame.name, None, &frame.code_info);
+                }
+            }
+            Symbolized::Unknown => {
+                println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
             }
         }
-
-        let Sym {
-            name,
-            addr,
-            offset,
-            code_info,
-            ..
-        } = &sym;
-
-        let src_loc = if let Some(code_info) = code_info {
-            let path = code_info.to_path();
-            let path = path.display();
-
-            match (code_info.line, code_info.column) {
-                (Some(line), Some(col)) => format!(" {path}:{line}:{col}"),
-                (Some(line), None) => format!(" {path}:{line}"),
-                (None, _) => format!(" {path}"),
-            }
-        } else {
-            String::new()
-        };
-
-        if prev_addr_idx != Some(addr_idx) {
-            // If the address index changed we reached a new symbol.
-            println!(
-                "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{src_loc}",
-                input_addr = addrs[addr_idx],
-                width = addr_width
-            );
-        } else {
-            // Otherwise we are dealing with an inlined call.
-            println!(
-                "{:width$}  {name} @ {addr:#x}+{offset:#x}{src_loc}",
-                " ",
-                width = addr_width
-            );
-        }
-
-        prev_addr_idx = Some(addr_idx);
     }
     Ok(())
 }

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -309,6 +309,8 @@ typedef struct blaze_symbolize_code_info {
 typedef struct blaze_sym {
   /**
    * The symbol name is where the given address should belong to.
+   *
+   * If an address could not be symbolized, this member will be NULL.
    */
   const char *name;
   /**
@@ -338,21 +340,6 @@ typedef struct blaze_sym {
 } blaze_sym;
 
 /**
- * `blaze_entry` is the output of symbolization for a call frame.
- */
-typedef struct blaze_entry {
-  /**
-   * The symbol.
-   */
-  struct blaze_sym sym;
-  /**
-   * The index of the input address to which this symbolization result
-   * belongs.
-   */
-  size_t addr_idx;
-} blaze_entry;
-
-/**
  * `blaze_result` is the result of symbolization for C API.
  *
  * Instances of [`blaze_result`] are returned by any of the `blaze_symbolize_*`
@@ -364,13 +351,12 @@ typedef struct blaze_result {
    */
   size_t cnt;
   /**
-   * The entries for addresses.
+   * The symbols corresponding to input addresses.
    *
-   * Symbolization occurs based on the order of addresses.
-   * Therefore, every address must have an entry here on the same
-   * order.
+   * Symbolization happens based on the ordering of (input) addresses.
+   * Therefore, every input address has an associated symbol.
    */
-  struct blaze_entry entries[0];
+  struct blaze_sym syms[0];
 } blaze_result;
 
 /**

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -10,12 +10,46 @@
 //! # use std::mem::size_of;
 //! # use std::mem::transmute;
 //! # use std::ptr;
-//! use blazesym::symbolize::Source;
+//! use blazesym::symbolize::CodeInfo;
 //! use blazesym::symbolize::Process;
+//! use blazesym::symbolize::Source;
 //! use blazesym::symbolize::Sym;
+//! use blazesym::symbolize::Symbolized;
 //! use blazesym::symbolize::Symbolizer;
 //! use blazesym::Addr;
 //! use blazesym::Pid;
+//!
+//! const ADDR_WIDTH: usize = 16;
+//!
+//! fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &Option<CodeInfo>) {
+//!     let code_info = if let Some(code_info) = code_info {
+//!         let path = code_info.to_path();
+//!         let path = path.display();
+//!
+//!         match (code_info.line, code_info.column) {
+//!             (Some(line), Some(col)) => format!(" {path}:{line}:{col}"),
+//!             (Some(line), None) => format!(" {path}:{line}"),
+//!             (None, _) => format!(" {path}"),
+//!         }
+//!     } else {
+//!         String::new()
+//!     };
+//!
+//!     if let Some((input_addr, addr, offset)) = addr_info {
+//!         // If we have various address information bits we have a new symbol.
+//!         println!(
+//!             "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+//!             width = ADDR_WIDTH
+//!         )
+//!     } else {
+//!         // Otherwise we are dealing with an inlined call.
+//!         println!(
+//!             "{:width$}  {name} @ {code_info} [inlined]",
+//!             " ",
+//!             width = ADDR_WIDTH
+//!         )
+//!     }
+//! }
 //!
 //! # assert_eq!(size_of::<*mut libc::c_void>(), size_of::<Addr>());
 //! // Retrieve up to 64 stack frames of the calling thread.
@@ -32,55 +66,25 @@
 //! let symbolizer = Symbolizer::new();
 //! let syms = symbolizer.symbolize(&src, addrs).unwrap();
 //!
-//! let addr_width = 16;
-//! let mut prev_addr_idx = None;
-//!
-//! for (sym, addr_idx) in syms {
-//!     if let Some(idx) = prev_addr_idx {
-//!         // Print a line for all addresses that did not get symbolized.
-//!         for input_addr in addrs.iter().take(addr_idx).skip(idx + 1) {
-//!             println!("{input_addr:#0width$x}: <no-symbol>", width = addr_width)
+//! for (input_addr, sym) in addrs.iter().copied().zip(syms) {
+//!     match sym {
+//!         Symbolized::Sym(Sym {
+//!             name,
+//!             addr,
+//!             offset,
+//!             code_info,
+//!             inlined,
+//!             ..
+//!         }) => {
+//!             print_frame(&name, Some((input_addr, addr, offset)), &code_info);
+//!             for frame in inlined.iter() {
+//!                 print_frame(&frame.name, None, &frame.code_info);
+//!             }
+//!         }
+//!         Symbolized::Unknown => {
+//!             println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
 //!         }
 //!     }
-//!
-//!     let Sym {
-//!         name,
-//!         addr,
-//!         offset,
-//!         code_info,
-//!         ..
-//!     } = &sym;
-//!
-//!     let src_loc = if let Some(code_info) = code_info {
-//!         let path = code_info.to_path();
-//!         let path = path.display();
-//!
-//!         match (code_info.line, code_info.column) {
-//!             (Some(line), Some(col)) => format!(" {path}:{line}:{col}"),
-//!             (Some(line), None) => format!(" {path}:{line}"),
-//!             (None, _) => format!(" {path}"),
-//!         }
-//!     } else {
-//!         String::new()
-//!     };
-//!
-//!     if prev_addr_idx != Some(addr_idx) {
-//!         // If the address index changed we reached a new symbol.
-//!         println!(
-//!             "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{src_loc}",
-//!             input_addr = addrs[addr_idx],
-//!             width = addr_width
-//!         );
-//!     } else {
-//!         // Otherwise we are dealing with an inlined call.
-//!         println!(
-//!             "{:width$}  {name} @ {addr:#x}+{offset:#x}{src_loc}",
-//!             " ",
-//!             width = addr_width
-//!         );
-//!     }
-//!
-//!     prev_addr_idx = Some(addr_idx);
 //! }
 //! ```
 
@@ -228,4 +232,38 @@ pub struct Sym {
     pub inlined: Box<[InlinedFn]>,
     /// The struct is non-exhaustive and open to extension.
     pub(crate) _non_exhaustive: (),
+}
+
+
+/// An enumeration used as reporting vehicle for address symbolization.
+// We keep this enum as exhaustive because additions to it, should they occur,
+// are expected to be backwards-compatibility breaking.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Symbolized {
+    /// The input address was symbolized as the provided symbol.
+    Sym(Sym),
+    /// The input address was not found and could not be symbolized.
+    Unknown,
+}
+
+impl Symbolized {
+    /// Convert the object into a [`Sym`] reference, if the corresponding
+    /// variant is active.
+    #[inline]
+    pub fn as_sym(&self) -> Option<&Sym> {
+        match self {
+            Self::Sym(sym) => Some(sym),
+            Self::Unknown => None,
+        }
+    }
+
+    /// Convert the object into a [`Sym`] object, if the corresponding variant
+    /// is active.
+    #[inline]
+    pub fn into_sym(self) -> Option<Sym> {
+        match self {
+            Self::Sym(sym) => Some(sym),
+            Self::Unknown => None,
+        }
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,16 +11,8 @@ use std::ptr::NonNull;
 use std::slice;
 
 
-#[inline]
-fn swap_array_elems<T>(array: &mut [T], i: usize, j: usize) {
-    array.swap(i, j)
-}
-
 /// Reorder elements of `array` based on index information in `indices`.
-fn reorder<T, U, S>(array: &mut [T], indices: Vec<(U, usize)>, mut swap: S)
-where
-    S: FnMut(&mut [T], usize, usize),
-{
+fn reorder<T, U>(array: &mut [T], indices: Vec<(U, usize)>) {
     debug_assert_eq!(array.len(), indices.len());
 
     let mut indices = indices;
@@ -28,38 +20,13 @@ where
     // (second member).
     for i in 0..array.len() {
         while indices[i].1 != i {
-            let () = swap(array, i, indices[i].1);
+            let () = array.swap(i, indices[i].1);
             let idx = indices[i].1;
             let () = indices.swap(i, idx);
         }
     }
 }
 
-
-/// [`with_ordered_elems`], but with a customizable "swap" function.
-pub(crate) fn with_ordered_elems_with_swap<T, U, E, H, R, Err, S>(
-    slice: &[T],
-    extract: E,
-    handle: H,
-    swap: S,
-) -> Result<R, Err>
-where
-    T: Copy + Ord,
-    E: FnOnce(&mut R) -> &mut [U],
-    H: FnOnce(iter::Map<slice::Iter<'_, (T, usize)>, fn(&(T, usize)) -> T>) -> Result<R, Err>,
-    S: FnMut(&mut [U], usize, usize),
-{
-    let mut vec = slice
-        .iter()
-        .enumerate()
-        .map(|(idx, t)| (*t, idx))
-        .collect::<Vec<_>>();
-    let () = vec.sort_unstable();
-
-    let mut result = handle(vec.iter().map(|(t, _idx)| *t))?;
-    let () = reorder(extract(&mut result), vec, swap);
-    Ok(result)
-}
 
 /// Take a slice `slice` of unordered elements, sort them into a vector, then
 /// invoke a function `handle` on the vector, take the result of this function
@@ -75,7 +42,16 @@ where
     E: FnOnce(&mut R) -> &mut [U],
     H: FnOnce(iter::Map<slice::Iter<'_, (T, usize)>, fn(&(T, usize)) -> T>) -> Result<R, Err>,
 {
-    with_ordered_elems_with_swap(slice, extract, handle, swap_array_elems)
+    let mut vec = slice
+        .iter()
+        .enumerate()
+        .map(|(idx, t)| (*t, idx))
+        .collect::<Vec<_>>();
+    let () = vec.sort_unstable();
+
+    let mut result = handle(vec.iter().map(|(t, _idx)| *t))?;
+    let () = reorder(extract(&mut result), vec);
+    Ok(result)
 }
 
 
@@ -450,17 +426,16 @@ mod tests {
     #[test]
     fn array_reordering() {
         let mut array = vec![];
-        reorder::<usize, (), _>(&mut array, vec![], swap_array_elems);
+        reorder::<usize, ()>(&mut array, vec![]);
 
         let mut array = vec![8];
-        reorder(&mut array, vec![((), 0)], swap_array_elems);
+        reorder(&mut array, vec![((), 0)]);
         assert_eq!(array, vec![8]);
 
         let mut array = vec![8, 1, 4, 0, 3];
         reorder(
             &mut array,
             [4, 1, 3, 0, 2].into_iter().map(|x| ((), x)).collect(),
-            swap_array_elems,
         );
         assert_eq!(array, vec![0, 1, 3, 4, 8]);
     }

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -63,7 +63,7 @@ fn symbolizer_creation_with_opts() {
 /// GSYM.
 #[test]
 fn symbolize_elf_dwarf_gsym() {
-    fn test<F>(symbolize: F, has_src_loc: bool)
+    fn test<F>(symbolize: F, has_code_info: bool)
     where
         F: FnOnce(*mut blaze_symbolizer, *const Addr, usize) -> *const blaze_result,
     {
@@ -75,11 +75,8 @@ fn symbolize_elf_dwarf_gsym() {
 
         let result = unsafe { &*result };
         assert_eq!(result.cnt, 1);
-        let entries = unsafe { slice::from_raw_parts(result.entries.as_ptr(), result.cnt) };
-        let entry = &entries[0];
-        assert_eq!(entry.addr_idx, 0);
-
-        let sym = &entry.sym;
+        let syms = unsafe { slice::from_raw_parts(result.syms.as_ptr(), result.cnt) };
+        let sym = &syms[0];
         assert_eq!(
             unsafe { CStr::from_ptr(sym.name) },
             CStr::from_bytes_with_nul(b"factorial\0").unwrap()
@@ -87,7 +84,7 @@ fn symbolize_elf_dwarf_gsym() {
         assert_eq!(sym.addr, 0x2000100);
         assert_eq!(sym.offset, 0);
 
-        if has_src_loc {
+        if has_code_info {
             assert!(!sym.code_info.dir.is_null());
             assert!(!sym.code_info.file.is_null());
             assert_eq!(
@@ -170,11 +167,8 @@ fn symbolize_in_process() {
 
     let result = unsafe { &*result };
     assert_eq!(result.cnt, 1);
-    let entries = unsafe { slice::from_raw_parts(result.entries.as_ptr(), result.cnt) };
-    let entry = &entries[0];
-    assert_eq!(entry.addr_idx, 0);
-
-    let sym = &entry.sym;
+    let syms = unsafe { slice::from_raw_parts(result.syms.as_ptr(), result.cnt) };
+    let sym = &syms[0];
     assert_eq!(
         unsafe { CStr::from_ptr(sym.name) },
         CStr::from_bytes_with_nul(b"blaze_symbolizer_new\0").unwrap()


### PR DESCRIPTION
After going back and forth about the approach to returning symbolized symbols, we concluded that the property if having a 1:1 mapping from input address index to resulting symbol index is desirable to have. To that end, this change removes the index based reporting logic and replaces it with a custom enumeration that encapsulates both successful symbolization as well as non-symbolized addresses in its variants. We decided against the usage of an Option to open up the possibility of adding more variants in the future.