### PR TITLE
Introduce workflow for publishing `blazesym-c`

### DIFF
--- a/.github/workflows/publish-capi.yml
+++ b/.github/workflows/publish-capi.yml
@@ -1,0 +1,24 @@
+name: Publish blazesym-c
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+  publish:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Publish
+      run: cargo publish --package blazesym-c --token "${CARGO_REGISTRY_TOKEN}"
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "blazesym-c"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This change introduces a workflow for publishing the `blazesym-c` crate. For now it only covers publishing, not creating any GitHub releases or Git tags. These may or may not come later, as needed.