### PR TITLE
Include "runs-on" value in CI matrix cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.rust }}-${{ matrix.profile }}
+        key: ${{ matrix.runs-on }}-${{ matrix.rust }}-${{ matrix.profile }}
     - name: Build ${{ matrix.profile }}
       run: |
         cargo build --profile=${{ matrix.profile }} ${{ matrix.args }} --lib


### PR DESCRIPTION
It doesn't really make sense to restore, say, Linux build artifacts for a MacOS build.
Include the "runs-on" value in the cache key we use for the matrix to make that happening less likely.