### PR TITLE
Move IntSym definition into symbolize module

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -18,11 +18,11 @@ use crate::inspect::SymInfo;
 use crate::inspect::SymType;
 use crate::symbolize::AddrCodeInfo;
 use crate::symbolize::FrameCodeInfo;
+use crate::symbolize::IntSym;
+use crate::symbolize::SrcLang;
 use crate::Addr;
 use crate::Error;
-use crate::IntSym;
 use crate::Result;
-use crate::SrcLang;
 
 use super::location::Location;
 use super::reader;

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -8,10 +8,10 @@ use std::rc::Rc;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::symbolize::AddrCodeInfo;
+use crate::symbolize::IntSym;
+use crate::symbolize::SrcLang;
 use crate::Addr;
-use crate::IntSym;
 use crate::Result;
-use crate::SrcLang;
 use crate::SymResolver;
 
 use super::types::STT_FUNC;

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -11,11 +11,11 @@ use crate::inspect::SymInfo;
 use crate::mmap::Mmap;
 use crate::symbolize::AddrCodeInfo;
 use crate::symbolize::FrameCodeInfo;
+use crate::symbolize::IntSym;
+use crate::symbolize::SrcLang;
 use crate::Addr;
-use crate::IntSym;
 use crate::IntoError as _;
 use crate::Result;
-use crate::SrcLang;
 use crate::SymResolver;
 
 use super::inline::InlineInfo;

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -9,9 +9,9 @@ use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::ksym::KSymResolver;
 use crate::symbolize::AddrCodeInfo;
+use crate::symbolize::IntSym;
 use crate::Addr;
 use crate::Error;
-use crate::IntSym;
 use crate::Result;
 use crate::SymResolver;
 

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -13,11 +13,11 @@ use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::inspect::SymType;
 use crate::symbolize::AddrCodeInfo;
+use crate::symbolize::IntSym;
+use crate::symbolize::SrcLang;
 use crate::util::find_match_or_lower_bound_by_key;
 use crate::Addr;
-use crate::IntSym;
 use crate::Result;
-use crate::SrcLang;
 use crate::SymResolver;
 
 pub const KALLSYMS: &str = "/proc/kallsyms";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,6 @@ use std::fmt::Result as FmtResult;
 use std::num::NonZeroU32;
 use std::result;
 
-use resolver::IntSym;
-use resolver::SrcLang;
 use resolver::SymResolver;
 
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3,34 +3,9 @@ use std::fmt::Debug;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::symbolize::AddrCodeInfo;
+use crate::symbolize::IntSym;
 use crate::Addr;
 use crate::Result;
-
-
-/// The source code language from which a symbol originates.
-#[derive(Clone, Copy, Default, Debug)]
-pub(crate) enum SrcLang {
-    /// The language is unknown.
-    #[default]
-    Unknown,
-    /// The language is C++.
-    Cpp,
-    /// The language is Rust.
-    Rust,
-}
-
-
-/// Our internal representation of a symbol.
-pub(crate) struct IntSym<'src> {
-    /// The name of the symbol.
-    pub(crate) name: &'src str,
-    /// The symbol's normalized address.
-    pub(crate) addr: Addr,
-    /// The symbol's size, if available.
-    pub(crate) size: Option<usize>,
-    /// The source code language from which the symbol originates.
-    pub(crate) lang: SrcLang,
-}
 
 
 /// The trait of symbol resolvers.

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -238,6 +238,32 @@ pub struct InlinedFn {
 }
 
 
+/// The source code language from which a symbol originates.
+#[derive(Clone, Copy, Default, Debug)]
+pub(crate) enum SrcLang {
+    /// The language is unknown.
+    #[default]
+    Unknown,
+    /// The language is C++.
+    Cpp,
+    /// The language is Rust.
+    Rust,
+}
+
+
+/// Our internal representation of a symbol.
+pub(crate) struct IntSym<'src> {
+    /// The name of the symbol.
+    pub(crate) name: &'src str,
+    /// The symbol's normalized address.
+    pub(crate) addr: Addr,
+    /// The symbol's size, if available.
+    pub(crate) size: Option<usize>,
+    /// The source code language from which the symbol originates.
+    pub(crate) lang: SrcLang,
+}
+
+
 /// The result of address symbolization by [`Symbolizer`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct Sym {

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -34,11 +34,9 @@ use crate::zip;
 use crate::Addr;
 use crate::Error;
 use crate::ErrorExt as _;
-use crate::IntSym;
 use crate::IntoError as _;
 use crate::Pid;
 use crate::Result;
-use crate::SrcLang;
 use crate::SymResolver;
 
 use super::source::Apk;
@@ -52,6 +50,8 @@ use super::source::Source;
 use super::CodeInfo;
 use super::InlinedFn;
 use super::Input;
+use super::IntSym;
+use super::SrcLang;
 use super::Sym;
 use super::Symbolized;
 


### PR DESCRIPTION
This change moves the definition of the IntSym type into the symbolize module. We already defined the Sym in there, so it makes little sense to have a "more internal" type be defined at a higher level.