### PR TITLE
Fix signature of ElfResolver::find_line_info() method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,14 @@ jobs:
         runs-on: [ubuntu-latest, macos-latest]
         rust: [1.64.0, stable]
         profile: [dev, release]
-        args: [""]
+        args: ["--workspace"]
         include:
           - runs-on: ubuntu-latest
             rust: stable
             profile: dev
+            # Make sure to build *without* `--workspace` or feature
+            # unification may mean that `--no-default-features` goes
+            # without effect.
             args: "--no-default-features"
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +38,7 @@ jobs:
         override: true
     - name: Build ${{ matrix.profile }}
       run: |
-        cargo build --workspace --profile=${{ matrix.profile }} ${{ matrix.args }} --lib
+        cargo build --profile=${{ matrix.profile }} ${{ matrix.args }} --lib
   nop-rebuilds:
     name: No-op rebuilds
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Fixed build failure when `dwarf` feature is not enabled
+
+
 0.2.0-alpha.7
 -------------
 - "Flattened" return type of `symbolize::Symbolizer::symbolize` method from

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -107,7 +107,7 @@ impl SymResolver for ElfResolver {
     }
 
     #[cfg(not(feature = "dwarf"))]
-    fn find_line_info(&self, addr: Addr) -> Result<Option<AddrCodeInfo>> {
+    fn find_code_info(&self, addr: Addr, inlined_fns: bool) -> Result<Option<AddrCodeInfo<'_>>> {
         Ok(None)
     }
 


### PR DESCRIPTION
The SymResolver::find_line_info() method was renamed a while back and an additional argument added some time later. However, presumably because of conditional compilation, the variant in the ElfResolver in use when the `dwarf` feature is not active had not been updated accordingly. Do that now to prevent a build failure.
Now we did have the --no-default-features CI job for this specific case. However, it turns out that because we build with the --workspace flag, with the introduction of blazecli (which depends on blazesym with the default features), we end up compiling with just the default features (despite specifying --no-default-features) and with that rendering the check useless. So fix it up work correctly again.