### PR TITLE
Build blazecli and blazesym-c in isolation in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,15 +28,23 @@ jobs:
             # Make sure to build *without* `--workspace` or feature
             # unification may mean that `--no-default-features` goes
             # without effect.
-            args: "--no-default-features"
+            args: "--lib --no-default-features"
           - runs-on: ubuntu-latest
             rust: stable
             profile: dev
-            args: "--no-default-features --features=apk"
+            args: "--lib --no-default-features --features=apk"
           - runs-on: ubuntu-latest
             rust: stable
             profile: dev
-            args: "--no-default-features --features=gsym"
+            args: "--lib --no-default-features --features=gsym"
+          - runs-on: ubuntu-latest
+            rust: stable
+            profile: dev
+            args: "--package=blazecli"
+          - runs-on: ubuntu-latest
+            rust: stable
+            profile: dev
+            args: "--package=blazesym-c"
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
@@ -47,7 +55,7 @@ jobs:
         key: ${{ matrix.runs-on }}-${{ matrix.rust }}-${{ matrix.profile }}
     - name: Build ${{ matrix.profile }}
       run: |
-        cargo build --profile=${{ matrix.profile }} ${{ matrix.args }} --lib
+        cargo build --profile=${{ matrix.profile }} ${{ matrix.args }}
   build-cross:
     name: Cross-compile [${{ matrix.target }}]
     runs-on: ubuntu-latest

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ grev = "0.1.3"
 
 [dependencies]
 anyhow = "1.0.68"
-blazesym = {version = "=0.2.0-alpha.9", path = "../", features = ["tracing"]}
+blazesym = {version = "=0.2.0-alpha.9", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "tracing"]}
 clap = {version = "4.1.7", features = ["derive"]}
 clap_complete = {version = "4.1.1", optional = true}
 tracing = "0.1"


### PR DESCRIPTION
Be sure to build blazecli and blazesym-c in isolation, to prevent any feature unification from messing up the result. Fix the blazecli build, which broke because the program does not enable the gsym feature of blazesym.