### PR TITLE
Introduce 'apk' and 'gsym' features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,14 @@ jobs:
             # unification may mean that `--no-default-features` goes
             # without effect.
             args: "--no-default-features"
+          - runs-on: ubuntu-latest
+            rust: stable
+            profile: dev
+            args: "--no-default-features --features=apk"
+          - runs-on: ubuntu-latest
+            rust: stable
+            profile: dev
+            args: "--no-default-features --features=gsym"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
@@ -216,8 +224,8 @@ jobs:
     name: Generate documentation
     runs-on: ubuntu-latest
     env:
-      RUSTDOCFLAGS: '-D warnings'
+      RUSTDOCFLAGS: '--cfg docsrs -D warnings'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
       - run: cargo doc --workspace --no-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 - Introduced `symbolize::Reason` enum to provide best guess at
   why symbolization was not successful as part of the
   `symbolize::Symbolized::Unknown` variant
+- Introduced `apk` and `gsym` compile-time features
 - Reordered `pid` argument to normalization functions before addresses
 - Reordered `src` argument to inspection functions before names
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,15 +35,30 @@ autobenches = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["backtrace", "demangle", "dwarf"]
+default = [
+  "apk",
+  "backtrace",
+  "demangle",
+  "dwarf",
+  "gsym",
+]
+# Enable this feature to enable APK support (mostly relevant for
+# Android).
+apk = []
 # Enable this feature to compile in support for capturing backtraces in errors.
 # Note that by default backtraces will not be collected unless opted in with
 # environment variables.
 backtrace = []
-# Enable this feature to enable DWARF support.
-dwarf = ["gimli"]
 # Enable this feature to get transparent symbol demangling.
 demangle = ["cpp_demangle", "rustc-demangle"]
+# Enable this feature to enable DWARF support.
+dwarf = ["gimli"]
+# Enable this feature to enable Gsym support.
+gsym = []
+
+# Below here are dev-mostly features that should not be needed by
+# regular users.
+
 # Enable this feature to opt in to the generation of unit test files.
 # Having these test files created is necessary for running tests.
 generate-unit-test-files = ["xz2", "zip"]
@@ -92,3 +107,8 @@ libc = "0.2.137"
 reqwest = {version = "0.11.18", optional = true, features = ["blocking"]}
 xz2 = {version = "0.1.7", optional = true}
 zip = {version = "0.6.4", optional = true, default-features = false}
+
+# https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,0 +1,19 @@
+macro_rules! cfg_apk {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "apk")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "apk")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_gsym {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "gsym")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "gsym")))]
+            $item
+        )*
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,18 +34,25 @@
     clippy::absolute_paths,
     rustdoc::broken_intra_doc_links
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "nightly", feature(test))]
-#![cfg_attr(not(feature = "dwarf"), allow(dead_code))]
+#![cfg_attr(
+    not(all(feature = "apk", feature = "dwarf", feature = "gsym")),
+    allow(dead_code, unused_imports)
+)]
 
 
 #[cfg(feature = "nightly")]
 extern crate test;
 
+#[macro_use]
+mod cfg;
 #[cfg(feature = "dwarf")]
 mod dwarf;
 mod elf;
 mod error;
 mod file_cache;
+#[cfg(feature = "gsym")]
 mod gsym;
 mod insert_map;
 pub mod inspect;
@@ -58,6 +65,7 @@ mod once;
 mod resolver;
 pub mod symbolize;
 mod util;
+#[cfg(feature = "apk")]
 mod zip;
 
 use std::fmt::Display;

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -158,7 +158,6 @@ mod tests {
     use crate::normalize::UserMeta;
     use crate::symbolize;
     use crate::symbolize::Symbolizer;
-    use crate::zip;
 
 
     /// Check that we detect unsorted input addresses.
@@ -287,8 +286,11 @@ mod tests {
 
     /// Check that we can normalize addresses in our own shared object inside a
     /// zip archive.
+    #[cfg(feature = "apk")]
     #[test]
     fn normalize_custom_so_in_zip() {
+        use crate::zip;
+
         fn test(so_name: &str) {
             let test_zip = Path::new(&env!("CARGO_MANIFEST_DIR"))
                 .join("data")

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -106,10 +106,14 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::path::Path;
 
+#[cfg(feature = "apk")]
 pub use source::Apk;
 pub use source::Elf;
+#[cfg(feature = "gsym")]
 pub use source::Gsym;
+#[cfg(feature = "gsym")]
 pub use source::GsymData;
+#[cfg(feature = "gsym")]
 pub use source::GsymFile;
 pub use source::Kernel;
 pub use source::Process;


### PR DESCRIPTION
Not every user will have a use for symbolization of addresses in APK files or for Gsym support. While conceptually these features should not have much of an impact on the library's footprint (neither in terms of compile time, number of dependencies, runtime performance, nor code size), there is still an argument to be made that users should not pay for something they don't use -- it feels wrong to include support for Gsym symbolization if it is clear that this feature will simply never be used.
To that end, this change introduces compile time features that guard the availability of APK and Gsym support. We also make sure to highlight which functionality is enabled by which feature in the generated documentation by usage of the doc_cfg rustdoc functionality (and enable it for generation on docs.rs).