### PR TITLE
Make Addr a u64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Fixed build failure when `dwarf` feature is not enabled
+- Changed `Addr` to map to 64 bit integer
 
 
 0.2.0-alpha.7

--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::fn_to_numeric_cast)]
+
 use std::hint::black_box;
 
 use blazesym::c_api;

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::fn_to_numeric_cast)]
+
 use std::hint::black_box;
 use std::path::Path;
 

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -105,7 +105,7 @@ impl DwarfResolver {
         //       unnecessary. Consider removing it or moving it higher
         //       in the call chain.
         let code_info = if self.line_number_info {
-            if let Some(direct_location) = self.units.find_location(addr as u64)? {
+            if let Some(direct_location) = self.units.find_location(addr)? {
                 let Location {
                     dir,
                     file,
@@ -121,7 +121,7 @@ impl DwarfResolver {
                 };
 
                 let inlined = if inlined_fns {
-                    if let Some(inline_stack) = self.units.find_inlined_functions(addr as u64)? {
+                    if let Some(inline_stack) = self.units.find_inlined_functions(addr)? {
                         let mut inlined = Vec::with_capacity(inline_stack.len());
                         for result in inline_stack {
                             let (name, location) = result?;
@@ -186,17 +186,14 @@ impl DwarfResolver {
             ))
         }
 
-        let result = self.units.find_function(addr as u64)?;
+        let result = self.units.find_function(addr)?;
         if let Some((function, language)) = result {
             let name = function
                 .name
                 .map(|name| name.to_string())
                 .transpose()?
                 .unwrap_or("");
-            let addr = function
-                .range
-                .map(|range| range.begin as usize)
-                .unwrap_or(0);
+            let addr = function.range.map(|range| range.begin).unwrap_or(0);
             let size = function
                 .range
                 .map(|range| usize::try_from(range.end - range.begin).unwrap_or(usize::MAX));

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -58,7 +58,6 @@ fn find_sym<'mmap>(
                     break
                 }
 
-                let addr = addr as u64;
                 // In ELF, a symbol size of 0 indicates "no size or an unknown
                 // size" (see elf(5)). We take our changes and report these on a
                 // best-effort basis.

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -116,7 +116,6 @@ impl SymResolver for ElfResolver {
     //       the ELF symbol index (and potentially an offset from it) [this will
     //       require a bit of a larger rework, including on call sites].
     fn addr_file_off(&self, addr: Addr) -> Option<u64> {
-        let addr = addr as u64;
         let parser = self.parser();
         let phdrs = parser.program_headers().ok()?;
         let offset = phdrs.iter().find_map(|phdr| {

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -324,7 +324,7 @@ mod tests {
                 ctx.header.base_address = 0;
                 ctx.addr_tab = addr_tab.as_slice();
 
-                let idx = ctx.find_addr(addr).unwrap_or(0);
+                let idx = ctx.find_addr(addr as Addr).unwrap_or(0);
                 let addr_u32 = addr as u32;
                 let idx1 = match values.binary_search(&addr_u32) {
                     Ok(idx) => idx,

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -220,8 +220,7 @@ impl SymResolver for GsymResolver<'_> {
                 INFO_TYPE_INLINE_INFO if inlined_fns => {
                     if inline_info.is_none() {
                         let mut data = addr_ent.data;
-                        inline_info =
-                            InlineInfo::parse(&mut data, symaddr as u64, Some(addr as u64))?;
+                        inline_info = InlineInfo::parse(&mut data, symaddr, Some(addr))?;
                     }
                 }
                 typ => {
@@ -239,7 +238,7 @@ impl SymResolver for GsymResolver<'_> {
             let mut inlined = Vec::new();
 
             if let Some(inline_info) = inline_info {
-                let mut inline_stack = inline_info.inline_stack(addr as u64).into_iter();
+                let mut inline_stack = inline_info.inline_stack(addr).into_iter();
                 // As per Gsym file format, the first "frame" only contains the
                 // name and it effectively is meant to overwrite what is already
                 // contained in the line table.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,12 @@
 //! functions and on the ABI level this module organization has no relevance for
 //! C).
 
-#![allow(clippy::collapsible_if, clippy::let_and_return, clippy::let_unit_value)]
+#![allow(
+    clippy::collapsible_if,
+    clippy::fn_to_numeric_cast,
+    clippy::let_and_return,
+    clippy::let_unit_value
+)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(
     missing_debug_implementations,
@@ -79,7 +84,7 @@ pub type Result<T, E = Error> = result::Result<T, E>;
 
 
 /// A type representing addresses.
-pub type Addr = usize;
+pub type Addr = u64;
 
 
 /// Utility functionality not specific to any overarching theme.

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -68,7 +68,7 @@ impl Builder {
         let mapping = Mapping { ptr, len };
         let mmap = Mmap {
             mapping: Rc::new(mapping),
-            view: 0..len,
+            view: 0..len as u64,
         };
         Ok(mmap)
     }
@@ -106,7 +106,7 @@ pub(crate) struct Mmap {
     /// The actual memory mapping.
     mapping: Rc<Mapping>,
     /// The view on the memory mapping that this object represents.
-    view: Range<usize>,
+    view: Range<u64>,
 }
 
 impl Mmap {
@@ -123,7 +123,7 @@ impl Mmap {
     /// Create a new `Mmap` object (sharing the same underlying memory mapping
     /// as the current one) that restricts its view to the provided `range`.
     /// Adjustment happens relative to the current view.
-    pub fn constrain(&self, range: Range<usize>) -> Option<Self> {
+    pub fn constrain(&self, range: Range<u64>) -> Option<Self> {
         if self.view.start + range.end > self.view.end {
             return None
         }
@@ -139,7 +139,10 @@ impl Deref for Mmap {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        self.mapping.deref().get(self.view.clone()).unwrap()
+        self.mapping
+            .deref()
+            .get(self.view.start as usize..self.view.end as usize)
+            .unwrap()
     }
 }
 

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -252,7 +252,7 @@ mod tests {
         assert_eq!(syms.len(), 1);
         let sym = syms.first().unwrap();
 
-        let the_answer_addr = unsafe { mmap.as_ptr().add(sym.addr) };
+        let the_answer_addr = unsafe { mmap.as_ptr().add(sym.addr as usize) };
         // Now just double check that everything worked out and the function
         // is actually where it was meant to be.
         let the_answer_fn =
@@ -301,7 +301,7 @@ mod tests {
                 .unwrap();
 
             let elf_mmap = mmap
-                .constrain(so.data_offset..so.data_offset + so.data.len())
+                .constrain(so.data_offset..so.data_offset + so.data.len() as u64)
                 .unwrap();
 
             // Look up the address of the `the_answer` function inside of the shared
@@ -316,7 +316,7 @@ mod tests {
             assert_eq!(syms.len(), 1);
             let sym = syms.first().unwrap();
 
-            let the_answer_addr = unsafe { elf_mmap.as_ptr().add(sym.addr) };
+            let the_answer_addr = unsafe { elf_mmap.as_ptr().add(sym.addr as usize) };
             // Now just double check that everything worked out and the function
             // is actually where it was meant to be.
             let the_answer_fn =

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -244,7 +244,7 @@ impl Symbolizer {
         let sym = Sym {
             name: self.maybe_demangle(name.unwrap_or(sym_name), lang),
             addr: sym_addr,
-            offset: addr - sym_addr,
+            offset: (addr - sym_addr) as usize,
             size: sym_size,
             code_info,
             inlined: inlined.into_boxed_slice(),
@@ -593,7 +593,7 @@ mod tests {
             .unwrap();
 
         let elf_mmap = mmap
-            .constrain(so.data_offset..so.data_offset + so.data.len())
+            .constrain(so.data_offset..so.data_offset + so.data.len() as u64)
             .unwrap();
 
         // Look up the address of the `the_answer` function inside of the shared
@@ -608,7 +608,7 @@ mod tests {
         assert_eq!(syms.len(), 1);
         let sym = syms.first().unwrap();
 
-        let the_answer_addr = unsafe { elf_mmap.as_ptr().add(sym.addr) };
+        let the_answer_addr = unsafe { elf_mmap.as_ptr().add(sym.addr as usize) };
         // Now just double check that everything worked out and the function
         // is actually where it was meant to be.
         let the_answer_fn =

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -123,7 +123,7 @@ pub struct Entry<'archive> {
     /// The path to the file inside the archive.
     pub path: &'archive Path,
     /// The offset of the data from the beginning of the archive.
-    pub data_offset: usize,
+    pub data_offset: u64,
     /// Pointer to the file data.
     pub data: &'archive [u8],
 }
@@ -183,8 +183,8 @@ impl<'archive> EntryIter<'archive> {
 
             let _extra = data.read_slice(lfh.extra_field_length.into())?;
             // SAFETY: Both pointers point into the same underlying byte array.
-            let data_offset = offset as usize
-                + usize::try_from(unsafe { data.as_ptr().offset_from(start) }).unwrap();
+            let data_offset = u64::from(offset)
+                + u64::try_from(unsafe { data.as_ptr().offset_from(start) }).unwrap();
             let data = data.read_slice(lfh.compressed_size as usize)?;
 
             let entry = Entry {
@@ -447,7 +447,7 @@ mod tests {
             entry.data,
             archive
                 .mmap
-                .get(entry.data_offset..entry.data_offset + entry.data.len())
+                .get(entry.data_offset as usize..entry.data_offset as usize + entry.data.len())
                 .unwrap()
         );
 

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::let_and_return, clippy::let_unit_value)]
+#![allow(
+    clippy::fn_to_numeric_cast,
+    clippy::let_and_return,
+    clippy::let_unit_value
+)]
 
 use std::ffi::CString;
 use std::ffi::OsStr;
@@ -68,7 +72,7 @@ fn symbolize_elf_dwarf_gsym() {
         let offsets = (1..size).collect::<Vec<_>>();
         let addrs = offsets
             .iter()
-            .map(|offset| 0x2000100 + offset)
+            .map(|offset| (0x2000100 + offset) as Addr)
             .collect::<Vec<_>>();
         let results = symbolizer
             .symbolize(&src, &addrs)
@@ -288,7 +292,7 @@ fn symbolize_dwarf_demangle() {
         .unwrap();
 
     let addr = result.addr;
-    let size = result.size.unwrap();
+    let size = result.size.unwrap() as u64;
     for inst_addr in addr..addr + size {
         if test(&test_dwarf, inst_addr).is_ok() {
             return

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::let_and_return, clippy::let_unit_value)]
+#![allow(
+    clippy::fn_to_numeric_cast,
+    clippy::let_and_return,
+    clippy::let_unit_value
+)]
 
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -267,7 +271,7 @@ fn symbolize_dwarf_demangle() {
         .unwrap();
 
     let addr = result.addr;
-    let size = result.size.unwrap();
+    let size = result.size.unwrap() as u64;
     for inst_addr in addr..addr + size {
         if test(&test_dwarf, inst_addr).is_ok() {
             return


### PR DESCRIPTION
So far `Addr` was defined to be a `usize`. That is in line with Rust specifying that `usize` has the size of a pointer. However, once we start using the library in a cross compilation context (e.g., using it to symbolize parts of a dump captured on a different machine), the local pointer size has admittedly little meaning.
With this change we define `Addr` to be of type `u64`, which is in-line with the representation of many of the formats that we support. Doing so makes us more independent of the actual pointer size as it basically is meant as an upper limit on current sizes (that may not be entirely true with research architectures such as CHERI, but it is still a reasonable and arguably better approximation for what we expect to support).