### PR TITLE
Hide _non_exhaustive markers from documentation

### DIFF
--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -205,6 +205,7 @@ pub struct CodeInfo<'src> {
     /// code.
     pub column: Option<u16>,
     /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
     pub _non_exhaustive: (),
 }
 
@@ -244,6 +245,7 @@ pub struct InlinedFn<'src> {
     /// Source code location information for the call to the function.
     pub code_info: Option<CodeInfo<'src>>,
     /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
     pub _non_exhaustive: (),
 }
 
@@ -312,6 +314,7 @@ pub struct Sym<'src> {
     /// order `f`, `g`, `h`.
     pub inlined: Box<[InlinedFn<'src>]>,
     /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
     pub _non_exhaustive: (),
 }
 


### PR DESCRIPTION
The _non_exhaustive markers we use in a bunch of public types were never meant to be visible in the documentation. Hide them.