### PR TITLE
Make symbolization results include references to memory mapped data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,25 @@ jobs:
         profile: minimal
         override: true
     - run: cargo test --workspace --release
+  test-miri:
+    name: Test with Miri
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Miri
+      run: |
+        rustup toolchain install nightly --component miri
+        rustup override set nightly
+        cargo miri setup
+    # Miri would honor our custom test runner, but doesn't work with it. We
+    # could conceivably override that by specifying
+    # CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER, except it appears as if Miri
+    # uses the runner itself. In short, it's a mess. Just remove any
+    # such custom configuration when running Miri.
+    - name: Remove .cargo/config
+      run: rm .cargo/config
+    - name: Run tests
+      run: cargo miri test --features=dont-generate-unit-test-files -- "insert_map::" "util::"
   c-header:
     name: Check generated C header
     runs-on: ubuntu-latest
@@ -179,7 +198,6 @@ jobs:
         # libtest style benchmarks above. Sigh.
         cargo bench --bench=main --features=generate-large-test-files,dont-generate-unit-test-files -- --output-format=bencher | tee --append $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
-
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 - Added caching logic for Gsym resolvers to `symbolize::Symbolizer`
+- Adjusted various symbolization related types to contain `Cow` objects to
+  facilitate hand out of memory mapped data without unnecessary allocations
+  - Adjusted various symbolization code paths to stop heap-allocating
 
 
 0.2.0-alpha.8

--- a/src/c_api/symbolize.rs
+++ b/src/c_api/symbolize.rs
@@ -435,7 +435,7 @@ fn convert_symbolizedresults_to_c(results: Vec<Symbolized>) -> *const blaze_resu
         match sym {
             Symbolized::Sym(sym) => {
                 let sym_ref = unsafe { &mut *syms_last };
-                let name_ptr = make_cstr(OsStr::new(&sym.name));
+                let name_ptr = make_cstr(OsStr::new(sym.name.as_ref()));
 
                 sym_ref.name = name_ptr;
                 sym_ref.addr = sym.addr;
@@ -447,7 +447,7 @@ fn convert_symbolizedresults_to_c(results: Vec<Symbolized>) -> *const blaze_resu
                 for inlined in sym.inlined.iter() {
                     let inlined_ref = unsafe { &mut *inlined_last };
 
-                    let name_ptr = make_cstr(OsStr::new(&inlined.name));
+                    let name_ptr = make_cstr(OsStr::new(inlined.name.as_ref()));
                     inlined_ref.name = name_ptr;
                     convert_code_info(
                         &inlined.code_info,

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -53,15 +53,6 @@ impl ElfResolver {
     pub(crate) fn file_name(&self) -> &Path {
         &self.file_name
     }
-
-    #[inline]
-    pub(crate) fn uses_dwarf(&self) -> bool {
-        match &self.backend {
-            #[cfg(feature = "dwarf")]
-            ElfBackend::Dwarf(_) => true,
-            ElfBackend::Elf(_) => false,
-        }
-    }
 }
 
 impl SymResolver for ElfResolver {

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -62,7 +62,7 @@ impl<T> FileCache<T> {
         }
     }
 
-    pub fn entry(&mut self, path: &Path) -> Result<(&File, &OnceCell<T>)> {
+    pub fn entry(&self, path: &Path) -> Result<(&File, &OnceCell<T>)> {
         let file =
             File::open(path).with_context(|| format!("failed to open file {}", path.display()))?;
         let stat = fstat(file.as_raw_fd())?;
@@ -101,7 +101,7 @@ mod tests {
     /// Check that we can associate data with a file.
     #[test]
     fn lookup() {
-        let mut cache = FileCache::<usize>::new();
+        let cache = FileCache::<usize>::new();
         let tmpfile = NamedTempFile::new().unwrap();
 
         {
@@ -120,7 +120,7 @@ mod tests {
     /// Make sure that a changed file purges the cache entry.
     #[test]
     fn outdated() {
-        let mut cache = FileCache::<usize>::new();
+        let cache = FileCache::<usize>::new();
         let tmpfile = NamedTempFile::new().unwrap();
         let modified = {
             let (file, cell) = cache.entry(tmpfile.path()).unwrap();

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -1,10 +1,10 @@
-use std::cell::OnceCell;
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::path::PathBuf;
 
 use crate::insert_map::InsertMap;
+use crate::once::OnceCell;
 use crate::util::fstat;
 use crate::ErrorExt as _;
 use crate::Result;

--- a/src/insert_map.rs
+++ b/src/insert_map.rs
@@ -1,0 +1,128 @@
+use std::cell::RefCell;
+use std::collections::hash_map;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use crate::Result;
+
+
+/// An insert-only map.
+///
+/// This map allows only for insertion, but not removal of values. It
+/// does so behind an immutable interface.
+#[derive(Debug)]
+pub(crate) struct InsertMap<K, V> {
+    /// A proxy member used for making sure that we do not borrow `map` mutably
+    /// multiple times.
+    refcell: RefCell<()>,
+    map: RefCell<HashMap<K, V>>,
+}
+
+impl<K, V> InsertMap<K, V> {
+    /// Create a new, empty `InsertMap` instance.
+    pub(crate) fn new() -> Self {
+        Self {
+            refcell: RefCell::new(()),
+            map: RefCell::new(HashMap::new()),
+        }
+    }
+
+    /// Retrieve a value mapping to a key, if already present, or insert
+    /// it and return it then.
+    ///
+    /// # Panics
+    /// The `init` function should not use functionality provided by the
+    /// object this method operates on, recursively, or a runtime panic
+    /// may be the result.
+    pub(crate) fn get_or_insert<F>(&self, key: K, init: F) -> &V
+    where
+        K: Eq + Hash,
+        F: FnOnce() -> V,
+    {
+        let _borrow = self.map.borrow_mut();
+        // SAFETY: We are sure to not borrow mutably twice because the `_borrow`
+        //         guard protects us.
+        let map = unsafe { self.map.as_ptr().as_mut() }.unwrap();
+        match map.entry(key) {
+            hash_map::Entry::Occupied(occupied) => occupied.into_mut(),
+            hash_map::Entry::Vacant(vacancy) => vacancy.insert(init()),
+        }
+    }
+
+    /// Retrieve a value mapping to a key, if already present, or insert
+    /// it and return it then.
+    ///
+    /// # Panics
+    /// The `init` function should not use functionality provided by the
+    /// object this method operates on, recursively, or a runtime panic
+    /// may be the result.
+    pub(crate) fn get_or_try_insert<F>(&self, key: K, init: F) -> Result<&V>
+    where
+        K: Eq + Hash,
+        F: FnOnce() -> Result<V>,
+    {
+        let _borrow = self.refcell.borrow_mut();
+        // SAFETY: We are sure to not borrow mutably twice because the `_borrow`
+        //         guard protects us.
+        let map = unsafe { self.map.as_ptr().as_mut() }.unwrap();
+        match map.entry(key) {
+            hash_map::Entry::Occupied(occupied) => {
+                let entry = occupied.into_mut();
+                Ok(entry)
+            }
+            hash_map::Entry::Vacant(vacancy) => {
+                let value = init()?;
+                let entry = vacancy.insert(value);
+                Ok(entry)
+            }
+        }
+    }
+}
+
+impl<K, V> Default for InsertMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::Error;
+    use crate::ErrorKind;
+
+
+    /// Check that value insertion works as it should.
+    #[test]
+    fn insertion() {
+        let map = InsertMap::<usize, &'static str>::new();
+        let s = map
+            .get_or_try_insert(42, || Ok("you win the price"))
+            .unwrap();
+        assert_eq!(s, &"you win the price");
+
+        let s = map.get_or_try_insert(42, || panic!()).unwrap();
+        assert_eq!(s, &"you win the price");
+
+        let err = map
+            .get_or_try_insert(31, || Err(Error::with_unsupported("unsupported")))
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
+
+        let s = map.get_or_try_insert(31, || Ok("31 wins")).unwrap();
+        assert_eq!(s, &"31 wins");
+    }
+
+
+    /// Make sure that `InsertMap` does not allow for recursive
+    /// access as part of initialization.
+    #[test]
+    #[should_panic = "already borrowed"]
+    fn recursive_access() {
+        let map = InsertMap::<usize, &'static str>::new();
+        let _value =
+            map.get_or_try_insert(42, || map.get_or_try_insert(42, || Ok("foobar")).copied());
+    }
+}

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -1,4 +1,3 @@
-use std::cell::OnceCell;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -8,7 +7,7 @@ use crate::elf::ElfBackend;
 use crate::elf::ElfParser;
 use crate::elf::ElfResolver;
 use crate::file_cache::FileCache;
-use crate::util::OnceCellExt as _;
+use crate::once::OnceCell;
 use crate::Result;
 use crate::SymResolver;
 
@@ -84,7 +83,7 @@ impl Inspector {
         let (file, cell) = self.elf_cache.entry(path)?;
         let resolver = if let Some(data) = cell.get() {
             if debug_info {
-                data.dwarf.get_or_try_init_(|| {
+                data.dwarf.get_or_try_init(|| {
                     // SANITY: We *know* a `ResolverData` object is present and
                     //         given that we are initializing the `dwarf` part
                     //         of it, the `elf` part *must* be present.
@@ -92,7 +91,7 @@ impl Inspector {
                     self.elf_resolver_from_parser(path, parser, true)
                 })?
             } else {
-                data.elf.get_or_try_init_(|| {
+                data.elf.get_or_try_init(|| {
                     // SANITY: We *know* a `ResolverData` object is present and
                     //         given that we are initializing the `elf` part of
                     //         it, the `dwarf` part *must* be present.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod ksym;
 mod maps;
 mod mmap;
 pub mod normalize;
+mod once;
 mod resolver;
 pub mod symbolize;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ mod elf;
 mod error;
 mod file_cache;
 mod gsym;
+mod insert_map;
 pub mod inspect;
 mod kernel;
 mod ksym;

--- a/src/once.rs
+++ b/src/once.rs
@@ -1,0 +1,194 @@
+//! A copy of std::once::OnceCell.
+// TODO: Remove this module once our minimum supported Rust version is greater
+//       1.70 and/or `OnceCell::get_or_try_init` is stable.
+
+use std::cell::UnsafeCell;
+use std::convert::Infallible;
+use std::fmt;
+use std::hint::unreachable_unchecked;
+
+/// A cell which can be written to only once.
+///
+/// This allows obtaining a shared `&T` reference to its inner value without copying or replacing
+/// it (unlike [`Cell`]), and without runtime borrow checks (unlike [`RefCell`]). However,
+/// only immutable references can be obtained unless one has a mutable reference to the cell
+/// itself.
+///
+/// For a thread-safe version of this struct, see [`std::sync::OnceLock`].
+///
+/// [`RefCell`]: crate::cell::RefCell
+/// [`Cell`]: crate::cell::Cell
+/// [`std::sync::OnceLock`]: ../../std/sync/struct.OnceLock.html
+pub struct OnceCell<T> {
+    // Invariant: written to at most once.
+    inner: UnsafeCell<Option<T>>,
+}
+
+impl<T> OnceCell<T> {
+    /// Creates a new empty cell.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> OnceCell<T> {
+        OnceCell {
+            inner: UnsafeCell::new(None),
+        }
+    }
+
+    /// Gets the reference to the underlying value.
+    ///
+    /// Returns `None` if the cell is empty.
+    #[inline]
+    pub fn get(&self) -> Option<&T> {
+        // SAFETY: Safe due to `inner`'s invariant
+        unsafe { &*self.inner.get() }.as_ref()
+    }
+
+    /// Sets the contents of the cell to `value`.
+    ///
+    /// # Errors
+    ///
+    /// This method returns `Ok(())` if the cell was empty and `Err(value)` if
+    /// it was full.
+    #[inline]
+    pub fn set(&self, value: T) -> Result<(), T> {
+        match self.try_insert(value) {
+            Ok(_) => Ok(()),
+            Err((_, value)) => Err(value),
+        }
+    }
+
+    /// Sets the contents of the cell to `value` if the cell was empty, then
+    /// returns a reference to it.
+    ///
+    /// # Errors
+    ///
+    /// This method returns `Ok(&value)` if the cell was empty and
+    /// `Err(&current_value, value)` if it was full.
+    #[inline]
+    pub fn try_insert(&self, value: T) -> Result<&T, (&T, T)> {
+        if let Some(old) = self.get() {
+            return Err((old, value));
+        }
+
+        // SAFETY: This is the only place where we set the slot, no races
+        // due to reentrancy/concurrency are possible, and we've
+        // checked that slot is currently `None`, so this write
+        // maintains the `inner`'s invariant.
+        let slot = unsafe { &mut *self.inner.get() };
+        Ok(slot.insert(value))
+    }
+
+    /// Gets the contents of the cell, initializing it with `f`
+    /// if the cell was empty.
+    ///
+    /// # Panics
+    ///
+    /// If `f` panics, the panic is propagated to the caller, and the cell
+    /// remains uninitialized.
+    ///
+    /// It is an error to reentrantly initialize the cell from `f`. Doing
+    /// so results in a panic.
+    #[inline]
+    pub fn get_or_init<F>(&self, f: F) -> &T
+    where
+        F: FnOnce() -> T,
+    {
+        match self.get_or_try_init(|| Ok::<T, Infallible>(f())) {
+            Ok(val) => val,
+            Err(_) => unsafe { unreachable_unchecked() },
+        }
+    }
+
+    /// Gets the contents of the cell, initializing it with `f` if
+    /// the cell was empty. If the cell was empty and `f` failed, an
+    /// error is returned.
+    ///
+    /// # Panics
+    ///
+    /// If `f` panics, the panic is propagated to the caller, and the cell
+    /// remains uninitialized.
+    ///
+    /// It is an error to reentrantly initialize the cell from `f`. Doing
+    /// so results in a panic.
+    pub fn get_or_try_init<F, E>(&self, f: F) -> Result<&T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        if let Some(val) = self.get() {
+            return Ok(val);
+        }
+        /// Avoid inlining the initialization closure into the common path that fetches
+        /// the already initialized value
+        #[cold]
+        fn outlined_call<F, T, E>(f: F) -> Result<T, E>
+        where
+            F: FnOnce() -> Result<T, E>,
+        {
+            f()
+        }
+        let val = outlined_call(f)?;
+        // Note that *some* forms of reentrant initialization might lead to
+        // UB (see `reentrant_init` test). I believe that just removing this
+        // `panic`, while keeping `try_insert` would be sound, but it seems
+        // better to panic, rather than to silently use an old value.
+        if let Ok(val) = self.try_insert(val) {
+            Ok(val)
+        } else {
+            panic!("reentrant init")
+        }
+    }
+}
+
+impl<T> Default for OnceCell<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for OnceCell<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_tuple("OnceCell");
+        match self.get() {
+            Some(v) => d.field(v),
+            None => d.field(&format_args!("<uninit>")),
+        };
+        d.finish()
+    }
+}
+
+impl<T: Clone> Clone for OnceCell<T> {
+    #[inline]
+    fn clone(&self) -> OnceCell<T> {
+        let res = OnceCell::new();
+        if let Some(value) = self.get() {
+            match res.set(value.clone()) {
+                Ok(()) => (),
+                Err(_) => unreachable!(),
+            }
+        }
+        res
+    }
+}
+
+impl<T: PartialEq> PartialEq for OnceCell<T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.get() == other.get()
+    }
+}
+
+impl<T: Eq> Eq for OnceCell<T> {}
+
+impl<T> From<T> for OnceCell<T> {
+    /// Creates a new `OnceCell<T>` which already contains the given `value`.
+    #[inline]
+    fn from(value: T) -> Self {
+        OnceCell {
+            inner: UnsafeCell::new(Some(value)),
+        }
+    }
+}
+
+// Just like for `Cell<T>` this isn't needed, but results in nicer error messages.
+//impl<T> !Sync for OnceCell<T> {}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -27,5 +27,5 @@ where
     /// `inlined_fns` is true, information about inlined calls at the very
     /// address will also be looked up and reported as the optional
     /// [`AddrCodeInfo::inlined`] attribute.
-    fn find_code_info(&self, addr: Addr, inlined_fns: bool) -> Result<Option<AddrCodeInfo>>;
+    fn find_code_info(&self, addr: Addr, inlined_fns: bool) -> Result<Option<AddrCodeInfo<'_>>>;
 }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -29,7 +29,6 @@ use crate::normalize::normalize_sorted_user_addrs_with_entries;
 use crate::normalize::Handler as _;
 use crate::util;
 use crate::util::uname_release;
-use crate::util::OnceCellExt as _;
 use crate::zip;
 use crate::Addr;
 use crate::Error;
@@ -397,7 +396,7 @@ impl Symbolizer {
 
     fn elf_resolver<'slf>(&'slf self, path: &Path) -> Result<&'slf Rc<ElfResolver>> {
         let (file, cell) = self.elf_cache.entry(path)?;
-        let resolver = cell.get_or_try_init_(|| self.create_elf_resolver(path, file))?;
+        let resolver = cell.get_or_try_init(|| self.create_elf_resolver(path, file))?;
         Ok(resolver)
     }
 
@@ -408,7 +407,7 @@ impl Symbolizer {
 
     fn gsym_resolver<'slf>(&'slf self, path: &Path) -> Result<&'slf Rc<GsymResolver<'static>>> {
         let (file, cell) = self.gsym_cache.entry(path)?;
-        let resolver = cell.get_or_try_init_(|| self.create_gsym_resolver(path, file))?;
+        let resolver = cell.get_or_try_init(|| self.create_gsym_resolver(path, file))?;
         Ok(resolver)
     }
 
@@ -460,7 +459,7 @@ impl Symbolizer {
         file_off: u64,
     ) -> Result<Option<(&'slf Rc<ElfResolver>, Addr)>> {
         let (file, cell) = self.apk_cache.entry(path)?;
-        let (apk, resolvers) = cell.get_or_try_init_(|| {
+        let (apk, resolvers) = cell.get_or_try_init(|| {
             let apk = zip::Archive::with_mmap(Mmap::builder().map(file)?)?;
             let resolvers = InsertMap::new();
             Result::<_, Error>::Ok((apk, resolvers))
@@ -572,7 +571,7 @@ impl Symbolizer {
 
     fn ksym_resolver<'slf>(&'slf self, path: &Path) -> Result<&'slf Rc<KSymResolver>> {
         let (file, cell) = self.ksym_cache.entry(path)?;
-        let resolver = cell.get_or_try_init_(|| self.create_ksym_resolver(path, file))?;
+        let resolver = cell.get_or_try_init(|| self.create_ksym_resolver(path, file))?;
         Ok(resolver)
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-use std::cell::OnceCell;
 use std::cmp::Ordering;
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -10,28 +9,6 @@ use std::mem::MaybeUninit;
 use std::os::unix::io::RawFd;
 use std::ptr::NonNull;
 use std::slice;
-
-
-// TODO: Remove once `OnceCell::get_or_try_init()` is stable.
-pub(crate) trait OnceCellExt<T> {
-    fn get_or_try_init_<F, E>(&self, f: F) -> Result<&T, E>
-    where
-        F: FnOnce() -> Result<T, E>;
-}
-
-impl<T> OnceCellExt<T> for OnceCell<T> {
-    fn get_or_try_init_<F, E>(&self, f: F) -> Result<&T, E>
-    where
-        F: FnOnce() -> Result<T, E>,
-    {
-        if let Some(value) = self.get() {
-            Ok(value)
-        } else {
-            let value = f()?;
-            Ok(self.get_or_init(|| value))
-        }
-    }
-}
 
 
 /// Reorder elements of `array` based on index information in `indices`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use std::cell::OnceCell;
 use std::cmp::Ordering;
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -9,6 +10,28 @@ use std::mem::MaybeUninit;
 use std::os::unix::io::RawFd;
 use std::ptr::NonNull;
 use std::slice;
+
+
+// TODO: Remove once `OnceCell::get_or_try_init()` is stable.
+pub(crate) trait OnceCellExt<T> {
+    fn get_or_try_init_<F, E>(&self, f: F) -> Result<&T, E>
+    where
+        F: FnOnce() -> Result<T, E>;
+}
+
+impl<T> OnceCellExt<T> for OnceCell<T> {
+    fn get_or_try_init_<F, E>(&self, f: F) -> Result<&T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        if let Some(value) = self.get() {
+            Ok(value)
+        } else {
+            let value = f()?;
+            Ok(self.get_or_init(|| value))
+        }
+    }
+}
 
 
 /// Reorder elements of `array` based on index information in `indices`.

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -154,13 +154,13 @@ fn symbolize_dwarf_gsym_inlined() {
             let name = &result.inlined[0].name;
             assert_eq!(*name, "factorial_inline_wrapper");
             let frame = result.inlined[0].code_info.as_ref().unwrap();
-            assert_eq!(frame.file, "test-stable-addresses.c");
+            assert_eq!(frame.file, OsStr::new("test-stable-addresses.c"));
             assert_eq!(frame.line, Some(26));
 
             let name = &result.inlined[1].name;
             assert_eq!(*name, "factorial_2nd_layer_inline_wrapper");
             let frame = result.inlined[1].code_info.as_ref().unwrap();
-            assert_eq!(frame.file, "test-stable-addresses.c");
+            assert_eq!(frame.file, OsStr::new("test-stable-addresses.c"));
             assert_eq!(frame.line, Some(21));
         } else {
             assert!(result.inlined.is_empty(), "{:#?}", result.inlined);


### PR DESCRIPTION
So far we unconditionally heap-allocated all dynamically sized bits of information that we hand out as part of the symbolization process. Conceptually a lot of these allocations are unnecessary: symbol names, file names, and directory paths all are present in the symbolization sources already.
With this change we adjust all involved types to carry Cow correspondents of the unconditionally-owned types previously used. We then adjust all the logic to omit allocating when that is unnecessary. Not all symbolization paths can be allocation free. For example, when the Gsym::Data source is used, we do not have control over the data and, hence, cannot safely embed references to it in the symbolization result. In such a case we fall back to heap allocating followed by copying of the necessary bytes.
