### PR TITLE
Enable clippy::absolute_paths lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,4 @@
+# For general information about this file, check
+# https://doc.rust-lang.org/stable/clippy/configuration.html
+
+absolute-paths-allowed-crates = [ "gimli" ]

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -1,3 +1,5 @@
+use crate::util::Pod;
+
 const EI_NIDENT: usize = 16;
 
 type Elf64_Addr = u64;
@@ -29,7 +31,7 @@ pub(crate) struct Elf64_Ehdr {
 }
 
 // SAFETY: `Elf64_Ehdr` is valid for any bit pattern.
-unsafe impl crate::util::Pod for Elf64_Ehdr {}
+unsafe impl Pod for Elf64_Ehdr {}
 
 pub(crate) const PT_LOAD: u32 = 1;
 
@@ -47,7 +49,7 @@ pub(crate) struct Elf64_Phdr {
 }
 
 // SAFETY: `Elf64_Phdr` is valid for any bit pattern.
-unsafe impl crate::util::Pod for Elf64_Phdr {}
+unsafe impl Pod for Elf64_Phdr {}
 
 pub(crate) const PF_X: Elf64_Word = 1;
 
@@ -69,7 +71,7 @@ pub(crate) struct Elf64_Shdr {
 }
 
 // SAFETY: `Elf64_Shdr` is valid for any bit pattern.
-unsafe impl crate::util::Pod for Elf64_Shdr {}
+unsafe impl Pod for Elf64_Shdr {}
 
 pub(crate) const SHN_UNDEF: u16 = 0;
 pub(crate) const SHN_LORESERVE: u16 = 0xff00;
@@ -98,7 +100,7 @@ impl Elf64_Sym {
 }
 
 // SAFETY: `Elf64_Sym` is valid for any bit pattern.
-unsafe impl crate::util::Pod for Elf64_Sym {}
+unsafe impl Pod for Elf64_Sym {}
 
 pub(crate) const NT_GNU_BUILD_ID: Elf64_Word = 3;
 
@@ -111,7 +113,7 @@ pub(crate) struct Elf64_Nhdr {
 }
 
 // SAFETY: `Elf64_Nhdr` is valid for any bit pattern.
-unsafe impl crate::util::Pod for Elf64_Nhdr {}
+unsafe impl Pod for Elf64_Nhdr {}
 
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 #![warn(
     missing_debug_implementations,
     missing_docs,
+    clippy::absolute_paths,
     rustdoc::broken_intra_doc_links
 )]
 #![cfg_attr(feature = "nightly", feature(test))]


### PR DESCRIPTION
In the past we had many submissions that, for one reason or another, were using absolute paths to functions/constants in a very inconsistent manner. It is not particularly great use of anybody's time pointing these out and it's certainly a job that computers can do better. Clippy folks seem to concur that this can be a useful lint [0] and we got blessed with clippy::absolute_paths.
Enable it throughout the crate and fix all violations.

[0] https://github.com/rust-lang/rust-clippy/issues/10568