### PR TITLE
Put read_elf_build_id() example code into "Examples" section

### DIFF
--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -135,6 +135,7 @@ impl BuildIdReader for NoBuildIdReader {
 ///
 /// Returns [`None`] if the file does not contain a build ID.
 ///
+/// # Examples
 /// ```
 /// # use std::path::Path;
 /// # let retrieve_path_to_elf_file = || {


### PR DESCRIPTION
Put the example code for the `read_elf_build_id()` function into a dedicated "Examples" section, similarly to how the standard library does things.