### PR TITLE
Remove enable_debug_info_syms flag from DwarfResolver

### DIFF
--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -55,8 +55,7 @@ impl Inspector {
         #[cfg(feature = "dwarf")]
         let backend = if debug_info {
             let debug_line_info = true;
-            let debug_info_symbols = true;
-            let dwarf = DwarfResolver::from_parser(parser, debug_line_info, debug_info_symbols)?;
+            let dwarf = DwarfResolver::from_parser(parser, debug_line_info)?;
             let backend = ElfBackend::Dwarf(Rc::new(dwarf));
             backend
         } else {

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -317,11 +317,11 @@ impl Symbolizer {
         parser: Rc<ElfParser>,
     ) -> Result<Rc<ElfResolver>> {
         #[cfg(feature = "dwarf")]
-        let backend = ElfBackend::Dwarf(Rc::new(DwarfResolver::from_parser(
-            parser,
-            self.code_info,
-            self.debug_syms,
-        )?));
+        let backend = if self.debug_syms {
+            ElfBackend::Dwarf(Rc::new(DwarfResolver::from_parser(parser, self.code_info)?))
+        } else {
+            ElfBackend::Elf(parser)
+        };
 
         #[cfg(not(feature = "dwarf"))]
         let backend = ElfBackend::Elf(parser);


### PR DESCRIPTION
It makes no sense to create a DwarfResolver object but then deny it the usage of DWARF debug information -- that's what is already controlled via the ElfBackend type. Remove the flag as a first step towards reclaiming sanity.