### PR TITLE
Properly demangle inlined calls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
           # https://github.com/japaric/rust-san#unrealiable-leaksanitizer
           sed -i '/\[features\]/i [profile.dev]' Cargo.toml
           sed -i '/profile.dev/a opt-level = 1' Cargo.toml
+          sed -i '/profile.dev/a debug-assertions = false' Cargo.toml
           cat Cargo.toml
     - name: cargo test -Zsanitizer=${{ matrix.sanitizer }}
       env:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -85,7 +85,7 @@ fn print_frame(
     addr_info: Option<(Addr, Addr, usize)>,
     code_info: &Option<symbolize::CodeInfo>,
 ) {
-    let code_info = if let Some(code_info) = code_info {
+    let code_info = code_info.as_ref().map(|code_info| {
         let path = code_info.to_path();
         let path = path.display();
 
@@ -94,21 +94,24 @@ fn print_frame(
             (Some(line), None) => format!(" {path}:{line}"),
             (None, _) => format!(" {path}"),
         }
-    } else {
-        String::new()
-    };
+    });
 
     if let Some((input_addr, addr, offset)) = addr_info {
         // If we have various address information bits we have a new symbol.
         println!(
             "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            code_info = code_info.as_deref().unwrap_or(""),
             width = ADDR_WIDTH
         )
     } else {
         // Otherwise we are dealing with an inlined call.
         println!(
-            "{:width$}  {name} @ {code_info} [inlined]",
+            "{:width$}  {name}{code_info} [inlined]",
             " ",
+            code_info = code_info
+                .map(|info| format!(" @{info}"))
+                .as_deref()
+                .unwrap_or(""),
             width = ADDR_WIDTH
         )
     }

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -16,7 +16,7 @@ const ADDR_WIDTH: usize = 16;
 
 
 fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &Option<CodeInfo>) {
-    let code_info = if let Some(code_info) = code_info {
+    let code_info = code_info.as_ref().map(|code_info| {
         let path = code_info.to_path();
         let path = path.display();
 
@@ -25,21 +25,24 @@ fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &O
             (Some(line), None) => format!(" {path}:{line}"),
             (None, _) => format!(" {path}"),
         }
-    } else {
-        String::new()
-    };
+    });
 
     if let Some((input_addr, addr, offset)) = addr_info {
         // If we have various address information bits we have a new symbol.
         println!(
             "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            code_info = code_info.as_deref().unwrap_or(""),
             width = ADDR_WIDTH
         )
     } else {
         // Otherwise we are dealing with an inlined call.
         println!(
-            "{:width$}  {name} @ {code_info} [inlined]",
+            "{:width$}  {name}{code_info} [inlined]",
             " ",
+            code_info = code_info
+                .map(|info| format!(" @{info}"))
+                .as_deref()
+                .unwrap_or(""),
             width = ADDR_WIDTH
         )
     }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -16,7 +16,7 @@ const ADDR_WIDTH: usize = 16;
 
 
 fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &Option<CodeInfo>) {
-    let code_info = if let Some(code_info) = code_info {
+    let code_info = code_info.as_ref().map(|code_info| {
         let path = code_info.to_path();
         let path = path.display();
 
@@ -25,21 +25,24 @@ fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &O
             (Some(line), None) => format!(" {path}:{line}"),
             (None, _) => format!(" {path}"),
         }
-    } else {
-        String::new()
-    };
+    });
 
     if let Some((input_addr, addr, offset)) = addr_info {
         // If we have various address information bits we have a new symbol.
         println!(
             "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            code_info = code_info.as_deref().unwrap_or(""),
             width = ADDR_WIDTH
         )
     } else {
         // Otherwise we are dealing with an inlined call.
         println!(
-            "{:width$}  {name} @ {code_info} [inlined]",
+            "{:width$}  {name}{code_info} [inlined]",
             " ",
+            code_info = code_info
+                .map(|info| format!(" @{info}"))
+                .as_deref()
+                .unwrap_or(""),
             width = ADDR_WIDTH
         )
     }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -21,8 +21,12 @@
 //!
 //! const ADDR_WIDTH: usize = 16;
 //!
-//! fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &Option<CodeInfo>) {
-//!     let code_info = if let Some(code_info) = code_info {
+//! fn print_frame(
+//!     name: &str,
+//!     addr_info: Option<(Addr, Addr, usize)>,
+//!     code_info: &Option<CodeInfo>,
+//! ) {
+//!     let code_info = code_info.as_ref().map(|code_info| {
 //!         let path = code_info.to_path();
 //!         let path = path.display();
 //!
@@ -31,21 +35,24 @@
 //!             (Some(line), None) => format!(" {path}:{line}"),
 //!             (None, _) => format!(" {path}"),
 //!         }
-//!     } else {
-//!         String::new()
-//!     };
+//!     });
 //!
 //!     if let Some((input_addr, addr, offset)) = addr_info {
 //!         // If we have various address information bits we have a new symbol.
 //!         println!(
 //!             "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+//!             code_info = code_info.as_deref().unwrap_or(""),
 //!             width = ADDR_WIDTH
 //!         )
 //!     } else {
 //!         // Otherwise we are dealing with an inlined call.
 //!         println!(
-//!             "{:width$}  {name} @ {code_info} [inlined]",
+//!             "{:width$}  {name}{code_info} [inlined]",
 //!             " ",
+//!             code_info = code_info
+//!                 .map(|info| format!(" @{info}"))
+//!                 .as_deref()
+//!                 .unwrap_or(""),
 //!             width = ADDR_WIDTH
 //!         )
 //!     }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -214,12 +214,19 @@ impl Symbolizer {
             (None, None)
         };
 
+        let IntSym {
+            name: sym_name,
+            addr: sym_addr,
+            size: sym_size,
+            lang,
+        } = sym;
+
         let inlined = if let Some(code_info) = &addr_code_info {
             code_info
                 .inlined
                 .iter()
                 .map(|(name, info)| {
-                    let name = name.to_string();
+                    let name = self.maybe_demangle(name, lang);
                     let info = info.as_ref().map(CodeInfo::from);
                     InlinedFn {
                         name,
@@ -231,13 +238,6 @@ impl Symbolizer {
         } else {
             Vec::new()
         };
-
-        let IntSym {
-            name: sym_name,
-            addr: sym_addr,
-            size: sym_size,
-            lang,
-        } = sym;
 
         let sym = Sym {
             name: self.maybe_demangle(name.unwrap_or(sym_name), lang),


### PR DESCRIPTION
We missed to honor the demangle setting for the recently added inlined function calls. Make sure to demangle their names as necessary and desired.
Also adjust the various symbolization snippets floating around to fix some formatting issues.

```
$ cargo run --example=backtrace
> 0x005606435278e0: backtrace::symbolize_current_bt @ 0x2e770+0x170 blazesym/examples/backtrace.rs:59:18
> 0x00560643528255: backtrace::h @ 0x2f250+0x5 blazesym/examples/backtrace.rs:111:5
> 0x00560643528245: backtrace::f @ 0x2f240+0x5 blazesym/examples/backtrace.rs:101:5
>                   backtrace::g @ blazesym/examples/backtrace.rs:106:5 [inlined]
> 0x00560643528265: backtrace::main @ 0x2f260+0x5 blazesym/examples/backtrace.rs:115:5
> 0x00560643524f8a: core::ops::function::FnOnce::call_once @ 0x2bf80+0xa /rustc/core/src/ops/function.rs:250:5
> 0x00560643524f4d: std::sys_common::backtrace::__rust_begin_short_backtrace @ 0x2bf40+0xd /rustc/std/src/sys_common/backtrace.rs:135:18
> 0x00560643525d50: std::rt::lang_start::{{closure}} @ 0x2cd40+0x10 /rustc/std/src/rt.rs:166:18
> 0x005606436ddb9a: std::rt::lang_start_internal @ 0x1e4780+0x41a
> 0x00560643525d29: std::rt::lang_start @ 0x2ccf0+0x39 /rustc/std/src/rt.rs:165:17
> 0x0056064352828d: main @ 0x2f270+0x1d
> 0x007f42319ed8c9: <no-symbol>
> 0x007f42319ed984: __libc_start_main @ 0x23900+0x84
> 0x00560643524990: _start @ 0x2b970+0x20
```