### PR TITLE
Introduce Reason enumeration to accompany `Symbolized::Unknown` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+----------
+- Introduced `symbolize::Reason` enum to provide best guess at
+  why symbolization was not successful as part of the
+  `symbolize::Symbolized::Unknown` variant
+
+
 0.2.0-alpha.9
 -------------
 - Added caching logic for Gsym resolvers to `symbolize::Symbolizer`

--- a/build.rs
+++ b/build.rs
@@ -371,6 +371,7 @@ fn prepare_test_files(crate_root: &Path) {
     let src = crate_root.join("data").join("test-stable-addresses.bin");
     gsym(&src, "test-stable-addresses.gsym");
     dwarf(&src, "test-stable-addresses-dwarf-only.bin");
+    strip(&src, "test-stable-addresses-stripped.bin", &[]);
 
     let src = crate_root.join("data").join("kallsyms.xz");
     let mut dst = src.clone();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -150,7 +150,7 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
                     print_frame(&frame.name, None, &frame.code_info);
                 }
             }
-            symbolize::Symbolized::Unknown => {
+            symbolize::Symbolized::Unknown(..) => {
                 println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
             }
         }

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -88,7 +88,7 @@ fn main() -> Result<()> {
                     print_frame(&frame.name, None, &frame.code_info);
                 }
             }
-            Symbolized::Unknown => {
+            Symbolized::Unknown(..) => {
                 println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
             }
         }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -91,7 +91,7 @@ print its symbol, the file name of the source, and the line number.",
                     print_frame(&frame.name, None, &frame.code_info);
                 }
             }
-            Symbolized::Unknown => {
+            Symbolized::Unknown(..) => {
                 println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
             }
         }

--- a/examples/backtrace.rs
+++ b/examples/backtrace.rs
@@ -89,7 +89,7 @@ fn symbolize_current_bt() {
                     print_frame(&frame.name, None, &frame.code_info);
                 }
             }
-            Symbolized::Unknown => {
+            Symbolized::Unknown(..) => {
                 println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
             }
         }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -10,6 +10,7 @@ use crate::inspect::SymInfo;
 use crate::ksym::KSymResolver;
 use crate::symbolize::AddrCodeInfo;
 use crate::symbolize::IntSym;
+use crate::symbolize::Reason;
 use crate::Addr;
 use crate::Error;
 use crate::Result;
@@ -40,7 +41,7 @@ impl KernelResolver {
 }
 
 impl SymResolver for KernelResolver {
-    fn find_sym(&self, addr: Addr) -> Result<Option<IntSym<'_>>> {
+    fn find_sym(&self, addr: Addr) -> Result<Result<IntSym<'_>, Reason>> {
         if let Some(ksym_resolver) = self.ksym_resolver.as_ref() {
             ksym_resolver.find_sym(addr)
         } else {

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -330,6 +330,7 @@ mod tests {
                 addrs.as_slice().iter().copied(),
                 entries,
                 handler,
+                (),
             )
             .unwrap()
             .normalized;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -4,6 +4,7 @@ use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::symbolize::AddrCodeInfo;
 use crate::symbolize::IntSym;
+use crate::symbolize::Reason;
 use crate::Addr;
 use crate::Result;
 
@@ -17,7 +18,7 @@ where
     Self: Debug,
 {
     /// Find the symbol corresponding to the given address.
-    fn find_sym(&self, addr: Addr) -> Result<Option<IntSym<'_>>>;
+    fn find_sym(&self, addr: Addr) -> Result<Result<IntSym<'_>, Reason>>;
     /// Find information about a symbol given its name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'_>>>;
     /// Finds the source code location for a given address.

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -496,7 +496,7 @@ impl Symbolizer {
                         let () = self.all_symbols.push(symbol);
                         Ok(())
                     }
-                    None => self.handle_unknown_addr(addr),
+                    None => self.handle_unknown_addr(addr, ()),
                 }
             }
 
@@ -521,14 +521,14 @@ impl Symbolizer {
                         let () = self.all_symbols.push(symbol);
                         Ok(())
                     }
-                    None => self.handle_unknown_addr(addr),
+                    None => self.handle_unknown_addr(addr, ()),
                 }
             }
         }
 
-        impl normalize::Handler for SymbolizeHandler<'_> {
+        impl normalize::Handler<()> for SymbolizeHandler<'_> {
             #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("{_addr:#x}"))))]
-            fn handle_unknown_addr(&mut self, _addr: Addr) -> Result<()> {
+            fn handle_unknown_addr(&mut self, _addr: Addr, (): ()) -> Result<()> {
                 let () = self.all_symbols.push(Symbolized::Unknown);
                 Ok(())
             }
@@ -556,7 +556,9 @@ impl Symbolizer {
         let handler = util::with_ordered_elems(
             addrs,
             |handler: &mut SymbolizeHandler<'_>| handler.all_symbols.as_mut_slice(),
-            |sorted_addrs| normalize_sorted_user_addrs_with_entries(sorted_addrs, entries, handler),
+            |sorted_addrs| {
+                normalize_sorted_user_addrs_with_entries(sorted_addrs, entries, handler, ())
+            },
         )?;
         Ok(handler.all_symbols)
     }

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -17,6 +17,8 @@ use blazesym::inspect;
 use blazesym::inspect::Inspector;
 use blazesym::normalize::Normalizer;
 use blazesym::symbolize;
+use blazesym::symbolize::Reason;
+use blazesym::symbolize::Symbolized;
 use blazesym::symbolize::Symbolizer;
 use blazesym::Addr;
 use blazesym::ErrorKind;
@@ -122,6 +124,22 @@ fn symbolize_elf_dwarf_gsym() {
     let data = read_file(&path).unwrap();
     let src = symbolize::Source::from(symbolize::GsymData::new(&data));
     test(src, true);
+}
+
+/// Check that we "fail" symbolization as expected on a stripped ELF
+/// binary.
+#[test]
+fn symbolize_elf_stripped() {
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addresses-stripped.bin");
+    let src = symbolize::Source::Elf(symbolize::Elf::new(path));
+    let symbolizer = Symbolizer::new();
+    let result = symbolizer
+        .symbolize_single(&src, symbolize::Input::VirtOffset(0x2000100))
+        .unwrap();
+
+    assert_eq!(result, Symbolized::Unknown(Reason::MissingSyms));
 }
 
 /// Make sure that we report (enabled) or don't report (disabled) inlined


### PR DESCRIPTION
Many paths can lead to an unsuccessful symbolization, and it may be hard for callers to figure out why symbolization didn't pan out. For example, a user may have provided a stripped binary, without being aware of that fact.

With this change we introduce the symbolize::Reason enumeration, which now accompanies the Symbolized::Unknown variant and aims to provide a best guess as to why symbolization was not successful.
