### PR TITLE
Replace deprecated actions-rs/toolchain usage

### DIFF
--- a/.github/workflows/publish-capi.yml
+++ b/.github/workflows/publish-capi.yml
@@ -12,12 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Publish
       run: cargo publish --package blazesym-c --token "${CARGO_REGISTRY_TOKEN}"
       env:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -12,12 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Publish
       run: cargo publish --package blazecli --token "${CARGO_REGISTRY_TOKEN}"
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,12 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Dry-run package creation
       run: cargo package --no-verify
     - name: Create git tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,9 @@ jobs:
             args: "--no-default-features"
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.rust }}-${{ matrix.profile }}
@@ -68,11 +66,7 @@ jobs:
        LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        override: true
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - name: Check incremental rebuilds
@@ -91,11 +85,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        override: true
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - name: Install cargo-llvm-cov
@@ -117,11 +107,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        override: true
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Enable debug symbols
       run: |
           # to get the symbolizer for debug symbol resolution
@@ -148,22 +134,16 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - run: cargo test --workspace --release
   test-miri:
     name: Test with Miri
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install Miri
-      run: |
-        rustup toolchain install nightly --component miri
-        rustup override set nightly
-        cargo miri setup
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: miri
     # Miri would honor our custom test runner, but doesn't work with it. We
     # could conceivably override that by specifying
     # CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER, except it appears as if Miri
@@ -178,11 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - run: cargo check --package=blazesym-c --features=generate-c-header
     - name: Check that C header is up-to-date
       run: git diff --exit-code ||
@@ -198,11 +174,7 @@ jobs:
        LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        override: true
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - uses: Swatinem/rust-cache@v2
@@ -224,24 +196,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo clippy --workspace --no-deps --all-targets --features=dont-generate-unit-test-files -- -A unknown_lints -D clippy::todo
   rustfmt:
     name: Check code formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          profile: minimal
           components: rustfmt
-          override: true
       - run: cargo +nightly fmt --all -- --check
   cargo-doc:
     name: Generate documentation
@@ -250,9 +214,5 @@ jobs:
       RUSTDOCFLAGS: '-D warnings'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo doc --workspace --no-deps


### PR DESCRIPTION
The `actions-rs/toolchain` GitHub action is no longer maintained. Switch over to using `dtolnay/rust-toolchain` in its stead.