### PR TITLE
Rename norm_addrs -> normalized

### DIFF
--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -22,10 +22,10 @@ fn normalize_process() {
     let () = addrs.sort();
 
     let normalizer = Normalizer::new();
-    let norm_addrs = normalizer
+    let normalized = normalizer
         .normalize_user_addrs_sorted(black_box(addrs.as_slice()), black_box(0.into()))
         .unwrap();
-    assert_eq!(norm_addrs.addrs.len(), 5);
+    assert_eq!(normalized.addrs.len(), 5);
 }
 
 pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -43,13 +43,13 @@ fn normalize(normalize: args::Normalize) -> Result<()> {
     let normalizer = Normalizer::new();
     match normalize {
         args::Normalize::User(args::User { pid, addrs }) => {
-            let norm_addrs = normalizer
+            let normalized = normalizer
                 .normalize_user_addrs(addrs.as_slice(), pid)
                 .context("failed to normalize addresses")?;
-            for (addr, (norm_addr, meta_idx)) in addrs.iter().zip(&norm_addrs.addrs) {
+            for (addr, (norm_addr, meta_idx)) in addrs.iter().zip(&normalized.addrs) {
                 print!("{addr:#016x}: ");
 
-                let meta = &norm_addrs.meta[*meta_idx];
+                let meta = &normalized.meta[*meta_idx];
                 match meta {
                     normalize::UserAddrMeta::ApkElf(normalize::ApkElf {
                         apk_path,

--- a/src/normalize/meta.rs
+++ b/src/normalize/meta.rs
@@ -18,11 +18,11 @@ type BuildId = Vec<u8>;
 /// # let capture_addr_in_elf_in_apk = || 0xdeadbeef;
 /// let addr_in_elf_in_apk = capture_addr_in_elf_in_apk();
 /// let normalizer = normalize::Normalizer::new();
-/// let norm_addrs = normalizer
+/// let normalized = normalizer
 ///     .normalize_user_addrs_sorted([addr_in_elf_in_apk].as_slice(), Pid::Slf)
 ///     .unwrap();
-/// let (norm_addr, meta_idx) = norm_addrs.addrs[0];
-/// let meta = &norm_addrs.meta[meta_idx];
+/// let (norm_addr, meta_idx) = normalized.addrs[0];
+/// let meta = &normalized.meta[meta_idx];
 /// let apk_elf = meta.apk_elf().unwrap();
 ///
 /// // Let's assume we have the ELF file lying around in a hypothetical

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -18,15 +18,15 @@
 //! let fopen_addr = libc::fopen as Addr;
 //! let addrs = [fopen_addr];
 //! let pid = Pid::Slf;
-//! let norm_addrs = normalizer.normalize_user_addrs(&addrs, pid).unwrap();
-//! assert_eq!(norm_addrs.addrs.len(), 1);
+//! let normalized = normalizer.normalize_user_addrs(&addrs, pid).unwrap();
+//! assert_eq!(normalized.addrs.len(), 1);
 //!
-//! let (addr, meta_idx) = norm_addrs.addrs[0];
+//! let (addr, meta_idx) = normalized.addrs[0];
 //! // fopen (0x7f5f8e23a790) corresponds to address 0x77790 within
 //! // Elf(Elf { path: "/usr/lib64/libc.so.6", build_id: Some([...]), ... })
 //! println!(
 //!   "fopen ({fopen_addr:#x}) corresponds to address {addr:#x} within {:?}",
-//!   norm_addrs.meta[meta_idx]
+//!   normalized.meta[meta_idx]
 //! );
 //! ```
 

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -183,14 +183,14 @@ mod tests {
         let addrs = [0x500 as Addr, 0x600 as Addr];
 
         let normalizer = Normalizer::new();
-        let norm_addrs = normalizer
+        let normalized = normalizer
             .normalize_user_addrs_sorted(addrs.as_slice(), Pid::Slf)
             .unwrap();
-        assert_eq!(norm_addrs.addrs.len(), 2);
-        assert_eq!(norm_addrs.meta.len(), 1);
-        assert_eq!(norm_addrs.meta[0], Unknown::default().into());
-        assert_eq!(norm_addrs.addrs[0].1, 0);
-        assert_eq!(norm_addrs.addrs[1].1, 0);
+        assert_eq!(normalized.addrs.len(), 2);
+        assert_eq!(normalized.meta.len(), 1);
+        assert_eq!(normalized.meta[0], Unknown::default().into());
+        assert_eq!(normalized.addrs[0].1, 0);
+        assert_eq!(normalized.addrs[1].1, 0);
     }
 
     /// Check that we can normalize user addresses.
@@ -212,13 +212,13 @@ mod tests {
             .unwrap();
 
         let normalizer = Normalizer::new();
-        let norm_addrs = normalizer
+        let normalized = normalizer
             .normalize_user_addrs(addrs.as_slice(), Pid::Slf)
             .unwrap();
-        assert_eq!(norm_addrs.addrs.len(), 6);
+        assert_eq!(normalized.addrs.len(), 6);
 
-        let addrs = &norm_addrs.addrs;
-        let meta = &norm_addrs.meta;
+        let addrs = &normalized.addrs;
+        let meta = &normalized.meta;
         assert_eq!(meta.len(), 2);
 
         let errno_meta_idx = addrs[errno_idx].1;
@@ -261,15 +261,15 @@ mod tests {
         assert_eq!(answer, 42);
 
         let normalizer = Normalizer::new();
-        let norm_addrs = normalizer
+        let normalized = normalizer
             .normalize_user_addrs_sorted([the_answer_addr as Addr].as_slice(), Pid::Slf)
             .unwrap();
-        assert_eq!(norm_addrs.addrs.len(), 1);
-        assert_eq!(norm_addrs.meta.len(), 1);
+        assert_eq!(normalized.addrs.len(), 1);
+        assert_eq!(normalized.meta.len(), 1);
 
-        let norm_addr = norm_addrs.addrs[0];
+        let norm_addr = normalized.addrs[0];
         assert_eq!(norm_addr.0, sym.addr);
-        let meta = &norm_addrs.meta[norm_addr.1];
+        let meta = &normalized.meta[norm_addr.1];
         let so_path = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
             .join("libtest-so.so");
@@ -325,15 +325,15 @@ mod tests {
             assert_eq!(answer, 42);
 
             let normalizer = Normalizer::new();
-            let norm_addrs = normalizer
+            let normalized = normalizer
                 .normalize_user_addrs_sorted([the_answer_addr as Addr].as_slice(), Pid::Slf)
                 .unwrap();
-            assert_eq!(norm_addrs.addrs.len(), 1);
-            assert_eq!(norm_addrs.meta.len(), 1);
+            assert_eq!(normalized.addrs.len(), 1);
+            assert_eq!(normalized.meta.len(), 1);
 
-            let norm_addr = norm_addrs.addrs[0];
+            let norm_addr = normalized.addrs[0];
             assert_eq!(norm_addr.0, sym.addr);
-            let meta = &norm_addrs.meta[norm_addr.1];
+            let meta = &normalized.meta[norm_addr.1];
             let so_path = Path::new(&env!("CARGO_MANIFEST_DIR"))
                 .join("data")
                 .join(so_name);

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -469,16 +469,16 @@ mod tests {
             let addrs = [unknown_addr as Addr];
 
             let handler = NormalizationHandler::<NoBuildIdReader>::new(addrs.len());
-            let norm_addrs = normalize_sorted_user_addrs_with_entries(
+            let normalized = normalize_sorted_user_addrs_with_entries(
                 addrs.as_slice().iter().copied(),
                 entries,
                 handler,
             )
             .unwrap()
             .normalized;
-            assert_eq!(norm_addrs.addrs.len(), 1);
-            assert_eq!(norm_addrs.meta.len(), 1);
-            assert_eq!(norm_addrs.meta[0], Unknown::default().into());
+            assert_eq!(normalized.addrs.len(), 1);
+            assert_eq!(normalized.meta.len(), 1);
+            assert_eq!(normalized.meta[0], Unknown::default().into());
         }
 
         test(0x0);

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -342,17 +342,17 @@ fn normalize_elf_addr() {
         assert!(!the_answer_addr.is_null());
 
         let normalizer = Normalizer::new();
-        let norm_addrs = normalizer
+        let normalized = normalizer
             .normalize_user_addrs_sorted([the_answer_addr as Addr].as_slice(), Pid::Slf)
             .unwrap();
-        assert_eq!(norm_addrs.addrs.len(), 1);
-        assert_eq!(norm_addrs.meta.len(), 1);
+        assert_eq!(normalized.addrs.len(), 1);
+        assert_eq!(normalized.meta.len(), 1);
 
         let rc = unsafe { libc::dlclose(handle) };
         assert_eq!(rc, 0, "{}", Error::last_os_error());
 
-        let norm_addr = norm_addrs.addrs[0];
-        let meta = &norm_addrs.meta[norm_addr.1];
+        let norm_addr = normalized.addrs[0];
+        let meta = &normalized.meta[norm_addr.1];
         assert_eq!(meta.elf().unwrap().path, test_so);
 
         let elf = symbolize::Elf::new(test_so);
@@ -391,17 +391,17 @@ fn normalize_build_id_rading() {
         let normalizer = Normalizer::builder()
             .enable_build_ids(read_build_ids)
             .build();
-        let norm_addrs = normalizer
+        let normalized = normalizer
             .normalize_user_addrs_sorted([the_answer_addr as Addr].as_slice(), Pid::Slf)
             .unwrap();
-        assert_eq!(norm_addrs.addrs.len(), 1);
-        assert_eq!(norm_addrs.meta.len(), 1);
+        assert_eq!(normalized.addrs.len(), 1);
+        assert_eq!(normalized.meta.len(), 1);
 
         let rc = unsafe { libc::dlclose(handle) };
         assert_eq!(rc, 0, "{}", Error::last_os_error());
 
-        let norm_addr = norm_addrs.addrs[0];
-        let meta = &norm_addrs.meta[norm_addr.1];
+        let norm_addr = normalized.addrs[0];
+        let meta = &normalized.meta[norm_addr.1];
         let elf = meta.elf().unwrap();
         assert_eq!(elf.path, test_so);
         if read_build_ids {


### PR DESCRIPTION
Rename `norm_addrs` (as frequently used to assigned the normalization result) to the more neutral `normalized`. With upcoming changes the result of normalization will no longer necessarily be addresses, but file offset and this term will allow us to reduce churn down the line.