### PR TITLE
Publish the C api crate a library

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.65"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "lib"]
 
 [features]
 # Enable this feature to re-generate the library's C header file. An


### PR DESCRIPTION
# Motivation

Enabling the blazesym-c crate as a library ensures that we can compose the blazesym library with other rust libraries that would publish C bindings.
