### PR TITLE
Add key suffix for Swatinem/rust-cache matrix usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.rust }}-${{ matrix.profile }}
     - name: Build ${{ matrix.profile }}
       run: |
         cargo build --profile=${{ matrix.profile }} ${{ matrix.args }} --lib


### PR DESCRIPTION
It turns out Swatinem/rust-cache does not automagically include all job related metadata in the cache key used. Rather, we have to tell it explicitly that we use a given toolchain with a given profile.