### PR TITLE
capi: Use our "Input" terminology in C API

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,0 +1,3 @@
+Unreleased
+----------
+- Renamed various symbolization functions to closer reflect Rust terminology

--- a/capi/README.md
+++ b/capi/README.md
@@ -4,6 +4,8 @@
 blazesym-c
 ==========
 
+- [Changelog](CHANGELOG.md)
+
 **blazesym-c** provides C language bindings for the [**blazesym**][blazesym]
 library.
 

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -608,10 +608,10 @@ blaze_symbolizer *blaze_symbolizer_new_opts(const struct blaze_symbolizer_opts *
 void blaze_symbolizer_free(blaze_symbolizer *symbolizer);
 
 /**
- * Symbolize a list of process virtual addresses.
+ * Symbolize a list of process absolute addresses.
  *
- * Return an array of [`blaze_result`] with the same size as the
- * number of input addresses. The caller should free the returned array by
+ * Return an array of [`blaze_result`] with the same size as the number
+ * of input addresses. The caller should free the returned array by
  * calling [`blaze_result_free`].
  *
  * # Safety
@@ -620,16 +620,16 @@ void blaze_symbolizer_free(blaze_symbolizer *symbolizer);
  * [`blaze_symbolize_src_process`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
-const struct blaze_result *blaze_symbolize_process_virt_addrs(blaze_symbolizer *symbolizer,
-                                                              const struct blaze_symbolize_src_process *src,
-                                                              const uintptr_t *addrs,
-                                                              size_t addr_cnt);
+const struct blaze_result *blaze_symbolize_process_abs_addrs(blaze_symbolizer *symbolizer,
+                                                             const struct blaze_symbolize_src_process *src,
+                                                             const uintptr_t *abs_addrs,
+                                                             size_t abs_addr_cnt);
 
 /**
- * Symbolize a list of kernel virtual addresses.
+ * Symbolize a list of kernel absolute addresses.
  *
- * Return an array of [`blaze_result`] with the same size as the
- * number of input addresses. The caller should free the returned array by
+ * Return an array of [`blaze_result`] with the same size as the number
+ * of input addresses. The caller should free the returned array by
  * calling [`blaze_result_free`].
  *
  * # Safety
@@ -638,16 +638,16 @@ const struct blaze_result *blaze_symbolize_process_virt_addrs(blaze_symbolizer *
  * [`blaze_symbolize_src_kernel`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
-const struct blaze_result *blaze_symbolize_kernel_virt_addrs(blaze_symbolizer *symbolizer,
-                                                             const struct blaze_symbolize_src_kernel *src,
-                                                             const uintptr_t *addrs,
-                                                             size_t addr_cnt);
+const struct blaze_result *blaze_symbolize_kernel_abs_addrs(blaze_symbolizer *symbolizer,
+                                                            const struct blaze_symbolize_src_kernel *src,
+                                                            const uintptr_t *abs_addrs,
+                                                            size_t abs_addr_cnt);
 
 /**
- * Symbolize file addresses in an ELF file.
+ * Symbolize virtual offsets in an ELF file.
  *
- * Return an array of [`blaze_result`] with the same size as the
- * number of input addresses. The caller should free the returned array by
+ * Return an array of [`blaze_result`] with the same size as the number
+ * of input addresses. The caller should free the returned array by
  * calling [`blaze_result_free`].
  *
  * # Safety
@@ -656,13 +656,13 @@ const struct blaze_result *blaze_symbolize_kernel_virt_addrs(blaze_symbolizer *s
  * [`blaze_symbolize_src_elf`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
-const struct blaze_result *blaze_symbolize_elf_file_addrs(blaze_symbolizer *symbolizer,
-                                                          const struct blaze_symbolize_src_elf *src,
-                                                          const uintptr_t *addrs,
-                                                          size_t addr_cnt);
+const struct blaze_result *blaze_symbolize_elf_virt_offsets(blaze_symbolizer *symbolizer,
+                                                            const struct blaze_symbolize_src_elf *src,
+                                                            const uintptr_t *virt_offsets,
+                                                            size_t virt_offset_cnt);
 
 /**
- * Symbolize file addresses using "raw" Gsym data.
+ * Symbolize virtual offsets using "raw" Gsym data.
  *
  * Return an array of [`blaze_result`] with the same size as the
  * number of input addresses. The caller should free the returned array by
@@ -674,16 +674,16 @@ const struct blaze_result *blaze_symbolize_elf_file_addrs(blaze_symbolizer *symb
  * [`blaze_symbolize_src_gsym_data`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
-const struct blaze_result *blaze_symbolize_gsym_data_file_addrs(blaze_symbolizer *symbolizer,
-                                                                const struct blaze_symbolize_src_gsym_data *src,
-                                                                const uintptr_t *addrs,
-                                                                size_t addr_cnt);
+const struct blaze_result *blaze_symbolize_gsym_data_virt_offsets(blaze_symbolizer *symbolizer,
+                                                                  const struct blaze_symbolize_src_gsym_data *src,
+                                                                  const uintptr_t *virt_offsets,
+                                                                  size_t virt_offset_cnt);
 
 /**
- * Symbolize file addresses in a Gsym file.
+ * Symbolize virtual offsets in a Gsym file.
  *
- * Return an array of [`blaze_result`] with the same size as the
- * number of input addresses. The caller should free the returned array by
+ * Return an array of [`blaze_result`] with the same size as the number
+ * of input addresses. The caller should free the returned array by
  * calling [`blaze_result_free`].
  *
  * # Safety
@@ -692,10 +692,10 @@ const struct blaze_result *blaze_symbolize_gsym_data_file_addrs(blaze_symbolizer
  * [`blaze_symbolize_src_gsym_file`] object. `addrs` must represent an array of
  * `addr_cnt` objects.
  */
-const struct blaze_result *blaze_symbolize_gsym_file_file_addrs(blaze_symbolizer *symbolizer,
-                                                                const struct blaze_symbolize_src_gsym_file *src,
-                                                                const uintptr_t *addrs,
-                                                                size_t addr_cnt);
+const struct blaze_result *blaze_symbolize_gsym_file_virt_offsets(blaze_symbolizer *symbolizer,
+                                                                  const struct blaze_symbolize_src_gsym_file *src,
+                                                                  const uintptr_t *virt_offsets,
+                                                                  size_t virt_offset_cnt);
 
 /**
  * Free an array returned by any of the `blaze_symbolize_*` variants.

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -518,10 +518,10 @@ unsafe fn blaze_symbolize_impl(
 }
 
 
-/// Symbolize a list of process virtual addresses.
+/// Symbolize a list of process absolute addresses.
 ///
-/// Return an array of [`blaze_result`] with the same size as the
-/// number of input addresses. The caller should free the returned array by
+/// Return an array of [`blaze_result`] with the same size as the number
+/// of input addresses. The caller should free the returned array by
 /// calling [`blaze_result_free`].
 ///
 /// # Safety
@@ -530,22 +530,22 @@ unsafe fn blaze_symbolize_impl(
 /// [`blaze_symbolize_src_process`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
-pub unsafe extern "C" fn blaze_symbolize_process_virt_addrs(
+pub unsafe extern "C" fn blaze_symbolize_process_abs_addrs(
     symbolizer: *mut blaze_symbolizer,
     src: *const blaze_symbolize_src_process,
-    addrs: *const Addr,
-    addr_cnt: usize,
+    abs_addrs: *const Addr,
+    abs_addr_cnt: usize,
 ) -> *const blaze_result {
     // SAFETY: The caller ensures that the pointer is valid.
     let src = Source::from(Process::from(unsafe { &*src }));
-    unsafe { blaze_symbolize_impl(symbolizer, src, Input::AbsAddr(addrs), addr_cnt) }
+    unsafe { blaze_symbolize_impl(symbolizer, src, Input::AbsAddr(abs_addrs), abs_addr_cnt) }
 }
 
 
-/// Symbolize a list of kernel virtual addresses.
+/// Symbolize a list of kernel absolute addresses.
 ///
-/// Return an array of [`blaze_result`] with the same size as the
-/// number of input addresses. The caller should free the returned array by
+/// Return an array of [`blaze_result`] with the same size as the number
+/// of input addresses. The caller should free the returned array by
 /// calling [`blaze_result_free`].
 ///
 /// # Safety
@@ -554,22 +554,22 @@ pub unsafe extern "C" fn blaze_symbolize_process_virt_addrs(
 /// [`blaze_symbolize_src_kernel`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
-pub unsafe extern "C" fn blaze_symbolize_kernel_virt_addrs(
+pub unsafe extern "C" fn blaze_symbolize_kernel_abs_addrs(
     symbolizer: *mut blaze_symbolizer,
     src: *const blaze_symbolize_src_kernel,
-    addrs: *const Addr,
-    addr_cnt: usize,
+    abs_addrs: *const Addr,
+    abs_addr_cnt: usize,
 ) -> *const blaze_result {
     // SAFETY: The caller ensures that the pointer is valid.
     let src = Source::from(Kernel::from(unsafe { &*src }));
-    unsafe { blaze_symbolize_impl(symbolizer, src, Input::AbsAddr(addrs), addr_cnt) }
+    unsafe { blaze_symbolize_impl(symbolizer, src, Input::AbsAddr(abs_addrs), abs_addr_cnt) }
 }
 
 
-/// Symbolize file addresses in an ELF file.
+/// Symbolize virtual offsets in an ELF file.
 ///
-/// Return an array of [`blaze_result`] with the same size as the
-/// number of input addresses. The caller should free the returned array by
+/// Return an array of [`blaze_result`] with the same size as the number
+/// of input addresses. The caller should free the returned array by
 /// calling [`blaze_result_free`].
 ///
 /// # Safety
@@ -578,19 +578,26 @@ pub unsafe extern "C" fn blaze_symbolize_kernel_virt_addrs(
 /// [`blaze_symbolize_src_elf`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
-pub unsafe extern "C" fn blaze_symbolize_elf_file_addrs(
+pub unsafe extern "C" fn blaze_symbolize_elf_virt_offsets(
     symbolizer: *mut blaze_symbolizer,
     src: *const blaze_symbolize_src_elf,
-    addrs: *const Addr,
-    addr_cnt: usize,
+    virt_offsets: *const Addr,
+    virt_offset_cnt: usize,
 ) -> *const blaze_result {
     // SAFETY: The caller ensures that the pointer is valid.
     let src = Source::from(Elf::from(unsafe { &*src }));
-    unsafe { blaze_symbolize_impl(symbolizer, src, Input::VirtOffset(addrs), addr_cnt) }
+    unsafe {
+        blaze_symbolize_impl(
+            symbolizer,
+            src,
+            Input::VirtOffset(virt_offsets),
+            virt_offset_cnt,
+        )
+    }
 }
 
 
-/// Symbolize file addresses using "raw" Gsym data.
+/// Symbolize virtual offsets using "raw" Gsym data.
 ///
 /// Return an array of [`blaze_result`] with the same size as the
 /// number of input addresses. The caller should free the returned array by
@@ -602,24 +609,31 @@ pub unsafe extern "C" fn blaze_symbolize_elf_file_addrs(
 /// [`blaze_symbolize_src_gsym_data`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
-pub unsafe extern "C" fn blaze_symbolize_gsym_data_file_addrs(
+pub unsafe extern "C" fn blaze_symbolize_gsym_data_virt_offsets(
     symbolizer: *mut blaze_symbolizer,
     src: *const blaze_symbolize_src_gsym_data,
-    addrs: *const Addr,
-    addr_cnt: usize,
+    virt_offsets: *const Addr,
+    virt_offset_cnt: usize,
 ) -> *const blaze_result {
     // SAFETY: The caller ensures that the pointer is valid. The `GsymData`
     //         lifetime is entirely conjured up, but the object only needs to be
     //         valid for the call.
     let src = Source::from(GsymData::from(unsafe { &*src }));
-    unsafe { blaze_symbolize_impl(symbolizer, src, Input::VirtOffset(addrs), addr_cnt) }
+    unsafe {
+        blaze_symbolize_impl(
+            symbolizer,
+            src,
+            Input::VirtOffset(virt_offsets),
+            virt_offset_cnt,
+        )
+    }
 }
 
 
-/// Symbolize file addresses in a Gsym file.
+/// Symbolize virtual offsets in a Gsym file.
 ///
-/// Return an array of [`blaze_result`] with the same size as the
-/// number of input addresses. The caller should free the returned array by
+/// Return an array of [`blaze_result`] with the same size as the number
+/// of input addresses. The caller should free the returned array by
 /// calling [`blaze_result_free`].
 ///
 /// # Safety
@@ -628,15 +642,22 @@ pub unsafe extern "C" fn blaze_symbolize_gsym_data_file_addrs(
 /// [`blaze_symbolize_src_gsym_file`] object. `addrs` must represent an array of
 /// `addr_cnt` objects.
 #[no_mangle]
-pub unsafe extern "C" fn blaze_symbolize_gsym_file_file_addrs(
+pub unsafe extern "C" fn blaze_symbolize_gsym_file_virt_offsets(
     symbolizer: *mut blaze_symbolizer,
     src: *const blaze_symbolize_src_gsym_file,
-    addrs: *const Addr,
-    addr_cnt: usize,
+    virt_offsets: *const Addr,
+    virt_offset_cnt: usize,
 ) -> *const blaze_result {
     // SAFETY: The caller ensures that the pointer is valid.
     let src = Source::from(GsymFile::from(unsafe { &*src }));
-    unsafe { blaze_symbolize_impl(symbolizer, src, Input::VirtOffset(addrs), addr_cnt) }
+    unsafe {
+        blaze_symbolize_impl(
+            symbolizer,
+            src,
+            Input::VirtOffset(virt_offsets),
+            virt_offset_cnt,
+        )
+    }
 }
 
 
@@ -979,7 +1000,7 @@ mod tests {
             debug_syms: true,
         };
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
-            blaze_symbolize_elf_file_addrs(symbolizer, &elf_src, addrs, addr_cnt)
+            blaze_symbolize_elf_virt_offsets(symbolizer, &elf_src, addrs, addr_cnt)
         };
         test(symbolize, false);
 
@@ -993,7 +1014,7 @@ mod tests {
             debug_syms: true,
         };
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
-            blaze_symbolize_elf_file_addrs(symbolizer, &elf_src, addrs, addr_cnt)
+            blaze_symbolize_elf_virt_offsets(symbolizer, &elf_src, addrs, addr_cnt)
         };
         test(symbolize, true);
 
@@ -1006,7 +1027,7 @@ mod tests {
             path: path_c.as_ptr(),
         };
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
-            blaze_symbolize_gsym_file_file_addrs(symbolizer, &gsym_src, addrs, addr_cnt)
+            blaze_symbolize_gsym_file_virt_offsets(symbolizer, &gsym_src, addrs, addr_cnt)
         };
         test(symbolize, true);
 
@@ -1020,7 +1041,7 @@ mod tests {
             data_len: data.len(),
         };
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
-            blaze_symbolize_gsym_data_file_addrs(symbolizer, &gsym_src, addrs, addr_cnt)
+            blaze_symbolize_gsym_data_virt_offsets(symbolizer, &gsym_src, addrs, addr_cnt)
         };
         test(symbolize, true);
     }
@@ -1044,7 +1065,7 @@ mod tests {
             let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };
             let addrs = [addr];
             let result = unsafe {
-                blaze_symbolize_elf_file_addrs(symbolizer, &elf_src, addrs.as_ptr(), addrs.len())
+                blaze_symbolize_elf_virt_offsets(symbolizer, &elf_src, addrs.as_ptr(), addrs.len())
             };
             assert!(!result.is_null());
 
@@ -1086,7 +1107,7 @@ mod tests {
             let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };
             let addrs = [addr];
             let result = unsafe {
-                blaze_symbolize_elf_file_addrs(symbolizer, &elf_src, addrs.as_ptr(), addrs.len())
+                blaze_symbolize_elf_virt_offsets(symbolizer, &elf_src, addrs.as_ptr(), addrs.len())
             };
             assert!(!result.is_null());
 
@@ -1158,12 +1179,7 @@ mod tests {
         let symbolizer = blaze_symbolizer_new();
         let addrs = [blaze_symbolizer_new as Addr];
         let result = unsafe {
-            blaze_symbolize_process_virt_addrs(
-                symbolizer,
-                &process_src,
-                addrs.as_ptr(),
-                addrs.len(),
-            )
+            blaze_symbolize_process_abs_addrs(symbolizer, &process_src, addrs.as_ptr(), addrs.len())
         };
 
         assert!(!result.is_null());


### PR DESCRIPTION
There is a divergence between the terminology we use for the Input enum in Rust code and the suffixes we added to the symbolization functions in the C API.
This change unifies the two to minimize the potential for confusion.