### PR TITLE
Run benchmarks only on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Test and gather coverage
-      run: cargo llvm-cov --all-targets --features=generate-large-test-files --lcov --output-path lcov.info
+      run: cargo llvm-cov --all-targets --features=nightly,generate-large-test-files --lcov --output-path lcov.info
     - name: Upload code coverage results
       uses: codecov/codecov-action@v3
       with:
@@ -148,6 +148,10 @@ jobs:
       run: git diff --exit-code ||
              (echo "!!!! CHECKED IN C HEADER IS OUTDATED !!!!" && false)
   bench:
+    # Only run benchmarks on the final push. They are generally only
+    # informative because the GitHub Runners do not provide a stable
+    # performance baseline anyway.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Benchmark
     runs-on: ubuntu-22.04
     env:


### PR DESCRIPTION
By now (and with commit 4599086a712b ("Cache build artifacts in CI") landed), the running of benchmarks is by far the longest part blocking submission of a pull request. There isn't really that much of a point in running them as part of a pull request, as we generally don't rely on benchmark runtimes for anything -- see commit 43d3742ed828b ("Run all benchmarks in CI")
With this change we run them only as part of a push to the main branch. To ensure we do not regress our benchmark code, we still run them in "test mode" (i.e., a single iteration) during testing by enabling the nightly flag for the coverage job.