### PR TITLE
Query `CARGO_MANIFEST_DIR` variable at runtime

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -470,7 +470,7 @@ fn prepare_bench_files(crate_root: &Path) {
 }
 
 fn main() {
-    let crate_dir = env!("CARGO_MANIFEST_DIR");
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
     if cfg!(feature = "generate-unit-test-files")
         && !cfg!(feature = "dont-generate-unit-test-files")


### PR DESCRIPTION
We should be using the runtime environment variable query mechanism for reading CARGO_MANIFEST_DIR. Switch over.