### PR TITLE
Cache build artifacts in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
         profile: minimal
         override: true
+    - uses: Swatinem/rust-cache@v2
     - name: Build ${{ matrix.profile }}
       run: |
         cargo build --profile=${{ matrix.profile }} ${{ matrix.args }} --lib


### PR DESCRIPTION
Some of our build jobs are actively contending for the title of longest running job per CI workflow run.
Cache build artifacts similar to what we already do for benchmarks to speed them up. This has the potential to tremendously speed up builds, particularly on slower configurations. E.g., MacOS builds were seen to take anywhere from around 6-9 minutes in the past. With caching enabled they complete in less than 1 minute 20 seconds.