### PR TITLE
cli: Fix process symbolization

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,8 @@
+Unreleased
+----------
+- Fixed process symbolization erring out with wrong input type message
+
+
+0.1.0
+-----
+- Initial release

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,6 +4,8 @@
 blazecli
 ========
 
+- [Changelog](CHANGELOG.md)
+
 **blazecli** is a command line interface for the
 [**blazesym**][blazesym] library. It aims to closely mirror the
 structure of the library in its command and sub-command structure.


### PR DESCRIPTION
The process symbolization fails because we are providing the wrong input type to the library. Fix up the logic.