### PR TITLE
Rename count -> cnt

### DIFF
--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -225,17 +225,17 @@ typedef struct blaze_normalized_user_addrs {
   /**
    * The number of [`blaze_user_addr_meta`] objects present in `metas`.
    */
-  size_t meta_count;
+  size_t meta_cnt;
   /**
-   * An array of `meta_count` objects.
+   * An array of `meta_cnt` objects.
    */
   struct blaze_user_addr_meta *metas;
   /**
    * The number of [`blaze_normalized_addr`] objects present in `addrs`.
    */
-  size_t addr_count;
+  size_t addr_cnt;
   /**
-   * An array of `addr_count` objects.
+   * An array of `addr_cnt` objects.
    */
   struct blaze_normalized_addr *addrs;
 } blaze_normalized_user_addrs;
@@ -561,11 +561,11 @@ void blaze_normalizer_free(struct blaze_normalizer *normalizer);
  *
  * # Safety
  * Callers need to pass in a valid `addrs` pointer, pointing to memory of
- * `addr_count` addresses.
+ * `addr_cnt` addresses.
  */
 struct blaze_normalized_user_addrs *blaze_normalize_user_addrs(const struct blaze_normalizer *normalizer,
                                                                const uintptr_t *addrs,
-                                                               size_t addr_count,
+                                                               size_t addr_cnt,
                                                                uint32_t pid);
 
 /**
@@ -585,11 +585,11 @@ struct blaze_normalized_user_addrs *blaze_normalize_user_addrs(const struct blaz
  *
  * # Safety
  * Callers need to pass in a valid `addrs` pointer, pointing to memory of
- * `addr_count` addresses.
+ * `addr_cnt` addresses.
  */
 struct blaze_normalized_user_addrs *blaze_normalize_user_addrs_sorted(const struct blaze_normalizer *normalizer,
                                                                       const uintptr_t *addrs,
-                                                                      size_t addr_count,
+                                                                      size_t addr_cnt,
                                                                       uint32_t pid);
 
 /**

--- a/src/c_api/normalize.rs
+++ b/src/c_api/normalize.rs
@@ -334,19 +334,19 @@ impl From<blaze_user_addr_meta> for UserAddrMeta {
 #[derive(Debug)]
 pub struct blaze_normalized_user_addrs {
     /// The number of [`blaze_user_addr_meta`] objects present in `metas`.
-    pub meta_count: usize,
-    /// An array of `meta_count` objects.
+    pub meta_cnt: usize,
+    /// An array of `meta_cnt` objects.
     pub metas: *mut blaze_user_addr_meta,
     /// The number of [`blaze_normalized_addr`] objects present in `addrs`.
-    pub addr_count: usize,
-    /// An array of `addr_count` objects.
+    pub addr_cnt: usize,
+    /// An array of `addr_cnt` objects.
     pub addrs: *mut blaze_normalized_addr,
 }
 
 impl From<NormalizedUserAddrs> for blaze_normalized_user_addrs {
     fn from(other: NormalizedUserAddrs) -> Self {
         Self {
-            meta_count: other.meta.len(),
+            meta_cnt: other.meta.len(),
             metas: unsafe {
                 Box::into_raw(
                     other
@@ -360,7 +360,7 @@ impl From<NormalizedUserAddrs> for blaze_normalized_user_addrs {
                 .unwrap()
                 .as_mut_ptr()
             },
-            addr_count: other.addrs.len(),
+            addr_cnt: other.addrs.len(),
             addrs: unsafe {
                 Box::into_raw(
                     other
@@ -393,20 +393,20 @@ impl From<NormalizedUserAddrs> for blaze_normalized_user_addrs {
 ///
 /// # Safety
 /// Callers need to pass in a valid `addrs` pointer, pointing to memory of
-/// `addr_count` addresses.
+/// `addr_cnt` addresses.
 #[no_mangle]
 pub unsafe extern "C" fn blaze_normalize_user_addrs(
     normalizer: *const Normalizer,
     addrs: *const Addr,
-    addr_count: usize,
+    addr_cnt: usize,
     pid: u32,
 ) -> *mut blaze_normalized_user_addrs {
     // SAFETY: The caller needs to ensure that `normalizer` is a valid
     //         pointer.
     let normalizer = unsafe { &*normalizer };
     // SAFETY: The caller needs to ensure that `addrs` is a valid pointer and
-    //         that it points to `addr_count` elements.
-    let addrs = unsafe { slice_from_user_array(addrs, addr_count) };
+    //         that it points to `addr_cnt` elements.
+    let addrs = unsafe { slice_from_user_array(addrs, addr_cnt) };
     let result = normalizer.normalize_user_addrs(addrs, pid.into());
     match result {
         Ok(addrs) => Box::into_raw(Box::new(blaze_normalized_user_addrs::from(addrs))),
@@ -434,20 +434,20 @@ pub unsafe extern "C" fn blaze_normalize_user_addrs(
 ///
 /// # Safety
 /// Callers need to pass in a valid `addrs` pointer, pointing to memory of
-/// `addr_count` addresses.
+/// `addr_cnt` addresses.
 #[no_mangle]
 pub unsafe extern "C" fn blaze_normalize_user_addrs_sorted(
     normalizer: *const Normalizer,
     addrs: *const Addr,
-    addr_count: usize,
+    addr_cnt: usize,
     pid: u32,
 ) -> *mut blaze_normalized_user_addrs {
     // SAFETY: The caller needs to ensure that `normalizer` is a valid
     //         pointer.
     let normalizer = unsafe { &*normalizer };
     // SAFETY: The caller needs to ensure that `addrs` is a valid pointer and
-    //         that it points to `addr_count` elements.
-    let addrs = unsafe { slice_from_user_array(addrs, addr_count) };
+    //         that it points to `addr_cnt` elements.
+    let addrs = unsafe { slice_from_user_array(addrs, addr_cnt) };
     let result = normalizer.normalize_user_addrs_sorted(addrs, pid.into());
     match result {
         Ok(addrs) => Box::into_raw(Box::new(blaze_normalized_user_addrs::from(addrs))),
@@ -477,14 +477,14 @@ pub unsafe extern "C" fn blaze_user_addrs_free(addrs: *mut blaze_normalized_user
     let addr_metas = unsafe {
         Box::<[blaze_user_addr_meta]>::from_raw(slice::from_raw_parts_mut(
             user_addrs.metas,
-            user_addrs.meta_count,
+            user_addrs.meta_cnt,
         ))
     }
     .into_vec();
     let _norm_addrs = unsafe {
         Box::<[blaze_normalized_addr]>::from_raw(slice::from_raw_parts_mut(
             user_addrs.addrs,
-            user_addrs.addr_count,
+            user_addrs.addr_cnt,
         ))
     }
     .into_vec();
@@ -554,14 +554,14 @@ mod tests {
         );
 
         let user_addrs = blaze_normalized_user_addrs {
-            meta_count: 0,
+            meta_cnt: 0,
             metas: ptr::null_mut(),
-            addr_count: 0,
+            addr_cnt: 0,
             addrs: ptr::null_mut(),
         };
         assert_eq!(
             format!("{user_addrs:?}"),
-            "blaze_normalized_user_addrs { meta_count: 0, metas: 0x0, addr_count: 0, addrs: 0x0 }",
+            "blaze_normalized_user_addrs { meta_cnt: 0, metas: 0x0, addr_cnt: 0, addrs: 0x0 }",
         );
     }
 

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -240,10 +240,10 @@ struct NormalizationHandler<R> {
 
 impl<R> NormalizationHandler<R> {
     /// Instantiate a new `NormalizationHandler` object.
-    fn new(addr_count: usize) -> Self {
+    fn new(addr_cnt: usize) -> Self {
         Self {
             normalized: NormalizedUserAddrs {
-                addrs: Vec::with_capacity(addr_count),
+                addrs: Vec::with_capacity(addr_cnt),
                 meta: Vec::new(),
             },
             meta_lookup: HashMap::<PathBuf, usize>::new(),

--- a/tests/c_api.rs
+++ b/tests/c_api.rs
@@ -336,8 +336,8 @@ fn normalize_user_addrs() {
     assert_ne!(result, ptr::null_mut());
 
     let user_addrs = unsafe { &*result };
-    assert_eq!(user_addrs.meta_count, 2);
-    assert_eq!(user_addrs.addr_count, 5);
+    assert_eq!(user_addrs.meta_cnt, 2);
+    assert_eq!(user_addrs.addr_cnt, 5);
 
     let () = unsafe { blaze_user_addrs_free(result) };
     let () = unsafe { blaze_normalizer_free(normalizer) };
@@ -365,8 +365,8 @@ fn normalize_user_addrs_sorted() {
     assert_ne!(result, ptr::null_mut());
 
     let user_addrs = unsafe { &*result };
-    assert_eq!(user_addrs.meta_count, 2);
-    assert_eq!(user_addrs.addr_count, 5);
+    assert_eq!(user_addrs.meta_cnt, 2);
+    assert_eq!(user_addrs.addr_cnt, 5);
 
     let () = unsafe { blaze_user_addrs_free(result) };
     let () = unsafe { blaze_normalizer_free(normalizer) };


### PR DESCRIPTION
We use count and the shorter cnt for the same purposes. Converge on using only 'cnt' for brevity.