### PR TITLE
Set desired features for docs.rs documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,5 +109,6 @@ zip = {version = "0.6.4", optional = true, default-features = false}
 
 # https://docs.rs/about/metadata
 [package.metadata.docs.rs]
+features = ["apk", "backtrace", "demangle", "dwarf", "gsym"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Now that we have more non-default features, make sure to tell docs.rs what features to generate the documentation with, or it will lack crucial information.