### PR TITLE
Use Swatinem/rust-cache@v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
         override: true
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
-    - uses: Swatinem/rust-cache@v2.7.0
+    - uses: Swatinem/rust-cache@v2
     - name: Run benchmarks
       shell: bash
       run: |


### PR DESCRIPTION
Let's depended on `Swatinem/rust-cache@v2` instead of `Swatinem/rust-cache@v2.x.y`. The former gets automatically bumped when a new release is cut, which is more convenient than having a pull request created every time (though it comes at the cost of being less obvious).