### PR TITLE
Make inspect::SymType enum non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
   by default)
 - Added support for usage of perf map files as part of process symbolization
   - Added `perf_map` attribute to `symbolize::Process` type
+- Made `inspect::SymType` enum non-exhaustive
 
 
 0.2.0-alpha.10

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -108,6 +108,7 @@ impl From<SymType> for blaze_sym_type {
             SymType::Unknown => blaze_sym_type::BLAZE_SYM_UNKNOWN,
             SymType::Function => blaze_sym_type::BLAZE_SYM_FUNC,
             SymType::Variable => blaze_sym_type::BLAZE_SYM_VAR,
+            _ => unreachable!(),
         }
     }
 }
@@ -196,11 +197,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
                     name: name_ptr,
                     addr,
                     size,
-                    sym_type: match sym_type {
-                        SymType::Function => blaze_sym_type::BLAZE_SYM_FUNC,
-                        SymType::Variable => blaze_sym_type::BLAZE_SYM_VAR,
-                        SymType::Unknown => blaze_sym_type::BLAZE_SYM_UNKNOWN,
-                    },
+                    sym_type: sym_type.into(),
                     file_offset: file_offset.unwrap_or(0),
                     obj_file_name,
                 }

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -30,6 +30,7 @@ pub use source::Source;
 
 /// The type of a symbol.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum SymType {
     /// The symbol type is unknown.
     #[default]


### PR DESCRIPTION
We want to leave open the options of adding additional variants to the inspect::SymType enum down the line without breaking backwards compatibility.
Mark the type as non-exhaustive to make sure that this is a possibility.