### PR TITLE
Stop filtering out non-executable but readable proc maps entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Adjusted various symbolization related types to contain `Cow` objects to
   facilitate hand out of memory mapped data without unnecessary allocations
   - Adjusted various symbolization code paths to stop heap-allocating
+- Adjusted normalization logic to honor executable and readable proc maps
+  entries
 - Handled potential numeric overflow in Gsym inlined function parser more
   gracefully
 - Moved C API definitions into `blazesym-c` crate

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -257,8 +257,8 @@ pub(crate) fn filter_map_relevant(entry: MapsEntry) -> Option<PathMapsEntry> {
         path_name,
     } = entry;
 
-    // Only entries that are executable (--x-) are of relevance.
-    if (mode & 0b0010) != 0b0010 {
+    // Only readable (r---) or executable (--x-) entries are of relevance.
+    if (mode & 0b1010) == 0 {
         return None
     }
 

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -306,7 +306,7 @@ mod tests {
 7fd5ba059000-7fd5ba1a8000 r-xp 00022000 00:12 2088876                    /lib64/libc.so.6
 7fd5ba1a8000-7fd5ba1fa000 r--p 00171000 00:12 2088876                    /lib64/libc.so.6
 7fd5ba1fa000-7fd5ba1fe000 r--p 001c3000 00:12 2088876                    /lib64/libc.so.6
-7fd5ba1fe000-7fd5ba200000 rw-p 001c7000 00:12 2088876                    /lib64/libc.so.6
+7fd5ba1fe000-7fd5ba200000 -w-p 001c7000 00:12 2088876                    /lib64/libc.so.6
 7fd5ba200000-7fd5ba208000 rw-p 00000000 00:00 0
 7fd5ba214000-7fd5ba216000 rw-p 00000000 00:00 0
 7fd5ba216000-7fd5ba217000 r--p 00000000 00:12 2088889                    /lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
We currently ignore all proc maps entries that are non-executable. That can be a problem once addresses of variables or other data are meant to be symbolized as well.
To remove this potential issue, let's work with both executable OR readable entries.