### PR TITLE
Move create_apk_elf_path() into symbolize module

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -55,6 +55,5 @@ pub use normalizer::Normalizer;
 pub use normalizer::Output;
 pub use user::UserOutput;
 
-pub(crate) use user::create_apk_elf_path;
 pub(crate) use user::normalize_sorted_user_addrs_with_entries;
 pub(crate) use user::Handler;

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -23,29 +23,6 @@ use super::meta::UserMeta;
 use super::normalizer::Output;
 
 
-pub(crate) fn create_apk_elf_path(apk: &Path, elf: &Path) -> Result<PathBuf> {
-    let mut extension = apk
-        .extension()
-        .unwrap_or_else(|| OsStr::new("apk"))
-        .to_os_string();
-    // Append '!' to indicate separation from archive internal contents
-    // that follow. This is an Android convention.
-    let () = extension.push("!");
-
-    let mut apk = apk.to_path_buf();
-    if !apk.set_extension(extension) {
-        return Err(Error::new(
-            ErrorKind::InvalidInput,
-            format!("path {} is not valid", apk.display()),
-        )
-        .into())
-    }
-
-    let path = apk.join(elf);
-    Ok(path)
-}
-
-
 /// Make a [`UserMeta::Elf`] variant.
 fn make_elf_meta(entry: &PathMapsEntry, get_build_id: &BuildIdFn) -> Result<UserMeta> {
     let elf = Elf {
@@ -309,15 +286,6 @@ mod tests {
 
     use test_log::test;
 
-
-    /// Check that we can create a path to an ELF inside an APK as expected.
-    #[test]
-    fn elf_apk_path_creation() {
-        let apk = Path::new("/root/test.apk");
-        let elf = Path::new("subdir/libc.so");
-        let path = create_apk_elf_path(apk, elf).unwrap();
-        assert_eq!(path, Path::new("/root/test.apk!/subdir/libc.so"));
-    }
 
     /// Check that we correctly handle normalization of an address not
     /// in any executable segment.


### PR DESCRIPTION
With the rework of the normalization APIs a while back, the create_apk_elf_path() function is no longer used by the normalization code itself -- yet it is defined in there.
Move it over into the symbolize module, where it is actually used.