### PR TITLE
Introduce proper minimum supported Rust version CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, macos-latest]
-        rust: [1.65.0, stable]
+        rust: [stable]
         profile: [dev, release]
         args: ["--workspace"]
         include:
@@ -67,6 +67,20 @@ jobs:
           target: ${{ matrix.target }}
       - run: |
           cargo build --lib
+  build-minimum:
+    name: Build using minimum versions of dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo +nightly -Z minimal-versions update
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # Please adjust README and rust-version field in Cargo.toml files when
+          # bumping version.
+          toolchain: 1.65.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --features="apk,backtrace,demangle,dwarf,gsym,tracing"
   nop-rebuilds:
     name: No-op rebuilds
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,8 @@ codegen-units = 1
 cpp_demangle = {version = "0.4", optional = true}
 gimli = {version = "0.28", optional = true}
 libc = "0.2.137"
-rustc-demangle = {version = "0.1", optional = true}
-tracing = {version = "0.1", default-features = false, features = ["attributes"], optional = true}
+rustc-demangle = {version = "0.1.4", optional = true}
+tracing = {version = "0.1.27", default-features = false, features = ["attributes"], optional = true}
 
 [dev-dependencies]
 # For performance comparison; pinned, because we use #[doc(hidden)]


### PR DESCRIPTION
So far we have captured the need for building with our minimum supported Rust version (MSRV) by just building the library. Because we do not check in a Cargo.lock file, that means that the most recent versions of dependencies are being pulled in. Recently this backfired, because transitive dependencies started to have a higher minimum supported Rust version than we do.
This change fixes this issue by introducing a proper CI job for checking the MSRV and making sure to explicitly downgrade all dependencies to their minimum versions as part of it.