### PR TITLE
Add "test" for Debug representation of Symbolizer related types

### DIFF
--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -338,3 +338,30 @@ impl Symbolized {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let lang = SrcLang::default();
+        assert_ne!(format!("{lang:?}"), "");
+
+        let sym = Sym {
+            name: "test".to_string(),
+            addr: 1337,
+            offset: 42,
+            size: None,
+            code_info: None,
+            inlined: Box::new([]),
+            _non_exhaustive: (),
+        };
+        assert_ne!(format!("{sym:?}"), "");
+
+        let symbolized = Symbolized::Sym(sym);
+        assert_ne!(format!("{symbolized:?}"), "");
+    }
+}

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -900,6 +900,16 @@ mod tests {
     use test_log::test;
 
 
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let builder = Symbolizer::builder();
+        assert_ne!(format!("{builder:?}"), "");
+
+        let symbolizer = builder.build();
+        assert_ne!(format!("{symbolizer:?}"), "");
+    }
+
     /// Check that we can correctly construct the source code path to a symbol.
     #[test]
     fn symbol_source_code_path() {


### PR DESCRIPTION
Code coverage is highlighting a bunch of "red" on the `#[derive(Debug)]` annotations on the `Symbolizer` related types. Add tests for them.