### PR TITLE
Query CARGO_MANIFEST_DIR at runtime from build scripts

### DIFF
--- a/capi/build.rs
+++ b/capi/build.rs
@@ -107,14 +107,14 @@ fn main() {
         use std::fs::copy;
         use std::fs::write;
 
-        let crate_dir = env!("CARGO_MANIFEST_DIR");
+        let crate_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
 
         cbindgen::Builder::new()
-            .with_crate(crate_dir)
-            .with_config(cbindgen::Config::from_root_or_default(crate_dir))
+            .with_crate(&crate_dir)
+            .with_config(cbindgen::Config::from_root_or_default(&crate_dir))
             .generate()
             .expect("Unable to generate bindings")
-            .write_to_file(Path::new(crate_dir).join("include").join("blazesym.h"));
+            .write_to_file(Path::new(&crate_dir).join("include").join("blazesym.h"));
 
         // Generate a C program that just included blazesym.h as a basic
         // smoke test that cbindgen didn't screw up completely.
@@ -144,7 +144,7 @@ int main() {
                 "-Wextra",
                 "-Werror",
                 "-I",
-                Path::new(crate_dir).join("include").to_str().unwrap(),
+                Path::new(&crate_dir).join("include").to_str().unwrap(),
             ],
         );
 
@@ -161,7 +161,7 @@ int main() {
                         "-Wextra",
                         "-Werror",
                         "-I",
-                        Path::new(crate_dir).join("include").to_str().unwrap(),
+                        Path::new(&crate_dir).join("include").to_str().unwrap(),
                     ],
                 );
             }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,10 +1,12 @@
+use std::env;
+
 use anyhow::Result;
 
 use grev::git_revision_auto;
 
 
 fn main() -> Result<()> {
-    let dir = env!("CARGO_MANIFEST_DIR");
+    let dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     if let Some(git_rev) = git_revision_auto(dir)? {
         println!(
             "cargo:rustc-env=VERSION={} ({})",


### PR DESCRIPTION
As a follow on to 8ca056740fe4 ("Query CARGO_MANIFEST_DIR variable at runtime"), which just provided a quick fix to blazesym proper, this change adjusts the remaining build scripts to query the CARGO_MANIFEST_DIR environment variable at runtime rather than compile time. This is the correct approach as per the reference [0]

[0] https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts