### PR TITLE
Remove bogus file_line check in run_op()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
   least-recently-used semantics in favor of full user control
 - Added caching for APK related symbolization data structures
 - Added support for symbolizing Gsym addresses to `blazecli`
+- Fixed bogus inlined function reporting for Gsym
 
 
 0.2.0-alpha.7

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -139,10 +139,6 @@ pub fn run_op(
             let addr_delta = adjusted / range;
 
             let file_line = row.file_line as i32 + line_delta as i32;
-            if file_line < 1 {
-                return None
-            }
-
             row.file_line = file_line as u32;
             row.addr += addr_delta as Addr;
             Some(RunResult::NewRow)


### PR DESCRIPTION
The check and early return when file_line is less than one inside of run_op() is bogus. It leads to wrong symbolization results and it is not prevent in the original C++ code. Remove it.