### PR TITLE
Support more than 0xffff program headers

### DIFF
--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -51,6 +51,8 @@ unsafe impl crate::util::Pod for Elf64_Phdr {}
 
 pub(crate) const PF_X: Elf64_Word = 1;
 
+pub(crate) const PN_XNUM: u16 = 0xffff;
+
 #[derive(Debug)]
 #[repr(C)]
 pub(crate) struct Elf64_Shdr {


### PR DESCRIPTION
Our ELF support is incomplete. One issue we have is that we cannot handle more than 0xffff program headers, because ELF special cases anything above this value.
This change fixes this very shortcoming, by using the correct sequence of steps for retrieving the actual value.

Refs: #64