### PR TITLE
Support more than 0xff00 (SHN_LORESERVE) section headers

### DIFF
--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -67,6 +67,7 @@ pub(crate) struct Elf64_Shdr {
 unsafe impl crate::util::Pod for Elf64_Shdr {}
 
 pub(crate) const SHN_UNDEF: u16 = 0;
+pub(crate) const SHN_LORESERVE: u16 = 0xff00;
 
 pub(crate) const SHT_NOTE: Elf64_Word = 7;
 


### PR DESCRIPTION
Our ELF support is incomplete. One issue we have is that we cannot handle more than 0xff00 section headers, because ELF special cases anything above this value.
This change fixes this very shortcoming, by using the correct sequence of steps for inferring the number of section headers.

Refs: #64