### PR TITLE
Introduce workflow for publishing blazecli

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,24 @@
+name: Publish blazecli
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+  publish:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Publish
+      run: cargo publish --package blazecli --no-verify --token "${CARGO_REGISTRY_TOKEN}"
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish blazesym
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Introduce a GitHub Actions workflow for publishing blazecli. For now it only covers publishing, not creating any GitHub releases or Git tags. These may or may not come later, as needed.