### PR TITLE
Cache inspection related data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
 - Made symbolization source caching unconditional and removed
   least-recently-used semantics in favor of full user control
 - Added caching for APK related symbolization data structures
+- Added caching logic to `inspect::Inspector`
 - Added support for symbolizing Gsym addresses to `blazecli`
 - Fixed bogus inlined function reporting for Gsym
 

--- a/include/blazesym.h
+++ b/include/blazesym.h
@@ -50,6 +50,14 @@ typedef enum blaze_user_meta_kind {
  * Object of this type can be used to perform inspections of supported sources.
  * E.g., using an ELF file as a source, information about a symbol can be
  * inquired based on its name.
+ *
+ * An instance of this type is the unit at which inspection inputs are cached.
+ * That is to say, source files (such as ELF) and the parsed data structures
+ * may be kept around in memory for the lifetime of this object to speed up
+ * future inspection requests.
+ * If you are working with large input sources and/or do not intend to perform
+ * multiple inspection requests for the same symbolization source, you may want
+ * to consider creating a new `Inspector` instance regularly.
  */
 typedef struct blaze_inspector blaze_inspector;
 

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -6,6 +6,7 @@ use std::fmt::Result as FmtResult;
 use std::mem;
 use std::mem::swap;
 use std::ops::Deref as _;
+#[cfg(test)]
 use std::path::Path;
 use std::rc::Rc;
 
@@ -89,6 +90,7 @@ impl DwarfResolver {
     ///
     /// `filename` is the name of an ELF binary/or shared object that
     /// has .debug_line section.
+    #[cfg(test)]
     pub fn open(filename: &Path, debug_line_info: bool, debug_info_symbols: bool) -> Result<Self> {
         let parser = ElfParser::open(filename)?;
         Self::from_parser(Rc::new(parser), debug_line_info, debug_info_symbols)

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -52,6 +52,15 @@ impl ElfResolver {
     pub(crate) fn file_name(&self) -> &Path {
         &self.file_name
     }
+
+    #[inline]
+    pub(crate) fn uses_dwarf(&self) -> bool {
+        match &self.backend {
+            #[cfg(feature = "dwarf")]
+            ElfBackend::Dwarf(_) => true,
+            ElfBackend::Elf(_) => false,
+        }
+    }
 }
 
 impl SymResolver for ElfResolver {

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::path::Path;
 use std::rc::Rc;
 
 #[cfg(feature = "dwarf")]
@@ -5,6 +7,7 @@ use crate::dwarf::DwarfResolver;
 use crate::elf::ElfBackend;
 use crate::elf::ElfParser;
 use crate::elf::ElfResolver;
+use crate::file_cache::FileCache;
 use crate::Result;
 use crate::SymResolver;
 
@@ -20,15 +23,69 @@ use super::SymType;
 /// Object of this type can be used to perform inspections of supported sources.
 /// E.g., using an ELF file as a source, information about a symbol can be
 /// inquired based on its name.
-#[derive(Debug, Default)]
+///
+/// An instance of this type is the unit at which inspection inputs are cached.
+/// That is to say, source files (such as ELF) and the parsed data structures
+/// may be kept around in memory for the lifetime of this object to speed up
+/// future inspection requests.
+/// If you are working with large input sources and/or do not intend to perform
+/// multiple inspection requests for the same symbolization source, you may want
+/// to consider creating a new `Inspector` instance regularly.
+#[derive(Debug)]
 pub struct Inspector {
-    _private: (),
+    elf_cache: RefCell<FileCache<Rc<ElfResolver>>>,
 }
 
 impl Inspector {
     /// Create a new `Inspector`.
     pub fn new() -> Self {
-        Self { _private: () }
+        Self {
+            elf_cache: RefCell::new(FileCache::new()),
+        }
+    }
+
+    // TODO: Overlap with similar functionality in the `Symbolizer`. Need to
+    //       deduplicate at some point.
+    fn elf_resolver_from_parser(
+        &self,
+        path: &Path,
+        parser: Rc<ElfParser>,
+        debug_info: bool,
+    ) -> Result<Rc<ElfResolver>> {
+        #[cfg(feature = "dwarf")]
+        let backend = if debug_info {
+            let debug_line_info = true;
+            let debug_info_symbols = true;
+            let dwarf = DwarfResolver::from_parser(parser, debug_line_info, debug_info_symbols)?;
+            let backend = ElfBackend::Dwarf(Rc::new(dwarf));
+            backend
+        } else {
+            ElfBackend::Elf(parser)
+        };
+
+        #[cfg(not(feature = "dwarf"))]
+        let backend = ElfBackend::Elf(parser);
+
+        let resolver = Rc::new(ElfResolver::with_backend(path, backend)?);
+        Ok(resolver)
+    }
+
+    fn elf_resolver(&self, path: &Path, debug_info: bool) -> Result<Rc<ElfResolver>> {
+        let mut cache = self.elf_cache.borrow_mut();
+        let (file, entry) = cache.entry(path)?;
+        let resolver = if let Some(resolver) = entry {
+            if resolver.uses_dwarf() == debug_info {
+                resolver.clone()
+            } else {
+                self.elf_resolver_from_parser(path, resolver.parser().clone(), debug_info)?
+            }
+        } else {
+            let parser = Rc::new(ElfParser::open_file(file)?);
+            self.elf_resolver_from_parser(path, parser, debug_info)?
+        };
+
+        *entry = Some(resolver.clone());
+        Ok(resolver)
     }
 
     /// Look up information (address etc.) about a list of symbols,
@@ -46,27 +103,7 @@ impl Inspector {
                 debug_info,
                 _non_exhaustive: (),
             }) => {
-                #[cfg(feature = "dwarf")]
-                let backend = if *debug_info {
-                    let debug_line_info = true;
-                    let debug_info_symbols = true;
-                    let dwarf = DwarfResolver::open(path, debug_line_info, debug_info_symbols)?;
-                    let backend = ElfBackend::Dwarf(Rc::new(dwarf));
-                    backend
-                } else {
-                    let elf = ElfParser::open(path)?;
-                    let backend = ElfBackend::Elf(Rc::new(elf));
-                    backend
-                };
-
-                #[cfg(not(feature = "dwarf"))]
-                let backend = {
-                    let elf = ElfParser::open(path)?;
-                    let backend = ElfBackend::Elf(Rc::new(elf));
-                    backend
-                };
-
-                let resolver = ElfResolver::with_backend(path, backend)?;
+                let resolver = self.elf_resolver(path, *debug_info)?;
                 let syms = names
                     .iter()
                     .map(|name| {
@@ -92,6 +129,12 @@ impl Inspector {
     }
 }
 
+impl Default for Inspector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -101,6 +144,13 @@ mod tests {
 
     use crate::ErrorKind;
 
+
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let inspector = Inspector::default();
+        assert_ne!(format!("{inspector:?}"), "");
+    }
 
     /// Check that we error our as expected when encountering a source
     /// that is not present.
@@ -122,5 +172,36 @@ mod tests {
         elf.debug_info = !elf.debug_info;
         let src = Source::Elf(elf);
         let () = test(&src);
+    }
+
+    /// Check that ELF resolver caching works as expected.
+    #[test]
+    fn elf_resolver_caching() {
+        let test_elf = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join("test-stable-addresses-no-dwarf.bin");
+        let mut elf = Elf::new(&test_elf);
+        assert!(elf.debug_info);
+
+        let inspector = Inspector::new();
+        let resolver = || {
+            let mut cache = inspector.elf_cache.borrow_mut();
+            cache.entry(&test_elf).unwrap().1.as_ref().unwrap().clone()
+        };
+
+        let _results = inspector.lookup(&["factorial"], &Source::Elf(elf.clone()));
+        let resolver1 = resolver();
+
+        let _results = inspector.lookup(&["factorial"], &Source::Elf(elf.clone()));
+        let resolver2 = resolver();
+        assert!(Rc::ptr_eq(&resolver1, &resolver2));
+
+        // When changing whether we use debug information we should create a new
+        // resolver.
+        elf.debug_info = false;
+
+        let _results = inspector.lookup(&["factorial"], &Source::Elf(elf.clone()));
+        let resolver3 = resolver();
+        assert!(!Rc::ptr_eq(&resolver1, &resolver3));
     }
 }


### PR DESCRIPTION
With this change we start caching inspection related in-memory data structures across Inspector::lookup() requests. This is mirroring a similar scheme that we employ in the Symbolizer type.