### PR TITLE
Fix ksym_resolver_load_find test

### DIFF
--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -197,15 +197,21 @@ mod tests {
             "kallsyms seems to be unavailable or with all 0 addresses. (Check {KALLSYMS})"
         );
 
+        let ensure_addr_for_name = |name, addr| {
+            let opts = FindAddrOpts {
+                offset_in_file: false,
+                sym_type: SymType::Function,
+            };
+            let found = resolver.find_addr(name, &opts).unwrap();
+            assert!(found.iter().any(|x| x.addr == addr));
+        };
+
+
         // Find the address of the symbol placed at the middle
         let sym = &resolver.syms[resolver.syms.len() / 2];
         let addr = sym.addr;
-        let name = sym.name.clone();
         let found = resolver.find_sym(addr).unwrap().unwrap();
-        assert_eq!(found.name, name);
-
-        let found = resolver.find_sym(addr + 1).unwrap().unwrap();
-        assert_eq!(found.name, name);
+        ensure_addr_for_name(found.name, addr);
 
         // 0 is an invalid address.  We remove all symbols with 0 as
         // thier address from the list.
@@ -214,23 +220,12 @@ mod tests {
         // Find the address of the last symbol
         let sym = &resolver.syms.last().unwrap();
         let addr = sym.addr;
-        let name = sym.name.clone();
         let found = resolver.find_sym(addr).unwrap().unwrap();
-        assert_eq!(found.name, name);
+        ensure_addr_for_name(found.name, addr);
 
         let found = resolver.find_sym(addr + 1).unwrap().unwrap();
-        assert_eq!(found.name, name);
-
-        // Find the symbol placed at the one third
-        let sym = &resolver.syms[resolver.syms.len() / 3];
-        let addr = sym.addr;
-        let name = sym.name.clone();
-        let opts = FindAddrOpts {
-            offset_in_file: false,
-            sym_type: SymType::Function,
-        };
-        let found = resolver.find_addr(&name, &opts).unwrap();
-        assert!(found.iter().any(|x| x.addr == addr));
+        // Should still find the previous symbol, which is the last one.
+        ensure_addr_for_name(found.name, addr);
     }
 
     #[test]


### PR DESCRIPTION
The `ksym_resolver_load_find` test is flaky. The reason being that `kallsyms` may contain multiple function names for the same address (probably because of aliases) and that can trip us over when searching for the one alias by address but then getting back a different one. Fix the test by doing a reverse lookup back from name to address to make sure that we did indeed find one correct candidate, instead of mindlessly just checking the names for equality.