### PR TITLE
Remove normalization logic caching from roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Here is rough roadmap of currently planned features (in no particular order):
 
 - [ ] Fully support handling of kernel addresses
   - currently normalization APIs, for example, only support user space addresses
-- [ ] Optimize normalization logic with more aggressive caching
 - [x] Switch to using [`gimli`](https://crates.io/crates/gimli) for DWARF parsing
   - doing so will allow us to:
     - [x] Support more versions of the DWARF standard (https://github.com/libbpf/blazesym/issues/42 & https://github.com/libbpf/blazesym/issues/57)


### PR DESCRIPTION
With the normalization API rework (mainly #359; issue: #321) we trimmed down the work performed as part of address normalization to what is pretty much the bare minimum (removing "heavy-weight" operations such as memory mapping large binaries or parsing ELF data structures). We don't see a need for additional caching at this point, unless proven slow. Remove the corresponding TODO.