### PR TITLE
Simplify Unit::find_function_or_location()

### DIFF
--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -116,11 +116,11 @@ impl<'dwarf> Unit<'dwarf> {
             .map_err(gimli::Error::clone)
     }
 
-    pub(super) fn find_function_or_location(
+    pub(super) fn find_function(
         &self,
         probe: u64,
         sections: &gimli::Dwarf<R<'dwarf>>,
-    ) -> Result<(Option<&Function<'dwarf>>, Option<Location<'_>>), gimli::Error> {
+    ) -> Result<Option<&Function<'dwarf>>, gimli::Error> {
         let unit = &self.dw_unit;
         let functions = self.parse_functions_dwarf_and_unit(unit, sections)?;
         let function = match functions.find_address(probe) {
@@ -133,8 +133,7 @@ impl<'dwarf> Unit<'dwarf> {
             }
             None => None,
         };
-        let location = self.find_location(probe, sections)?;
-        Ok((function, location))
+        Ok(function)
     }
 
     pub(super) fn find_name<'slf>(

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -301,17 +301,8 @@ impl<'dwarf> Units<'dwarf> {
     ) -> Result<Option<(&Function<'dwarf>, Option<gimli::DwLang>)>, gimli::Error> {
         let units_iter = self.find_units(probe);
         for unit in units_iter {
-            let result = unit.find_function_or_location(probe, &self.dwarf)?;
-            match result {
-                (Some(function), _) => return Ok(Some((function, unit.language()))),
-                (None, Some(_location)) => {
-                    // We found the address in the unit, we just couldn't get
-                    // any symbol information.
-                    return Ok(None)
-                }
-                (None, None) => {
-                    // No luck. Let's try another unit.
-                }
+            if let Some(function) = unit.find_function(probe, &self.dwarf)? {
+                return Ok(Some((function, unit.language())))
             }
         }
         Ok(None)


### PR DESCRIPTION
The Unit::find_function_or_location() method is rather confusing and convoluted. The name seems to imply that "either or" is returned (at least that's always my reading of it) and it returns two things but the caller really only needs the first one. That's mostly because we kept its original intent and workings so far.
With this change we simplify it, renaming it to find_function() and making it return only the function, if found.