### PR TITLE
Fix a few minor issues

### DIFF
--- a/data/test-exe.c
+++ b/data/test-exe.c
@@ -1,7 +1,3 @@
-/*
- * The sample program is used to generate test.bin.
- */
-
 #include <stdio.h>
 
 static

--- a/data/test-so.c
+++ b/data/test-so.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 #include <stdio.h>
 #include <time.h>
 

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -476,7 +476,7 @@ mod tests {
             let loc = units.find_location(addr).unwrap().unwrap();
             assert_ne!(loc.dir, Path::new(""));
             assert_eq!(loc.file, OsStr::new("test-exe.c"));
-            assert_eq!(loc.line.unwrap(), 8);
+            assert_eq!(loc.line.unwrap(), 4);
 
             assert!(funcs.next().is_none());
         }

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -360,7 +360,7 @@ fn symbolize_process() {
 }
 
 /// Check that we can symbolize an address in a process using a binary
-/// located in a local mount namespace accessible binary.
+/// located in a local mount namespace.
 #[test]
 fn symbolize_process_in_mount_namespace() {
     let test_so = Path::new(&env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
- remove unnecessary `errno.h` include
- fix comment for recently added symbolize_process_in_mount_namespace test
- remove outdated header comment from test-exe.c