### PR TITLE
Remove LRU caching logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased
   distinguish between and support different input types
   - Added support for ELF symbolization using file offsets instead of addresses
 - Added `symbolize::Source::Apk` variant
+- Made symbolization source caching unconditional and removed
+  least-recently-used semantics in favor of full user control
 
 
 0.2.0-alpha.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ name = "blazesym"
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
-default = ["demangle", "dwarf", "lru"]
+default = ["demangle", "dwarf"]
 # Enable this feature to enable DWARF support.
 dwarf = ["gimli"]
 # Enable this feature to get transparent symbol demangling.
@@ -76,7 +76,6 @@ codegen-units = 1
 cpp_demangle = {version = "0.4", optional = true}
 gimli = {version = "0.28", optional = true}
 libc = "0.2.137"
-lru = {version = "0.12", optional = true}
 rustc-demangle = {version = "0.1", optional = true}
 tracing = {version = "0.1", default-features = false, features = ["attributes"], optional = true}
 

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -67,6 +67,16 @@ typedef struct blaze_normalizer blaze_normalizer;
 
 /**
  * Symbolizer provides an interface to symbolize addresses.
+ *
+ * An instance of this type is the unit at which symbolization inputs are
+ * cached. That is to say, source files (DWARF, ELF, ...) and the parsed data
+ * structures may be kept around in memory for the lifetime of this object to
+ * speed up future symbolization requests. If you are working with large input
+ * sources and/or do not intend to perform multiple symbolization requests
+ * (i.e., [`symbolize`][Symbolizer::symbolize] or
+ * [`symbolize_single`][Symbolizer::symbolize_single] calls) for the same
+ * symbolization source, you may want to consider creating a new `Symbolizer`
+ * instance regularly.
  */
 typedef struct blaze_symbolizer blaze_symbolizer;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
     rustdoc::broken_intra_doc_links
 )]
 #![cfg_attr(feature = "nightly", feature(test))]
-#![cfg_attr(not(feature = "lru"), allow(dead_code))]
+#![cfg_attr(not(feature = "dwarf"), allow(dead_code))]
 
 
 #[cfg(feature = "nightly")]

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -217,6 +217,16 @@ impl Default for Builder {
 
 
 /// Symbolizer provides an interface to symbolize addresses.
+///
+/// An instance of this type is the unit at which symbolization inputs are
+/// cached. That is to say, source files (DWARF, ELF, ...) and the parsed data
+/// structures may be kept around in memory for the lifetime of this object to
+/// speed up future symbolization requests. If you are working with large input
+/// sources and/or do not intend to perform multiple symbolization requests
+/// (i.e., [`symbolize`][Symbolizer::symbolize] or
+/// [`symbolize_single`][Symbolizer::symbolize_single] calls) for the same
+/// symbolization source, you may want to consider creating a new `Symbolizer`
+/// instance regularly.
 #[derive(Debug)]
 pub struct Symbolizer {
     ksym_cache: KSymCache,


### PR DESCRIPTION
It arguably makes little sense to purge least recently used symbolization related data from a cache based solely on a number of elements in the cache: it means that a 50 KiB ELF file has the same "weight" as a 2 GiB DWARF monstrosity. Yet, that's what our ElfCache type currently does. To get more reasonable behavior, we'd need to account for how much actual data is allocated. That in turn needs to be made configurable, because 1 GiB of memory may be a lot to one user but not at all to another, and it needs to account for the potential of lazy loading (e.g., various DWARF data structures are only loaded into memory once needed, which can happen delayed compared to others). In short, it's a bunch of complexity that we do not want to deal with at this point (or ever).
To that end, this change removes the LRU logic altogether. We still support caching, but once loaded, data will be kept around for future requests unconditionally. To still allow clients control over memory behavior, we document that caching happens at the level of a Symbolizer instance. You destroy the symbolizer you purge the cache.