### PR TITLE
Handle potential numeric overflows more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Adjusted various symbolization related types to contain `Cow` objects to
   facilitate hand out of memory mapped data without unnecessary allocations
   - Adjusted various symbolization code paths to stop heap-allocating
+- Handled potential numeric overflow in Gsym inlined function parser more
+  gracefully
 
 
 0.2.0-alpha.8


### PR DESCRIPTION
The start and end address calculation that we perform as part of the Gsym inlined function parsing could potentially result in a numeric overflow, depending on inputs.
Make sure to handle such cases more gracefully then panicking (on debug builds).