### PR TITLE
Bump version to `0.2.0-alpha.9`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
-version = "0.2.0-alpha.8"
+version = "0.2.0-alpha.9"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "=0.2.0-alpha.8"
+blazesym = "=0.2.0-alpha.9"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -22,7 +22,7 @@ which = {version = "5.0.0", optional = true}
 
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
-blazesym = {version = "=0.2.0-alpha.8", path = "../"}
+blazesym = {version = "=0.2.0-alpha.9", path = "../"}
 libc = "0.2.137"
 
 [dev-dependencies]

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Bumped `blazesym` dependency to `0.2.0-alpha.9`
+
+
 0.1.1
 -----
 - Fixed process symbolization erring out with wrong input type message

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ grev = "0.1.3"
 
 [dependencies]
 anyhow = "1.0.68"
-blazesym = {version = "=0.2.0-alpha.8", path = "../", features = ["tracing"]}
+blazesym = {version = "=0.2.0-alpha.9", path = "../", features = ["tracing"]}
 clap = {version = "4.1.7", features = ["derive"]}
 clap_complete = {version = "4.1.1", optional = true}
 tracing = "0.1"

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,5 +59,5 @@ refer to the help text (`--help`) of the `shell-complete` program for
 the list of supported shells.
 
 [blazesym]: https://crates.io/crates/blazesym
-[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.8/blazesym/symbolize/struct.Symbolizer.html
-[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.8/blazesym/symbolize/enum.Source.html#variant.Elf
+[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.9/blazesym/symbolize/struct.Symbolizer.html
+[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.9/blazesym/symbolize/enum.Source.html#variant.Elf


### PR DESCRIPTION
This change bumps the version of the crate to `0.2.0-alpha.9`.