### PR TITLE
Make SymInfo::file_offset an Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
   least-recently-used semantics in favor of full user control
 - Added caching for APK related symbolization data structures
 - Added caching logic to `inspect::Inspector`
+- Made `inspect::SymInfo::file_offset` member optional
 - Added support for symbolizing Gsym addresses to `blazecli`
 - Fixed bogus inlined function reporting for Gsym
 

--- a/src/c_api/inspect.rs
+++ b/src/c_api/inspect.rs
@@ -197,7 +197,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
                         SymType::Variable => blaze_sym_type::BLAZE_SYM_VAR,
                         SymType::Unknown => blaze_sym_type::BLAZE_SYM_UNKNOWN,
                     },
-                    file_offset,
+                    file_offset: file_offset.unwrap_or(0),
                     obj_file_name,
                 }
             };
@@ -368,7 +368,7 @@ mod tests {
                     assert_eq!(c_sym.addr, sym.addr);
                     assert_eq!(c_sym.size, sym.size);
                     assert_eq!(c_sym.sym_type, blaze_sym_type::from(sym.sym_type));
-                    assert_eq!(c_sym.file_offset, sym.file_offset);
+                    assert_eq!(Some(c_sym.file_offset), sym.file_offset);
                     assert_eq!(
                         unsafe { CStr::from_ptr(c_sym.obj_file_name) }.to_bytes(),
                         CString::new(
@@ -398,7 +398,7 @@ mod tests {
             addr: 0xdeadbeef,
             size: 42,
             sym_type: SymType::Function,
-            file_offset: 1337,
+            file_offset: Some(1337),
             obj_file_name: Some(PathBuf::from("/tmp/foobar.so")),
         }]];
         test(syms);
@@ -410,7 +410,7 @@ mod tests {
                 addr: 0xdeadbeef,
                 size: 42,
                 sym_type: SymType::Function,
-                file_offset: 1337,
+                file_offset: Some(1337),
                 obj_file_name: Some(PathBuf::from("/tmp/foobar.so")),
             },
             SymInfo {
@@ -418,7 +418,7 @@ mod tests {
                 addr: 0xdeadbeef + 52,
                 size: 45,
                 sym_type: SymType::Unknown,
-                file_offset: 1338,
+                file_offset: Some(1338),
                 obj_file_name: Some(PathBuf::from("other.so")),
             },
         ]];
@@ -431,7 +431,7 @@ mod tests {
                 addr: 0xdeadbeef,
                 size: 42,
                 sym_type: SymType::Function,
-                file_offset: 1337,
+                file_offset: Some(1337),
                 obj_file_name: Some(PathBuf::from("/tmp/foobar.so")),
             }],
             vec![SymInfo {
@@ -439,7 +439,7 @@ mod tests {
                 addr: 0xdeadbeef + 52,
                 size: 45,
                 sym_type: SymType::Unknown,
-                file_offset: 1338,
+                file_offset: Some(1338),
                 obj_file_name: Some(PathBuf::from("other.so")),
             }],
         ];
@@ -451,7 +451,7 @@ mod tests {
             addr: 0xdeadbeef,
             size: 42,
             sym_type: SymType::Function,
-            file_offset: 1337,
+            file_offset: Some(1337),
             obj_file_name: Some(PathBuf::from("/tmp/foobar.so")),
         };
         let syms = vec![(0..200).map(|_| sym.clone()).collect()];

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -233,7 +233,7 @@ impl DwarfResolver {
                             addr,
                             size,
                             sym_type: SymType::Function,
-                            file_offset: 0,
+                            file_offset: None,
                             obj_file_name: None,
                         };
                         Ok(info)

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -447,7 +447,7 @@ impl ElfParser {
                             addr: sym_ref.st_value as Addr,
                             size: sym_ref.st_size as usize,
                             sym_type: SymType::Function,
-                            file_offset: 0,
+                            file_offset: None,
                             obj_file_name: None,
                         });
                     }

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -114,9 +114,7 @@ impl SymResolver for ElfResolver {
         let mut syms = find_addr_impl(self, name, opts)?;
         let () = syms.iter_mut().for_each(|sym| {
             if opts.offset_in_file {
-                if let Some(off) = self.addr_file_off(sym.addr) {
-                    sym.file_offset = off;
-                }
+                sym.file_offset = self.addr_file_off(sym.addr);
             }
             sym.obj_file_name = Some(self.file_name.clone())
         });

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -52,7 +52,7 @@ pub struct SymInfo {
     /// A function or a variable.
     pub sym_type: SymType,
     /// The offset in the object file.
-    pub file_offset: u64,
+    pub file_offset: Option<u64>,
     /// The file name of the shared object.
     pub obj_file_name: Option<PathBuf>,
 }

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -135,7 +135,7 @@ impl SymResolver for KSymResolver {
                 addr: *addr,
                 size: 0,
                 sym_type: SymType::Function,
-                file_offset: 0,
+                file_offset: None,
                 obj_file_name: None,
             }])
         } else {

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -438,7 +438,7 @@ fn inspect() {
 
         let result = &results[0];
         assert_eq!(result.addr, 0x2000100);
-        assert_ne!(result.file_offset, 0);
+        assert_ne!(result.file_offset, None);
         assert_eq!(
             result.obj_file_name.as_deref().unwrap(),
             src.path().unwrap()
@@ -490,7 +490,7 @@ fn inspect_file_offset_elf() {
     assert_eq!(results.len(), 1);
 
     let result = &results[0];
-    assert_ne!(result.file_offset, 0);
-    let bytes = read_4bytes_at(src.path().unwrap(), result.file_offset);
+    assert_ne!(result.file_offset, None);
+    let bytes = read_4bytes_at(src.path().unwrap(), result.file_offset.unwrap());
     assert_eq!(bytes, [0xde, 0xad, 0xbe, 0xef]);
 }


### PR DESCRIPTION
The SymInfo::file_offset member is not present all the time: some sources may not be able to provide this information and in general retrieval is currently optional (at least internally). Make this fact more obvious by making this member an Option. This could potentially be reverted in the future, but for the time being we want to have an explicit differentiation between None and 0 (certainly at the Rust level) for upcoming changes.