### PR TITLE
Support handling large e_shstrndx values

### DIFF
--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -71,6 +71,7 @@ unsafe impl crate::util::Pod for Elf64_Shdr {}
 
 pub(crate) const SHN_UNDEF: u16 = 0;
 pub(crate) const SHN_LORESERVE: u16 = 0xff00;
+pub(crate) const SHN_XINDEX: u16 = 0xffff;
 
 pub(crate) const SHT_NOTE: Elf64_Word = 7;
 


### PR DESCRIPTION
Our ELF support is incomplete. One issue we have is that we cannot handle a e_shstrndx value greater than 0xff00, because ELF special cases anything above this value.
This change fixes this very shortcoming, by using the correct sequence of steps for retrieving the actual value.

Refs: #64