### PR TITLE
cli: Run verification against crates.io blazesym before publish

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -19,6 +19,6 @@ jobs:
         toolchain: stable
         override: true
     - name: Publish
-      run: cargo publish --package blazecli --no-verify --token "${CARGO_REGISTRY_TOKEN}"
+      run: cargo publish --package blazecli --token "${CARGO_REGISTRY_TOKEN}"
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The publish workflow for blazecli runs the entire workspace test suite. However, by default blazecli consumes the in-repository copy of blazesym. This copy could potentially have unpublished changes. When we publish blazecli, however, it will end up consuming a published version of blazesym. If there is a divergence, a broken release may be the result.
Unfortunately, I haven't really found a satisfactory way of testing: ideally we'd want to run the test suite against the published blazesym (though doing so may have other problems). For now, let's just let cargo do its basic set of verification steps as part of the publish command to improve on what we have.