### PR TITLE
Add benchmark for Gsym symbolization without setup

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -8,6 +8,12 @@ macro_rules! bench_fn {
     };
 }
 
+macro_rules! bench_sub_fn {
+    ($group:expr, $bench_fn:ident) => {
+        $group.bench_function(crate::bench_fn_name(stringify!($bench_fn)), $bench_fn);
+    };
+}
+
 
 mod inspect;
 mod normalize;

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -14,6 +14,7 @@ use blazesym::Addr;
 use blazesym::Pid;
 
 use criterion::measurement::Measurement;
+use criterion::Bencher;
 use criterion::BenchmarkGroup;
 
 
@@ -103,7 +104,7 @@ fn symbolize_dwarf() {
     assert_eq!(result.code_info.as_ref().unwrap().line, Some(534));
 }
 
-/// Symbolize an address in a GSYM file, end-to-end, i.e., including all
+/// Symbolize an address in a Gsym file, end-to-end, i.e., including all
 /// necessary setup.
 fn symbolize_gsym() {
     let gsym_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
@@ -124,6 +125,39 @@ fn symbolize_gsym() {
     assert_eq!(result.name, "abort_creds");
 }
 
+/// Symbolize multiple addresses in a Gsym file.
+///
+/// Addresses with high inlined function count were chosen, to
+/// illustrate impact of reporting large numbers of them.
+fn symbolize_gsym_multi_no_setup<M>(b: &mut Bencher<'_, M>)
+where
+    M: Measurement,
+{
+    let gsym_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("vmlinux-5.17.12-100.fc34.x86_64.gsym");
+    let src = Source::from(GsymFile::new(gsym_vmlinux));
+    let symbolizer = Symbolizer::new();
+
+    // Addresses of instructions with an inlined function count >= 12.
+    let addrs = &[
+        0xffffffff812d527c,
+        0xffffffff812d5285,
+        0xffffffff812d9677,
+        0xffffffff812dc48a,
+        0xffffffff812dc4a2,
+        0xffffffff812dc52d,
+    ];
+
+    let () = b.iter(|| {
+        let result = symbolizer
+            .symbolize(black_box(&src), black_box(Input::VirtOffset(addrs)))
+            .unwrap();
+        let _result = black_box(result);
+    });
+}
+
+
 pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
 where
     M: Measurement,
@@ -134,5 +168,6 @@ where
         bench_fn!(group, symbolize_dwarf_no_lines);
         bench_fn!(group, symbolize_dwarf);
         bench_fn!(group, symbolize_gsym);
+        bench_sub_fn!(group, symbolize_gsym_multi_no_setup);
     }
 }


### PR DESCRIPTION
All our existing end-to-end benchmarks included setup time and excluded
any benefits gained from caching symbolization data -- effectively a
worst case scenario.
This change adds a benchmark that keeps around the symbolizer and
symbolizes multiple addresses in a single call. All addresses have a
high (n >= 12) number of inlined functions, so reporting them does have
a large effect on performance.
When run with and without https://github.com/libbpf/blazesym/pull/402,
which eliminates large amounts of allocations (which apply to all symbol
names and paths, including those in reported inlined functions), we can
see an almost 12% performance improvement by said change:

```
  main/symbolize_gsym_multi_no_setup
    time:   [119.31 µs 121.71 µs 124.59 µs]
    change: [-13.978% -11.955% -9.7199%] (p = 0.00 < 0.02)
    Performance has improved.
```