### PR TITLE
Remove FindAddrOpts::obj_file_name flag

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -297,7 +297,6 @@ mod tests {
             .join("test-stable-addresses-dwarf-only.bin");
         let opts = FindAddrOpts {
             offset_in_file: false,
-            obj_file_name: false,
             sym_type: SymType::Function,
         };
         let resolver = DwarfResolver::open(test_dwarf.as_ref(), true).unwrap();
@@ -318,7 +317,6 @@ mod tests {
             .join("test-stable-addresses-dwarf-only.bin");
         let opts = FindAddrOpts {
             offset_in_file: false,
-            obj_file_name: false,
             sym_type: SymType::Variable,
         };
         let resolver = DwarfResolver::open(test_dwarf.as_ref(), true).unwrap();

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -118,9 +118,7 @@ impl SymResolver for ElfResolver {
                     sym.file_offset = off;
                 }
             }
-            if opts.obj_file_name {
-                sym.obj_file_name = Some(self.file_name.clone())
-            }
+            sym.obj_file_name = Some(self.file_name.clone())
         });
         Ok(syms)
     }

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -92,7 +92,6 @@ impl Inspector {
     pub fn lookup(&self, names: &[&str], src: &Source) -> Result<Vec<Vec<SymInfo>>> {
         let opts = FindAddrOpts {
             offset_in_file: true,
-            obj_file_name: true,
             sym_type: SymType::Unknown,
         };
 

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -66,8 +66,6 @@ pub(crate) struct FindAddrOpts {
     /// Return the offset of the symbol from the first byte of the
     /// object file if it is true. (False by default)
     pub offset_in_file: bool,
-    /// Return the name of the object file if it is true. (False by default)
-    pub obj_file_name: bool,
     /// Return the symbol(s) matching a given type. Unknown, by default,
     /// means all types.
     pub sym_type: SymType,

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -230,7 +230,6 @@ mod tests {
         let name = sym.name.clone();
         let opts = FindAddrOpts {
             offset_in_file: false,
-            obj_file_name: false,
             sym_type: SymType::Function,
         };
         let found = resolver.find_addr(&name, &opts).unwrap();

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -313,7 +313,6 @@ mod tests {
             let opts = FindAddrOpts {
                 sym_type: SymType::Function,
                 offset_in_file: true,
-                ..Default::default()
             };
             let syms = elf_parser.find_addr("the_answer", &opts).unwrap();
             // There is only one symbol with this address in there.


### PR DESCRIPTION
It's unclear what we gain from making the object file name retrieval conditional: the string is readily present unconditionally and so all we save is an allocation. On top of that, this flag isn't even exposed so it's complexity for nothing. Remove it.