### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 25
+    rebase-strategy: "auto"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    versioning-strategy: "auto"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a Dependabot configuration for GitHub Actions and Cargo. I have no idea whether the Cargo logic is of any use for us, because the documentation is pretty nondescript. So we have to try it out.