### PR TITLE
Let rustfmt take care of wrapping comments

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,5 @@
 blank_lines_upper_bound = 2
 imports_granularity = "item"
 trailing_semicolon = false
+wrap_comments = true
+comment_width = 80

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -485,7 +485,6 @@ const struct blaze_sym_info *const *blaze_inspect_syms_elf(const blaze_inspector
  * # Safety
  *
  * The pointer must be returned by [`blaze_inspect_syms_elf`].
- *
  */
 void blaze_inspect_syms_free(const struct blaze_sym_info *const *syms);
 

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -275,7 +275,6 @@ pub unsafe extern "C" fn blaze_inspect_syms_elf(
 /// # Safety
 ///
 /// The pointer must be returned by [`blaze_inspect_syms_elf`].
-///
 #[no_mangle]
 pub unsafe extern "C" fn blaze_inspect_syms_free(syms: *const *const blaze_sym_info) {
     if syms.is_null() {
@@ -476,7 +475,8 @@ mod tests {
         let () = unsafe { blaze_inspector_free(inspector) };
     }
 
-    /// Make sure that we can lookup a function's address using DWARF information.
+    /// Make sure that we can lookup a function's address using DWARF
+    /// information.
     #[test]
     fn lookup_dwarf() {
         let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -1025,8 +1025,8 @@ mod tests {
         test(symbolize, true);
     }
 
-    /// Symbolize an address inside a DWARF file, with and without auto-demangling
-    /// enabled.
+    /// Symbolize an address inside a DWARF file, with and without
+    /// auto-demangling enabled.
     #[test]
     fn symbolize_dwarf_demangle() {
         fn test(path: &Path, addr: Addr) -> Result<(), ()> {

--- a/src/dwarf/lines.rs
+++ b/src/dwarf/lines.rs
@@ -57,7 +57,8 @@ fn render_file<'dwarf>(
         Path::new("")
     };
 
-    // The directory index 0 is defined to correspond to the compilation unit directory.
+    // The directory index 0 is defined to correspond to the compilation unit
+    // directory.
     let dir = if file.directory_index() != 0 {
         if let Some(directory) = file.directory(header) {
             let d = sections.attr_string(dw_unit, directory)?;

--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -93,8 +93,8 @@ impl<'dwarf> Unit<'dwarf> {
         &self,
         sections: &gimli::Dwarf<R<'dwarf>>,
     ) -> Result<Option<&Lines<'dwarf>>, gimli::Error> {
-        // NB: line information is always stored in the main debug file so this does not need
-        // to handle DWOs.
+        // NB: line information is always stored in the main debug file so this does not
+        // need to handle DWOs.
         let ilnp = match self.dw_unit.line_program {
             Some(ref ilnp) => ilnp,
             None => return Ok(None),

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -82,7 +82,8 @@ impl<'dwarf> Units<'dwarf> {
                 None => continue,
             };
             // We mainly want compile units, but we may need to follow references to entries
-            // within other units for function names.  We don't need anything from type units.
+            // within other units for function names.  We don't need anything from type
+            // units.
             match header.type_() {
                 gimli::UnitType::Type { .. } | gimli::UnitType::SplitType { .. } => continue,
                 _ => {}
@@ -142,8 +143,8 @@ impl<'dwarf> Units<'dwarf> {
                 // - DW_AT_low_pc/DW_AT_high_pc
                 //
                 // Using DW_AT_ranges before .debug_aranges is possibly an arbitrary choice,
-                // but the feeling is that DW_AT_ranges is more likely to be reliable or complete
-                // if it is present.
+                // but the feeling is that DW_AT_ranges is more likely to be reliable or
+                // complete if it is present.
                 //
                 // .debug_aranges must be used before DW_AT_low_pc/DW_AT_high_pc because
                 // it has been observed on macOS that DW_AT_ranges was not emitted even for
@@ -245,8 +246,8 @@ impl<'dwarf> Units<'dwarf> {
 
     /// Finds the CUs covering the range of addresses given.
     ///
-    /// The range is [low, high) (ie, the upper bound is exclusive). This can return multiple
-    /// ranges for the same unit.
+    /// The range is [low, high) (ie, the upper bound is exclusive). This can
+    /// return multiple ranges for the same unit.
     #[inline]
     fn find_units_range(
         &self,
@@ -359,7 +360,8 @@ impl<'dwarf> Units<'dwarf> {
         Ok(None)
     }
 
-    /// Find the source file and line corresponding to the given virtual memory address.
+    /// Find the source file and line corresponding to the given virtual memory
+    /// address.
     pub fn find_location(&self, probe: u64) -> Result<Option<Location<'_>>, gimli::Error> {
         for unit in self.find_units(probe) {
             if let Some(location) = unit.find_location(probe, &self.dwarf)? {

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -107,7 +107,8 @@ struct Cache<'mmap> {
     symtab: OnceCell<Box<[&'mmap Elf64_Sym]>>, // in address order
     /// The cached ELF string table.
     strtab: OnceCell<&'mmap [u8]>,
-    str2symtab: OnceCell<Box<[(&'mmap str, usize)]>>, // strtab offset to symtab in the dictionary order
+    str2symtab: OnceCell<Box<[(&'mmap str, usize)]>>, /* strtab offset to symtab in the
+                                                       * dictionary order */
 }
 
 impl<'mmap> Cache<'mmap> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -370,10 +370,9 @@ pub enum ErrorKind {
 /// semantics, but in short:
 /// - If you want panics and errors to both have backtraces, set
 ///   `RUST_BACKTRACE=1`
-/// - If you want only errors to have backtraces, set
-///   `RUST_LIB_BACKTRACE=1`
-/// - If you want only panics to have backtraces, set `RUST_BACKTRACE=1`
-///   and `RUST_LIB_BACKTRACE=0`
+/// - If you want only errors to have backtraces, set `RUST_LIB_BACKTRACE=1`
+/// - If you want only panics to have backtraces, set `RUST_BACKTRACE=1` and
+///   `RUST_LIB_BACKTRACE=0`
 // Representation is optimized for fast copying (a single machine word),
 // not so much for fast creation (as it is heap allocated). We generally
 // expect errors to be exceptional, though a lot of functionality is

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -38,11 +38,11 @@ pub struct LineTableHeader {
 impl LineTableHeader {
     /// Parse [`AddrData`] of type [`INFO_TYPE_LINE_TABLE_INFO`].
     ///
-    /// An `AddrData` of `INFO_TYPE_LINE_TABLE_INFO` type is a table of line numbers
-    /// for a symbol. `AddrData` is the payload of `AddrInfo`. One `AddrInfo`
-    /// may have several `AddrData` entries in its payload. Each `AddrData`
-    /// entry stores a type of data related to the symbol the `AddrInfo`
-    /// presents.
+    /// An `AddrData` of `INFO_TYPE_LINE_TABLE_INFO` type is a table of line
+    /// numbers for a symbol. `AddrData` is the payload of `AddrInfo`. One
+    /// `AddrInfo` may have several `AddrData` entries in its payload. Each
+    /// `AddrData` entry stores a type of data related to the symbol the
+    /// `AddrInfo` presents.
     ///
     /// # Arguments
     ///
@@ -76,7 +76,8 @@ impl LineTableRow {
     ///
     /// # Arguments
     ///
-    /// * `header` - is a [`LineTableHeader`] returned by [`parse_line_table_header()`].
+    /// * `header` - is a [`LineTableHeader`] returned by
+    ///   [`parse_line_table_header()`].
     /// * `symaddr` - the address of the symbol that `header` belongs to.
     pub fn from_header(header: &LineTableHeader, symaddr: Addr) -> Self {
         Self {
@@ -93,11 +94,11 @@ impl LineTableRow {
 /// # Arguments
 ///
 /// * `row` - a line table row to present the current states of the virtual
-///           machine. [`LineTableRow::from_header`] can create a `LineTableRow`
-///           to keep the states of a virtual machine.
+///   machine. [`LineTableRow::from_header`] can create a `LineTableRow` to keep
+///   the states of a virtual machine.
 /// * `header` - is a `LineTableHeader`.
 /// * `ops` - is the buffer of the operators following the `LineTableHeader` in
-///           a GSYM file.
+///   a GSYM file.
 pub fn run_op(
     row: &mut LineTableRow,
     header: &LineTableHeader,

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -81,7 +81,8 @@ impl GsymContext<'_> {
     ///
     /// * `data` - is the content of a standalone GSYM.
     ///
-    /// Returns a GsymContext, which includes the Header and other important tables.
+    /// Returns a GsymContext, which includes the Header and other important
+    /// tables.
     pub fn parse_header(data: &[u8]) -> Result<GsymContext> {
         fn parse_header_impl(mut data: &[u8]) -> Option<Result<GsymContext>> {
             let head = data;
@@ -140,8 +141,8 @@ impl GsymContext<'_> {
             .ok_or_invalid_data(|| "GSYM data does not contain sufficient bytes")?
     }
 
-    /// Find the index of an entry in the address table potentially containing the
-    /// given address.
+    /// Find the index of an entry in the address table potentially containing
+    /// the given address.
     ///
     /// Callers should check the `AddrInfo` object at the returned index to see
     /// whether the symbol actually covers the provided address.

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -364,7 +364,8 @@ mod tests {
         assert_eq!(resolver.file_name, None);
     }
 
-    /// Make sure that we can find file line information for a function, if available.
+    /// Make sure that we can find file line information for a function, if
+    /// available.
     #[test]
     fn find_line_info() {
         let test_gsym = Path::new(&env!("CARGO_MANIFEST_DIR"))

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -84,10 +84,9 @@ impl Inspector {
     ///
     /// # Notes
     /// - no symbol name demangling is performed currently
-    /// - currently only function symbols (as opposed to variables) are
-    ///   reported
-    /// - undefined symbols (such as ones referencing a different shared
-    ///   object) are not reported
+    /// - currently only function symbols (as opposed to variables) are reported
+    /// - undefined symbols (such as ones referencing a different shared object)
+    ///   are not reported
     /// - for the [`Elf`](Source::Elf) source, at present DWARF symbols are
     ///   ignored (irrespective of the [`debug_syms`][Elf::debug_syms]
     ///   configuration)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 //! **blazesym** is a library that can be used to symbolize addresses. Address
-//! symbolization is a common problem in tracing contexts, for example, where users
-//! want to reason about functions by name, but low level components report only the
-//! "raw" addresses (e.g., in the form of stacktraces).
+//! symbolization is a common problem in tracing contexts, for example, where
+//! users want to reason about functions by name, but low level components
+//! report only the "raw" addresses (e.g., in the form of stacktraces).
 //!
-//! In addition to symbolization, **blazesym** also provides APIs for the reverse
-//! operation: looking up addresses from symbol names. That can be useful, for
-//! example, for configuring breakpoints or tracepoints.
+//! In addition to symbolization, **blazesym** also provides APIs for the
+//! reverse operation: looking up addresses from symbol names. That can be
+//! useful, for example, for configuring breakpoints or tracepoints.
 //!
 //! ## Overview
 //! The crate is organized via public modules that expose functionality

--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -42,7 +42,8 @@ fn read_build_id_from_notes(parser: &ElfParser) -> Result<Option<Vec<u8>>> {
     Ok(None)
 }
 
-/// Attempt to read an ELF binary's build ID from the .note.gnu.build-id section.
+/// Attempt to read an ELF binary's build ID from the .note.gnu.build-id
+/// section.
 fn read_build_id_from_section_name(parser: &ElfParser) -> Result<Option<Vec<u8>>> {
     let build_id_section = ".note.gnu.build-id";
     // The build ID is contained in the `.note.gnu.build-id` section. See
@@ -179,7 +180,8 @@ mod tests {
     use test_log::test;
 
 
-    /// Check that we can read a binary's build ID based on the ELF section name as well as ELF section type.
+    /// Check that we can read a binary's build ID based on the ELF section name
+    /// as well as ELF section type.
     #[test]
     fn build_id_reading_from_name_and_notes() {
         fn test(f: fn(&ElfParser) -> Result<Option<Vec<u8>>>) {

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -23,7 +23,8 @@ pub struct Output<M> {
     ///
     /// A file offset is one as it would appear in a binary or debug symbol
     /// file, i.e., one excluding any relocations. The data reported here can be
-    /// used with the [`symbolize::Input::FileOffset`][crate::symbolize::Input::FileOffset]
+    /// used with the
+    /// [`symbolize::Input::FileOffset`][crate::symbolize::Input::FileOffset]
     /// variant.
     pub outputs: Vec<(u64, usize)>,
     /// Meta information about the normalized outputs.

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -250,8 +250,8 @@ where
 /// normalized), could have a few reasons, including, but not limited
 /// to:
 /// - user error (if a bogus address was provided)
-/// - they belonged to an ELF object that has been unmapped since the
-///   address was captured
+/// - they belonged to an ELF object that has been unmapped since the address
+///   was captured
 ///
 /// The process' ID should be provided in `pid`.
 ///

--- a/src/once.rs
+++ b/src/once.rs
@@ -9,10 +9,10 @@ use std::hint::unreachable_unchecked;
 
 /// A cell which can be written to only once.
 ///
-/// This allows obtaining a shared `&T` reference to its inner value without copying or replacing
-/// it (unlike [`Cell`]), and without runtime borrow checks (unlike [`RefCell`]). However,
-/// only immutable references can be obtained unless one has a mutable reference to the cell
-/// itself.
+/// This allows obtaining a shared `&T` reference to its inner value without
+/// copying or replacing it (unlike [`Cell`]), and without runtime borrow checks
+/// (unlike [`RefCell`]). However, only immutable references can be obtained
+/// unless one has a mutable reference to the cell itself.
 ///
 /// For a thread-safe version of this struct, see [`std::sync::OnceLock`].
 ///
@@ -117,8 +117,8 @@ impl<T> OnceCell<T> {
         if let Some(val) = self.get() {
             return Ok(val)
         }
-        /// Avoid inlining the initialization closure into the common path that fetches
-        /// the already initialized value
+        /// Avoid inlining the initialization closure into the common path that
+        /// fetches the already initialized value
         #[cold]
         fn outlined_call<F, T, E>(f: F) -> Result<T, E>
         where
@@ -190,5 +190,6 @@ impl<T> From<T> for OnceCell<T> {
     }
 }
 
-// Just like for `Cell<T>` this isn't needed, but results in nicer error messages.
+// Just like for `Cell<T>` this isn't needed, but results in nicer error
+// messages.
 //impl<T> !Sync for OnceCell<T> {}

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -84,8 +84,8 @@ struct CdFileHeader {
     disk: u16,
     internal_attributes: u16,
     external_attributes: u32,
-    /// Offset from the start of the disk containing the local file header to the
-    /// start of the local file header.
+    /// Offset from the start of the disk containing the local file header to
+    /// the start of the local file header.
     offset: u32,
 }
 
@@ -118,7 +118,8 @@ unsafe impl Pod for LocalFileHeader {}
 /// Carries information on path, compression method, and data corresponding to a
 /// file in a zip archive.
 pub struct Entry<'archive> {
-    /// Compression method as defined in pkzip spec. 0 means data is uncompressed.
+    /// Compression method as defined in pkzip spec. 0 means data is
+    /// uncompressed.
     pub compression: u16,
     /// The path to the file inside the archive.
     pub path: &'archive Path,


### PR DESCRIPTION
It turns out `rustfmt` can ensure a consistent comment length by applying automatic wrapping. Let's enable the functionality to get some more consistency into the code base and ensure that pull requests adhere to a basic standard in the process.