### PR TITLE
Deny `todo!()` macro in product code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
           profile: minimal
           components: clippy
           override: true
-      - run: cargo clippy --workspace --no-deps --all-targets --features=dont-generate-unit-test-files -- -A unknown_lints
+      - run: cargo clippy --workspace --no-deps --all-targets --features=dont-generate-unit-test-files -- -A unknown_lints -D clippy::todo
   rustfmt:
     name: Check code formatting
     runs-on: ubuntu-latest


### PR DESCRIPTION
Let's employ the help of clippy to prevent todo!() call sites from sneaking into product code. Do so from CI, which is expected to check all crates in the workspace.