### PR TITLE
Rename LineTableRow.address to addr

### DIFF
--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -63,7 +63,7 @@ impl LineTableHeader {
 
 #[derive(Clone, Debug)]
 pub struct LineTableRow {
-    pub address: Addr,
+    pub addr: Addr,
     pub file_idx: u32,
     pub file_line: u32,
 }
@@ -80,7 +80,7 @@ impl LineTableRow {
     /// * `symaddr` - the address of the symbol that `header` belongs to.
     pub fn from_header(header: &LineTableHeader, symaddr: Addr) -> Self {
         Self {
-            address: symaddr,
+            addr: symaddr,
             file_idx: 1,
             file_line: header.first_line,
         }
@@ -113,7 +113,7 @@ pub fn run_op(
         }
         ADVANCE_PC => {
             let (adv, _bytes) = ops.read_u64_leb128()?;
-            ctx.address += adv as Addr;
+            ctx.addr += adv as Addr;
             Some(RunResult::NewRow)
         }
         ADVANCE_LINE => {
@@ -144,7 +144,7 @@ pub fn run_op(
             }
 
             ctx.file_line = file_line as u32;
-            ctx.address += addr_delta as Addr;
+            ctx.addr += addr_delta as Addr;
             Some(RunResult::NewRow)
         }
     }

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -121,7 +121,7 @@ impl<'dat> GsymResolver<'dat> {
                 Some(RunResult::Ok) => {}
                 Some(RunResult::NewRow) => {
                     row_cnt += 1;
-                    if addr < lntab_row.address {
+                    if addr < lntab_row.addr {
                         if row_cnt == 1 {
                             // The address is lower than the first row.
                             return Ok(None)


### PR DESCRIPTION
We use addr as opposed to address in many places. Rename the LineTableRow.address member to go with the flow.