### PR TITLE
Reorder `src` argument in inspection APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
   why symbolization was not successful as part of the
   `symbolize::Symbolized::Unknown` variant
 - Reordered `pid` argument to normalization functions before addresses
+- Reordered `src` argument to inspection functions before names
 
 
 0.2.0-alpha.9

--- a/benches/inspect.rs
+++ b/benches/inspect.rs
@@ -18,7 +18,7 @@ fn lookup_elf() {
 
     let inspector = Inspector::new();
     let results = inspector
-        .lookup(black_box(&["abort_creds"]), black_box(&src))
+        .lookup(black_box(&src), black_box(&["abort_creds"]))
         .unwrap()
         .into_iter()
         .flatten()
@@ -39,7 +39,7 @@ fn lookup_dwarf() {
 
     let inspector = Inspector::new();
     let results = inspector
-        .lookup(black_box(&["abort_creds"]), black_box(&src))
+        .lookup(black_box(&src), black_box(&["abort_creds"]))
         .unwrap()
         .into_iter()
         .flatten()

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -263,7 +263,7 @@ pub unsafe extern "C" fn blaze_inspect_syms_elf(
             unsafe { CStr::from_ptr(p) }.to_str().unwrap()
         })
         .collect::<Vec<_>>();
-    let result = inspector.lookup(&names, &src);
+    let result = inspector.lookup(&src, &names);
     match result {
         Ok(syms) => convert_syms_list_to_c(syms),
         Err(_err) => ptr::null(),

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -1120,7 +1120,7 @@ mod tests {
 
         let inspector = inspect::Inspector::new();
         let results = inspector
-            .lookup(&["_RNvCs69hjMPjVIJK_4test13test_function"], &src)
+            .lookup(&src, &["_RNvCs69hjMPjVIJK_4test13test_function"])
             .unwrap()
             .into_iter()
             .flatten()

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -43,8 +43,8 @@ impl Inspector {
     /// - no symbol name demangling is performed currently
     pub fn lookup<'slf>(
         &'slf self,
-        names: &[&str],
         src: &Source,
+        names: &[&str],
     ) -> Result<Vec<Vec<SymInfo<'slf>>>> {
         let opts = FindAddrOpts {
             offset_in_file: true,
@@ -144,7 +144,7 @@ mod tests {
     fn non_present_file() {
         fn test(src: &Source) {
             let inspector = Inspector::new();
-            let err = inspector.lookup(&["factorial"], src).unwrap_err();
+            let err = inspector.lookup(src, &["factorial"]).unwrap_err();
             assert_eq!(err.kind(), ErrorKind::NotFound);
         }
 
@@ -181,10 +181,10 @@ mod tests {
                 .clone()
         };
 
-        let _results = inspector.lookup(&["factorial"], &Source::Elf(elf.clone()));
+        let _results = inspector.lookup(&Source::Elf(elf.clone()), &["factorial"]);
         let data1 = data();
 
-        let _results = inspector.lookup(&["factorial"], &Source::Elf(elf.clone()));
+        let _results = inspector.lookup(&Source::Elf(elf.clone()), &["factorial"]);
         let data2 = data();
         assert!(Rc::ptr_eq(
             data1.dwarf.get().unwrap(),
@@ -195,7 +195,7 @@ mod tests {
         // new resolver.
         elf.debug_syms = false;
 
-        let _results = inspector.lookup(&["factorial"], &Source::Elf(elf.clone()));
+        let _results = inspector.lookup(&Source::Elf(elf.clone()), &["factorial"]);
         let data3 = data();
         assert!(!Rc::ptr_eq(
             data1.dwarf.get().unwrap(),

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -7,7 +7,7 @@
 //! let src = inspect::Source::Elf(inspect::Elf::new("/usr/bin/libc.so"));
 //! let inspector = Inspector::new();
 //! let results = inspector
-//!     .lookup(&["fopen"], &src)
+//!     .lookup(&src, &["fopen"])
 //!     .unwrap();
 //!
 //! // `results` contains a list of addresses of `fopen` symbols in `libc`.

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -294,7 +294,7 @@ fn symbolize_dwarf_demangle() {
 
     let inspector = Inspector::new();
     let results = inspector
-        .lookup(&["_RNvCs69hjMPjVIJK_4test13test_function"], &src)
+        .lookup(&src, &["_RNvCs69hjMPjVIJK_4test13test_function"])
         .unwrap()
         .into_iter()
         .flatten()
@@ -448,7 +448,7 @@ fn inspect() {
     fn test(src: inspect::Source) {
         let inspector = Inspector::new();
         let results = inspector
-            .lookup(&["factorial"], &src)
+            .lookup(&src, &["factorial"])
             .unwrap()
             .into_iter()
             .flatten()
@@ -501,7 +501,7 @@ fn inspect_file_offset_elf() {
 
     let inspector = Inspector::new();
     let results = inspector
-        .lookup(&["dummy"], &src)
+        .lookup(&src, &["dummy"])
         .unwrap()
         .into_iter()
         .flatten()


### PR DESCRIPTION
The symbolization APIs order the source to use as the first actual element, before the list of addresses. For the inspect APIs we diverge -- for no good reason.
This change reorders `src` to be the first argument there as well.