### PR TITLE
Move SymInfo object fixup from Inspector into ElfResolver

### DIFF
--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -105,22 +105,8 @@ impl Inspector {
                 let resolver = self.elf_resolver(path, *debug_info)?;
                 let syms = names
                     .iter()
-                    .map(|name| {
-                        let mut syms = resolver.find_addr(name, &opts).unwrap_or_default();
-                        let () = syms.iter_mut().for_each(|sym| {
-                            if opts.offset_in_file {
-                                if let Some(off) = resolver.addr_file_off(sym.addr) {
-                                    sym.file_offset = off;
-                                }
-                            }
-                            if opts.obj_file_name {
-                                sym.obj_file_name = Some(path.to_path_buf())
-                            }
-                        });
-
-                        syms
-                    })
-                    .collect();
+                    .map(|name| resolver.find_addr(name, &opts))
+                    .collect::<Result<Vec<_>>>()?;
 
                 Ok(syms)
             }


### PR DESCRIPTION
It's questionable practice to have `DwarfResolver` and `ElfResolver` return partly initialized objects and then fix them up later on in the Inspector, as we do for the `SymInfo` objects returned by `SymResolver::find_addr()`.
Admittedly we can't fill in all the gaps at the lowest layer at this point, but we have all the necessary information in the `ElfResolver` itself. So perform all the "fixups" there and at least preserve sanity at the `SymResolver` API surface level.