### PR TITLE
cli: Bump version to 0.1.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.1
+-----
 - Fixed process symbolization erring out with wrong input type message
 
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazecli"
 description = "A command line utility for the blazesym library."
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.65"
 default-run = "blazecli"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,5 @@
 [![pipeline](https://github.com/libbpf/blazesym/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/libbpf/blazesym/actions/workflows/test.yml)
+[![crates.io](https://img.shields.io/crates/v/blazecli.svg)](https://crates.io/crates/blazecli)
 [![rustc](https://img.shields.io/badge/rustc-1.65+-blue.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
 
 blazecli


### PR DESCRIPTION
This change bumps blazecli's version to 0.1.1. The following notable changes have been made since 0.1.0:
- Fixed process symbolization erring out with wrong input type message