### PR TITLE
Add GitHub workflow to close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Close stale PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Disable staleness logic for issues.
+          days-before-stale: -1
+          days-before-close: -1
+          # Explicitly enable staleness logic for pull requests.
+          days-before-pr-stale: 30
+          days-before-pr-close: 5
+          stale-pr-message: 'This pull request is considered stale because it has been open 30 days with no activity. Remove stale label or comment or it will be closed in 5 days.'
+          close-pr-message: 'Closing pull request as it is stale.'


### PR DESCRIPTION
This change introduces a GitHub workflow that takes care of automatically closing stale pull requests after a sufficiently long time has elapsed without any action.