### PR TITLE
Rename get_parser() to parser()

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -58,7 +58,7 @@ pub(crate) struct DwarfResolver {
 }
 
 impl DwarfResolver {
-    pub fn get_parser(&self) -> &ElfParser {
+    pub fn parser(&self) -> &ElfParser {
         &self.parser
     }
 

--- a/src/elf/cache.rs
+++ b/src/elf/cache.rs
@@ -191,8 +191,8 @@ mod tests {
         assert!(backend_first.is_dwarf());
         assert!(backend_second.is_dwarf());
         assert_eq!(
-            ptr::addr_of!(*backend_first.to_dwarf().unwrap().get_parser()),
-            ptr::addr_of!(*backend_second.to_dwarf().unwrap().get_parser())
+            ptr::addr_of!(*backend_first.to_dwarf().unwrap().parser()),
+            ptr::addr_of!(*backend_second.to_dwarf().unwrap().parser())
         );
     }
 }


### PR DESCRIPTION
Rename the various get_parser() methods to parser().