### PR TITLE
Run codecov in informational mode for all projects

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,9 +5,11 @@ coverage:
         # We don't gate anything based on flaky code coverage reports.
         informational: true
       blazesym:
+        informational: true
         paths:
           - src/
       blazesym-c:
+        informational: true
         paths:
           - capi/src/
       # Note: blazecli is ignored at the llvm-cov level.


### PR DESCRIPTION
Codecov is erring out again when code coverage decreases ever so slightly. The suspicion is that it has to do with the projects that we introduced.
Let's add the necessary property to them as well, in the hope that it helps.