### PR TITLE
Use checked arithmetic some more

### DIFF
--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -171,7 +171,7 @@ impl GsymContext<'_> {
     /// Get the address of an entry in the Address Table.
     pub fn addr_at(&self, idx: usize) -> Option<Addr> {
         let addr_off_size = self.header.addr_off_size as usize;
-        let mut data = self.addr_tab.get(idx * addr_off_size..)?;
+        let mut data = self.addr_tab.get(idx.checked_mul(addr_off_size)?..)?;
         let addr = match addr_off_size {
             1 => data.read_u8()?.into(),
             2 => data.read_u16()?.into(),
@@ -179,7 +179,7 @@ impl GsymContext<'_> {
             8 => data.read_u64()? as Addr,
             _ => return None,
         };
-        Some(self.header.base_address as Addr + addr)
+        (self.header.base_address as Addr).checked_add(addr)
     }
 
     /// Get the AddrInfo of an address given by an index.


### PR DESCRIPTION
Opt in to using explicitly checked arithmetic in two more places in the Gsym parser code.