### PR TITLE
capi: Remove `PartialEq` impl for `blaze_symbolize_src_kernel`

### DIFF
--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -64,7 +64,7 @@ impl From<&blaze_symbolize_src_elf> for Elf {
 /// Use a kernel image and a snapshot of its kallsyms as a source of symbols and
 /// debug information.
 #[repr(C)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct blaze_symbolize_src_kernel {
     /// The path of a copy of kallsyms.
     ///


### PR DESCRIPTION
It's unclear why we would have a PartialEq impl for the blaze_symbolize_src_kernel type -- there is really no need for comparing two such objects and comparing the contained pointers for equality is arguably providing the wrong semantics anyway. Remove the impl.