### PR TITLE
Cache Gsym (file-based) resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added caching logic for Gsym resolvers to `symbolize::Symbolizer`
+
+
 0.2.0-alpha.8
 -------------
 - Fixed build failure when `dwarf` feature is not enabled

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::ops::Deref;
 use std::ops::Range;
 use std::os::unix::io::AsRawFd;
+#[cfg(test)]
 use std::path::Path;
 use std::ptr::null_mut;
 use std::rc::Rc;
@@ -34,6 +35,7 @@ impl Builder {
     }
 
     /// Memory map the file at the provided `path`.
+    #[cfg(test)]
     pub fn open<P>(self, path: P) -> Result<Mmap>
     where
         P: AsRef<Path>,


### PR DESCRIPTION
With this change we cache Gsym file-based resolvers based on the file system path used. This is similar to what we do for other resolvers such as those used for ELF files.