### PR TITLE
Optionally include backtraces in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 - Added caching for APK related symbolization data structures
 - Added caching logic to `inspect::Inspector`
 - Made `inspect::SymInfo::file_offset` member optional
+- Added ability to contain backtraces in `Error` objects
 - Added support for symbolizing Gsym addresses to `blazecli`
 - Fixed bogus inlined function reporting for Gsym
 - Bumped minimum supported Rust version to `1.65`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,11 @@ name = "blazesym"
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
-default = ["demangle", "dwarf"]
+default = ["backtrace", "demangle", "dwarf"]
+# Enable this feature to compile in support for capturing backtraces in errors.
+# Note that by default backtraces will not be collected unless opted in with
+# environment variables.
+backtrace = []
 # Enable this feature to enable DWARF support.
 dwarf = ["gimli"]
 # Enable this feature to get transparent symbol demangling.

--- a/tests/error_backtrace.rs
+++ b/tests/error_backtrace.rs
@@ -1,0 +1,40 @@
+//! This test relies on environment variable modification for its
+//! workings and, hence, relies on being run in a dedicated process. Do
+//! not add additional test cases unless they are guaranteed to not
+//! interfere.
+
+#![allow(clippy::let_and_return, clippy::let_unit_value)]
+
+use std::env;
+use std::io;
+
+use blazesym::Error;
+
+
+/// Make sure that we can capture backtraces in errors.
+///
+/// # Notes
+/// This test requires sufficient debug information to be present so
+/// that the file name is contained in the backtrace. For that reason we
+/// only run it on debug builds (represented by the `debug_assertions`
+/// proxy cfg).
+#[test]
+fn error_backtrace() {
+    if !cfg!(debug_assertions) {
+        return
+    }
+
+    // Ensure that we capture a backtrace.
+    let () = env::set_var("RUST_LIB_BACKTRACE", "1");
+
+    let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");
+    let err = Error::from(err);
+    let debug = format!("{err:?}");
+
+    let start_idx = debug.find("Stack backtrace").unwrap();
+    let backtrace = &debug[start_idx..];
+    assert!(
+        backtrace.contains("tests/error_backtrace.rs"),
+        "{backtrace}"
+    );
+}

--- a/tests/error_no_backtrace1.rs
+++ b/tests/error_no_backtrace1.rs
@@ -1,0 +1,26 @@
+//! This test relies on environment variable modification for its
+//! workings and, hence, relies on being run in a dedicated process. Do
+//! not add additional test cases unless they are guaranteed to not
+//! interfere.
+
+#![allow(clippy::let_and_return, clippy::let_unit_value)]
+
+use std::env;
+use std::io;
+
+use blazesym::Error;
+
+
+/// Make sure that we do not emit backtraces in errors when
+/// the `RUST_LIB_BACKTRACE` environment variable is not present.
+#[test]
+fn error_no_backtrace1() {
+    let () = env::remove_var("RUST_BACKTRACE");
+    let () = env::remove_var("RUST_LIB_BACKTRACE");
+
+    let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");
+    let err = Error::from(err);
+    let debug = format!("{err:?}");
+
+    assert_eq!(debug.find("Stack backtrace"), None);
+}

--- a/tests/error_no_backtrace2.rs
+++ b/tests/error_no_backtrace2.rs
@@ -1,0 +1,25 @@
+//! This test relies on environment variable modification for its
+//! workings and, hence, relies on being run in a dedicated process. Do
+//! not add additional test cases unless they are guaranteed to not
+//! interfere.
+
+#![allow(clippy::let_and_return, clippy::let_unit_value)]
+
+use std::env;
+use std::io;
+
+use blazesym::Error;
+
+
+/// Make sure that we do not emit backtraces in errors when
+/// the `RUST_LIB_BACKTRACE` environment variable is "0".
+#[test]
+fn error_no_backtrace2() {
+    let () = env::set_var("RUST_LIB_BACKTRACE", "0");
+
+    let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");
+    let err = Error::from(err);
+    let debug = format!("{err:?}");
+
+    assert_eq!(debug.find("Stack backtrace"), None);
+}


### PR DESCRIPTION
Seeing error and their call chains can be tremendously useful and most of the time that is sufficient to get a good understanding of an issue. However, occasionally errors don't contain enough context and messages are reused on multiple call paths.
With this change we enhance our Error type with the capability to capture a backtrace at the time the error was created. This backtrace is then contained in the Debug representation. Note that because capturing a backtrace is a costly operation, backtrace capture is controlled by environment variables in the same way that Rust proper behaves.