### PR TITLE
capi: Make libc a dev-dependency

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -23,9 +23,9 @@ which = {version = "5.0.0", optional = true}
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
 blazesym = {version = "=0.2.0-alpha.9", path = "../"}
-libc = "0.2.137"
 
 [dev-dependencies]
 env_logger = "0.10"
+libc = "0.2.137"
 test-log = {version = "0.2.13", default-features = false, features = ["trace"]}
 tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}


### PR DESCRIPTION
The `blazesym-c` crate needs `libc` really only as a dev-dependency. Downgrade it accordingly.