### PR TITLE
Pull in git version of criterion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Test and gather coverage
-      run: cargo llvm-cov --workspace --all-targets --features=nightly,generate-large-test-files --ignore-filename-regex=cli/src/ --lcov --output-path lcov.info
+      run: cargo llvm-cov --workspace --all-targets --features=nightly,generate-large-test-files --ignore-filename-regex=cli/src/ --lcov --output-path lcov.info -- --include-ignored
     - name: Upload code coverage results
       uses: codecov/codecov-action@v3
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,8 @@ tracing = {version = "0.1.27", default-features = false, features = ["attributes
 addr2line = "=0.21.0"
 anyhow = "1.0.71"
 blazesym = {path = ".", features = ["generate-unit-test-files", "apk", "breakpad", "gsym", "tracing"]}
-criterion = {version = "0.5.1", default-features = false, features = ["rayon", "cargo_bench_support"]}
+# TODO: Use 0.5.2 once released.
+criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}
 env_logger = "0.10"
 scopeguard = "1.2"
 tempfile = "3.4"


### PR DESCRIPTION
The fine folks over at criterion have decided to be play unresponsive to any asks for new releases. Pull in a git snapshot of the library that includes:
- daa84cafe706e731139c768f7c67cc5577041309 ("Include thousands-separators in `bencher` output (#705)")
- 928d8a96dfd755dc14eb0f4821c196a9ec73cc9f ("Enable `--help` messages and accept `--include-ignored` as no-op (#703)")

to get what we need.