### PR TITLE
Exclude blazecli from coverage assessment

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,6 +4,13 @@ coverage:
       default:
         # We don't gate anything based on flaky code coverage reports.
         informational: true
+      blazesym:
+        paths:
+          - src/
+      blazesym-c:
+        paths:
+          - capi/src/
+      # Note: blazecli is ignored at the llvm-cov level.
     patch:
       default:
         informational: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Test and gather coverage
-      run: cargo llvm-cov --workspace --all-targets --features=nightly,generate-large-test-files --lcov --output-path lcov.info
+      run: cargo llvm-cov --workspace --all-targets --features=nightly,generate-large-test-files --ignore-filename-regex=cli/src/ --lcov --output-path lcov.info
     - name: Upload code coverage results
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
Blazecli is arguably a trivial wrapper around functionality provided by the main library. Given how simple it currently is, we didn't see a point in adding another test suite for it.
Exclude it from Codecov's coverage assessment accordingly.