### PR TITLE
Don't require generate-large-test-files for criterion benchmarks

### DIFF
--- a/README-devel.md
+++ b/README-devel.md
@@ -17,7 +17,9 @@ based][libtest] unit-test style ones.
 
 To run the full benchmark suite, use:
 ```sh
-$ cargo bench --features=nightly --features=generate-large-test-files
+# Perform one-time setup of required data.
+$ cargo check --features=generate-large-test-files
+$ cargo bench --features=nightly
 ```
 
 For all Criterion powered benchmarks, a run will automatically establish a new

--- a/benches/inspect.rs
+++ b/benches/inspect.rs
@@ -54,8 +54,6 @@ pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
 where
     M: Measurement,
 {
-    if cfg!(feature = "generate-large-test-files") {
-        bench_fn!(group, lookup_dwarf);
-        bench_fn!(group, lookup_elf);
-    }
+    bench_fn!(group, lookup_dwarf);
+    bench_fn!(group, lookup_elf);
 }

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -161,11 +161,9 @@ where
     M: Measurement,
 {
     bench_fn!(group, symbolize_process);
-    if cfg!(feature = "generate-large-test-files") {
-        bench_fn!(group, symbolize_elf);
-        bench_fn!(group, symbolize_dwarf_no_lines);
-        bench_fn!(group, symbolize_dwarf);
-        bench_fn!(group, symbolize_gsym);
-        bench_sub_fn!(group, symbolize_gsym_multi_no_setup);
-    }
+    bench_fn!(group, symbolize_elf);
+    bench_fn!(group, symbolize_dwarf_no_lines);
+    bench_fn!(group, symbolize_dwarf);
+    bench_fn!(group, symbolize_gsym);
+    bench_sub_fn!(group, symbolize_gsym_multi_no_setup);
 }


### PR DESCRIPTION
Our end-to-end Criterion benchmarks depend on the
generate-large-test-files feature, because we need to have vmlinux-5.17.12-100.fc34.x86_64 kernel image present, which gets "prepared" when this feature is enabled.
At the same time, whenever this feature is switched we download and process a 700 MiB file, which takes a long time and may cause excessive SSD wear. In short, it's just not viable.
When this image is not present benchmarks fail with a pretty clear error message what is missing, so let's just not guard the running of benchmarks with this feature. Unless generated files are deleted, it's only necessary to enable this feature once to prepare files.