### PR TITLE
Cross-compile to various targets in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,25 @@ jobs:
     - name: Build ${{ matrix.profile }}
       run: |
         cargo build --profile=${{ matrix.profile }} ${{ matrix.args }} --lib
+  build-cross:
+    name: Cross-compile [${{ matrix.target }}]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          aarch64-linux-android,
+          arm-linux-androideabi,
+          armv7-linux-androideabi,
+          x86_64-unknown-linux-musl,
+        ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - run: |
+          cargo build --lib
   nop-rebuilds:
     name: No-op rebuilds
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
   - Adjusted various symbolization code paths to stop heap-allocating
 - Handled potential numeric overflow in Gsym inlined function parser more
   gracefully
+- Fixed build for some Android flavors
 
 
 0.2.0-alpha.8


### PR DESCRIPTION
It probably makes sense for us to explicitly cross-compile to a few more targets to weed out type casting bugs or similar early on. Do just that.