### PR TITLE
Cache artifacts for more CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
+    - uses: Swatinem/rust-cache@v2
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - name: Install cargo-llvm-cov
@@ -108,6 +109,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.sanitizer }}
     - name: Enable debug symbols
       run: |
           # to get the symbolizer for debug symbol resolution
@@ -135,6 +139,7 @@ jobs:
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
     - run: cargo test --workspace --release
   test-miri:
     name: Test with Miri


### PR DESCRIPTION
With this change we use the Swatinem/rust-cache GitHub Action in more of our CI jobs to speed up the workflow even more.