### PR TITLE
Make tests assume necessary features to be present

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -245,7 +245,6 @@ mod tests {
 
     use std::path::Path;
 
-    #[cfg(feature = "dwarf")]
     use crate::dwarf::DwarfResolver;
 
 
@@ -263,15 +262,12 @@ mod tests {
         assert!(dbg.starts_with("ELF"), "{dbg}");
         assert!(dbg.ends_with("test-stable-addresses.bin"), "{dbg}");
 
-        #[cfg(feature = "dwarf")]
-        {
-            let dwarf = DwarfResolver::from_parser(parser, true).unwrap();
-            let backend = ElfBackend::Dwarf(Rc::new(dwarf));
-            let resolver = ElfResolver::with_backend(&path, backend).unwrap();
-            let dbg = format!("{resolver:?}");
-            assert!(dbg.starts_with("DWARF"), "{dbg}");
-            assert!(dbg.ends_with("test-stable-addresses.bin"), "{dbg}");
-        }
+        let dwarf = DwarfResolver::from_parser(parser, true).unwrap();
+        let backend = ElfBackend::Dwarf(Rc::new(dwarf));
+        let resolver = ElfResolver::with_backend(&path, backend).unwrap();
+        let dbg = format!("{resolver:?}");
+        assert!(dbg.starts_with("DWARF"), "{dbg}");
+        assert!(dbg.ends_with("test-stable-addresses.bin"), "{dbg}");
     }
 
     /// Check that we fail finding an offset for an address not

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -286,7 +286,6 @@ mod tests {
 
     /// Check that we can normalize addresses in our own shared object inside a
     /// zip archive.
-    #[cfg(feature = "apk")]
     #[test]
     fn normalize_custom_so_in_zip() {
         use crate::zip;

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -452,7 +452,6 @@ mod tests {
 
     /// Exercise the `Debug` representation of various types.
     #[test]
-    #[cfg(all(feature = "apk", feature = "breakpad", feature = "gsym"))]
     fn debug_repr() {
         let apk = Apk::new("/a-path/with/components.apk");
         assert_eq!(format!("{apk:?}"), "Apk(\"/a-path/with/components.apk\")");

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1185,7 +1185,6 @@ mod tests {
     }
 
     /// Check that we can create a path to an ELF inside an APK as expected.
-    #[cfg(feature = "apk")]
     #[test]
     fn elf_apk_path_creation() {
         let apk = Path::new("/root/test.apk");
@@ -1213,10 +1212,6 @@ mod tests {
     /// Make sure that we can demangle symbols.
     #[test]
     fn demangle() {
-        if !cfg!(feature = "demangle") {
-            return
-        }
-
         let symbol = Cow::Borrowed("_ZN4core9panicking9panic_fmt17h5f1a6fd39197ad62E");
         let name = maybe_demangle(symbol, SrcLang::Rust);
         assert_eq!(name, "core::panicking::panic_fmt");
@@ -1302,7 +1297,6 @@ mod tests {
     }
 
     /// Check that we can symbolize an address residing in a zip archive.
-    #[cfg(feature = "apk")]
     #[test]
     fn symbolize_zip() {
         use crate::zip;


### PR DESCRIPTION
We do not intend to run tests with recently introduced optional features (apk, dwarf, gsym, ...) disabled. Our recursive dev-dependency "ensures" that they are, in fact, enabled.
Remove the unnecessary complexity introduced by making certain tests conditional on said features.