### PR TITLE
Move ErrorExt impl for gimli::Error into dwarf module

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -578,26 +578,6 @@ impl ErrorExt for io::Error {
     }
 }
 
-#[cfg(feature = "dwarf")]
-impl ErrorExt for gimli::Error {
-    type Output = Error;
-
-    fn context<C>(self, context: C) -> Self::Output
-    where
-        C: IntoCowStr,
-    {
-        Error::from(self).context(context)
-    }
-
-    fn with_context<C, F>(self, f: F) -> Self::Output
-    where
-        C: IntoCowStr,
-        F: FnOnce() -> C,
-    {
-        Error::from(self).with_context(f)
-    }
-}
-
 
 /// A trait providing conversion shortcuts for creating `Error`
 /// instances.

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -34,10 +34,12 @@ use super::types::INFO_TYPE_LINE_TABLE_INFO;
 use crate::log::warn;
 
 
+#[allow(dead_code)]
 enum Data<'dat> {
     Mmap(Mmap),
     Slice(&'dat [u8]),
 }
+
 
 /// The symbol resolver for the GSYM format.
 pub struct GsymResolver<'dat> {


### PR DESCRIPTION
It arguably makes more sense to co-locate the `ErrorExt` impl for each error type that we support with the functionality that is using this error type, as opposed to it being located in a central location, as that leads to less conditional compilation directives being spread throughout the code base.
To that end, this change moves the `ErrorExt` impl for `gimli::Error` into the dwarf module.