### PR TITLE
cli: Adjust shell complete cargo command to specify package

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -47,7 +47,7 @@ completion script can be generated via the `shell-complete` utility
 program and then only needs to be sourced to make the current shell
 provide context-sensitive tab completion support. E.g.,
 ```bash
-$ cargo run --bin=shell-complete --features="clap_complete" -- bash > blazecli.bash
+$ cargo run -p blazecli --bin=shell-complete --features="clap_complete" -- bash > blazecli.bash
 $ source blazecli.bash
 ```
 


### PR DESCRIPTION
The README for `blazecli` mentions how to build the `shell-complete` binary, but the command for doing so is relative to the `cli/` sub-directory. That's not the case for other commands higher up in the README. Add the necessary package specification to make this command behave as the others.