### PR TITLE
Expose inlined functions through C API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,6 @@ jobs:
           # https://github.com/japaric/rust-san#unrealiable-leaksanitizer
           sed -i '/\[features\]/i [profile.dev]' Cargo.toml
           sed -i '/profile.dev/a opt-level = 1' Cargo.toml
-          sed -i '/profile.dev/a debug-assertions = false' Cargo.toml
           cat Cargo.toml
     - name: cargo test -Zsanitizer=${{ matrix.sanitizer }}
       env:

--- a/data/test.rs
+++ b/data/test.rs
@@ -1,0 +1,33 @@
+#![no_std]
+#![no_main]
+
+use core::hint::black_box;
+
+
+#[inline(never)]
+fn uninlined_call() -> usize {
+    let x = 1337;
+    x + 42
+}
+
+#[inline(always)]
+fn inlined_call() -> usize {
+    uninlined_call()
+}
+
+#[inline(never)]
+fn test_function() -> usize {
+    let x = inlined_call();
+    x
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    let _x = black_box(test_function());
+    loop {}
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -263,6 +263,10 @@ typedef struct blaze_symbolizer_opts {
    */
   bool code_info;
   /**
+   * Whether to report inlined functions as part of symbolization.
+   */
+  bool inlined_fns;
+  /**
    * Whether or not to transparently demangle symbols.
    *
    * Demangling happens on a best-effort basis. Currently supported
@@ -301,6 +305,20 @@ typedef struct blaze_symbolize_code_info {
 } blaze_symbolize_code_info;
 
 /**
+ * Data about an inlined function call.
+ */
+typedef struct blaze_symbolize_inlined_fn {
+  /**
+   * The symbol name of the inlined function.
+   */
+  const char *name;
+  /**
+   * Source code location information for the inlined function.
+   */
+  struct blaze_symbolize_code_info code_info;
+} blaze_symbolize_inlined_fn;
+
+/**
  * The result of symbolization of an address.
  *
  * A `blaze_sym` is the information of a symbol found for an
@@ -337,6 +355,14 @@ typedef struct blaze_sym {
    * Source code location information for the symbol.
    */
   struct blaze_symbolize_code_info code_info;
+  /**
+   * The number of symbolized inlined function calls present.
+   */
+  size_t inlined_cnt;
+  /**
+   * An array of `inlined_cnt` symbolized inlined function calls.
+   */
+  const struct blaze_symbolize_inlined_fn *inlined;
 } blaze_sym;
 
 /**

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -191,7 +191,7 @@ impl CodeInfo {
 /// A type representing an inlined function.
 #[derive(Clone, Debug, PartialEq)]
 pub struct InlinedFn {
-    /// The symbol name of the function.
+    /// The symbol name of the inlined function.
     pub name: String,
     /// Source code location information for the call to the function.
     pub code_info: Option<CodeInfo>,


### PR DESCRIPTION
With this change we expose inlined function information through the C API.

Please see individual commits for descriptions.