### PR TITLE
Bump version to `0.2.0-alpha.7`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.2.0-alpha.7
+-------------
 - "Flattened" return type of `symbolize::Symbolizer::symbolize` method from
   nested `Vec` to a single level `Vec` of newly introduced
   `symbolize::Symbolized` enum

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
-version = "0.2.0-alpha.6"
+version = "0.2.0-alpha.7"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "=0.2.0-alpha.6"
+blazesym = "=0.2.0-alpha.7"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).

--- a/cli/README.md
+++ b/cli/README.md
@@ -56,5 +56,5 @@ refer to the help text (`--help`) of the `shell-complete` program for
 the list of supported shells.
 
 [blazesym]: https://crates.io/crates/blazesym
-[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.6/blazesym/symbolize/struct.Symbolizer.html
-[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.6/blazesym/symbolize/enum.Source.html#variant.Elf
+[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.7/blazesym/symbolize/struct.Symbolizer.html
+[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.7/blazesym/symbolize/enum.Source.html#variant.Elf


### PR DESCRIPTION
This change bumps the version of the crate to `0.2.0-alpha.7`.