### PR TITLE
Return Rc<ElfParser> references from various getters

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -58,7 +58,8 @@ pub(crate) struct DwarfResolver {
 }
 
 impl DwarfResolver {
-    pub fn parser(&self) -> &ElfParser {
+    /// Retrieve the resolver's underlying `ElfParser`.
+    pub fn parser(&self) -> &Rc<ElfParser> {
         &self.parser
     }
 

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -3,6 +3,7 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
@@ -39,7 +40,7 @@ impl ElfResolver {
         })
     }
 
-    pub(crate) fn parser(&self) -> &ElfParser {
+    pub(crate) fn parser(&self) -> &Rc<ElfParser> {
         match &self.backend {
             #[cfg(feature = "dwarf")]
             ElfBackend::Dwarf(dwarf) => dwarf.parser(),


### PR DESCRIPTION
With upcoming changes we are going to need the fact that `ElfParser` objects are generally managed inside an `Rc` at the various call sites using resolvers.
To that end, this change adjusts the `DwarfResolver` and `ElfResolver` getters to return `Rc<ElfParser>` references instead of mere `ElfParser` references.