### PR TITLE
cli: Add support for symbolizing Gsym addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
 - Made symbolization source caching unconditional and removed
   least-recently-used semantics in favor of full user control
 - Added caching for APK related symbolization data structures
+- Added support for symbolizing Gsym addresses to `blazecli`
 
 
 0.2.0-alpha.7

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -79,12 +79,27 @@ pub struct User {
 #[derive(Debug, Subcommand)]
 pub enum Symbolize {
     Elf(Elf),
+    Gsym(Gsym),
     Process(Process),
 }
 
 #[derive(Debug, Arguments)]
 pub struct Elf {
     /// The path to the ELF file.
+    #[clap(short, long)]
+    pub path: PathBuf,
+    /// The addresses to symbolize.
+    ///
+    /// Addresses are assumed to already be normalized to the file
+    /// itself (i.e., with relocation and address randomization effects
+    /// removed).
+    #[arg(value_parser = parse_addr)]
+    pub addrs: Vec<Addr>,
+}
+
+#[derive(Debug, Arguments)]
+pub struct Gsym {
+    /// The path to the Gsym file.
     #[clap(short, long)]
     pub path: PathBuf,
     /// The addresses to symbolize.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -115,6 +115,10 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
             let src = symbolize::Source::from(symbolize::Elf::new(path));
             (src, addrs)
         }
+        args::Symbolize::Gsym(args::Gsym { path, addrs }) => {
+            let src = symbolize::Source::from(symbolize::GsymFile::new(path));
+            (src, addrs)
+        }
         args::Symbolize::Process(args::Process { pid, addrs }) => {
             let src = symbolize::Source::from(symbolize::Process::new(pid));
             (src, addrs)


### PR DESCRIPTION
This change adds support for symbolizing Gsym addresses to blazecli.

  $ cargo run -p blazecli -- symbolize gsym --path data/test-stable-addresses.gsym 0x200020a
  > 0x0000000200020a: factorial_inline_test @ 0x2000200+0xa blazesym/data/test-stable-addresses.c:32
  >                   factorial_inline_wrapper @ blazesym/data/test-stable-addresses.c:26 [inlined]
  >                   factorial_2nd_layer_inline_wrapper @ blazesym/data/test-stable-addresses.c:21 [inlined]