### PR TITLE
Provide a stable export mangled name for "test_function()"

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -304,6 +304,10 @@ fn prepare_test_files(crate_root: &Path) {
             "opt-level=0",
             "-C",
             "debuginfo=2",
+            // Note that despite us specifying the name mangling scheme
+            // here, because we want a stable mangled name the source
+            // actually uses a fixed "export name", which really is what
+            // is used for the function in question.
             "-C",
             "symbol-mangling-version=v0",
         ],

--- a/data/test.rs
+++ b/data/test.rs
@@ -16,6 +16,13 @@ fn inlined_call() -> usize {
 }
 
 #[inline(never)]
+// We export the function with a *fixed* mangled form here. That is
+// necessary because we rely on lookup by name, but rustc does *not*
+// guarantee stable mangled symbols. Specifically, the disambiguator [0]
+// can basically flip at random every time we recompile. So we just pick
+// one such symbol and fix it.
+// [0] https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html#free-standing-functions-and-statics
+#[export_name = "_RNvCs69hjMPjVIJK_4test13test_function"]
 fn test_function() -> usize {
     let x = inlined_call();
     x

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -271,16 +271,7 @@ fn symbolize_dwarf_demangle() {
 
     let inspector = Inspector::new();
     let results = inspector
-        .lookup(
-            // Evidently we could still end up with different mangled symbols
-            // for the same clear text name. Ugh.
-            &[
-                "_RNvCs69hjMPjVIJK_4test13test_function",
-                "_RNvCseTrKHoaUPIf_4test13test_function",
-                "_RNvCsfpyvYpDUPq_4test13test_function",
-            ],
-            &src,
-        )
+        .lookup(&["_RNvCs69hjMPjVIJK_4test13test_function"], &src)
         .unwrap()
         .into_iter()
         .flatten()

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -248,16 +248,7 @@ fn symbolize_dwarf_demangle() {
 
     let inspector = inspect::Inspector::new();
     let results = inspector
-        .lookup(
-            // Evidently we could still end up with different mangled symbols
-            // for the same clear text name. Ugh.
-            &[
-                "_RNvCs69hjMPjVIJK_4test13test_function",
-                "_RNvCseTrKHoaUPIf_4test13test_function",
-                "_RNvCsfpyvYpDUPq_4test13test_function",
-            ],
-            &src,
-        )
+        .lookup(&["_RNvCs69hjMPjVIJK_4test13test_function"], &src)
         .unwrap()
         .into_iter()
         .flatten()


### PR DESCRIPTION
With commit dff91ef1a01d ("Create proper Rust binary to test on") we provided a list of mangled symbol names of test_function() to our symbolize_dwarf_demangle test. However, that's not sufficient to ensure passing of the test unconditionally, because the compiler is free to conjure up additional mangled symbol variants as per the v0 mangling scheme.
To make the name stable, fix it using the `export_name` attribute instead.