### PR TITLE
Disable 'apk' and 'gsym' features by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Unreleased
 - Introduced `symbolize::Reason` enum to provide best guess at
   why symbolization was not successful as part of the
   `symbolize::Symbolized::Unknown` variant
-- Introduced `apk` and `gsym` compile-time features
+- Introduced `apk` and `gsym` compile-time features (disabled by default)
 - Improved handling of dynamic ELF symbols for symbolization and
   inspection
 - Reordered `pid` argument to normalization functions before addresses

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,9 @@ autobenches = false
 
 [features]
 default = [
-  "apk",
   "backtrace",
   "demangle",
   "dwarf",
-  "gsym",
 ]
 # Enable this feature to enable APK support (mostly relevant for
 # Android).
@@ -95,7 +93,7 @@ tracing = {version = "0.1", default-features = false, features = ["attributes"],
 # APIs.
 addr2line = "=0.21.0"
 anyhow = "1.0.71"
-blazesym = {path = ".", features = ["generate-unit-test-files", "tracing"]}
+blazesym = {path = ".", features = ["generate-unit-test-files", "apk", "gsym", "tracing"]}
 criterion = {version = "0.5.1", default-features = false, features = ["rayon", "cargo_bench_support"]}
 env_logger = "0.10"
 scopeguard = "1.2"

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -22,7 +22,7 @@ which = {version = "5.0.0", optional = true}
 
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
-blazesym = {version = "=0.2.0-alpha.9", path = "../"}
+blazesym = {version = "=0.2.0-alpha.9", path = "../", features = ["apk", "demangle", "dwarf", "gsym"]}
 
 [dev-dependencies]
 env_logger = "0.10"


### PR DESCRIPTION
With this change we disable the recently introduced 'apk' and 'gsym' features by default. We anticipate both to be comparably fringe features (one making only sense on an Android system and the other requiring development effort [in the sense that special APIs have to be used] in order to use) and so it makes more sense to have them be opt-in. For the blazesym-c crate, we enable both features by default, because we do not anticipate the C library to have this kind of configurability -- there will only be a single version of it.