### PR TITLE
Fix Gsym symbolization issue for "large" addresses

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -156,7 +156,8 @@ where
 /// This functionality is useful for cases where we compare elements with a
 /// size, such as ranges, and an address to search for can be covered by a range
 /// whose start is before the item to search for.
-pub(crate) fn find_match_or_lower_bound<T>(slice: &[T], item: T) -> Option<usize>
+#[cfg(test)]
+fn find_match_or_lower_bound<T>(slice: &[T], item: T) -> Option<usize>
 where
     T: Copy + Ord,
 {


### PR DESCRIPTION
Gsym encodes addresses inside its address table using the smallest integer that can capture all addresses used in it. Our code assumed that the address to search for can also be expressed as such an integer, but that is not necessarily the case, even for perfectly valid addresses: if the last symbol in the address table ends at a boundary that exceeds the type used to express the start address, then our Gsym will currently fail symbolization, as the conversion of the provided address into said integer type will not succeed.
This change fixes this issue by, instead of downcasting the input addresses for the binary search to happen, we upcast the addresses in the address table to our Addr type.