### PR TITLE
capi: Add blaze_normalizer_new_opts() constructor

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added `blaze_normalizer_new_opts` function and `blaze_normalizer_opts` type
 - Renamed various symbolization functions to closer reflect Rust
   terminology
 - Renamed `BLAZE_SYM_UNKNOWN` enum variant to `BLAZE_SYM_UNDEFINED`

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -105,6 +105,17 @@ typedef struct blaze_inspect_elf_src {
 typedef struct blaze_normalizer blaze_normalizer;
 
 /**
+ * Options for configuring [`blaze_normalizer`] objects.
+ */
+typedef struct blaze_normalizer_opts {
+  /**
+   * Whether to read and report build IDs as part of the normalization
+   * process.
+   */
+  bool build_ids;
+} blaze_normalizer_opts;
+
+/**
  * C compatible version of [`Apk`].
  */
 typedef struct blaze_user_meta_apk {
@@ -224,7 +235,7 @@ typedef struct blaze_normalized_user_output {
 typedef struct blaze_symbolizer blaze_symbolizer;
 
 /**
- * Options for configuring `blaze_symbolizer` objects.
+ * Options for configuring [`blaze_symbolizer`] objects.
  */
 typedef struct blaze_symbolizer_opts {
   /**
@@ -519,10 +530,22 @@ void blaze_inspector_free(blaze_inspector *inspector);
 /**
  * Create an instance of a blazesym normalizer.
  *
- * The returned pointer should be released using
- * [`blaze_normalizer_free`] once it is no longer needed.
+ * The returned pointer should be released using [`blaze_normalizer_free`] once
+ * it is no longer needed.
  */
 blaze_normalizer *blaze_normalizer_new(void);
+
+/**
+ * Create an instance of a blazesym normalizer.
+ *
+ * The returned pointer should be released using [`blaze_normalizer_free`] once
+ * it is no longer needed.
+ *
+ * # Safety
+ * The provided pointer needs to point to a valid [`blaze_normalizer_opts`]
+ * instance.
+ */
+blaze_normalizer *blaze_normalizer_new_opts(const struct blaze_normalizer_opts *opts);
 
 /**
  * Free a blazesym normalizer.

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -281,7 +281,7 @@ pub(crate) unsafe fn from_cstr(cstr: *const c_char) -> PathBuf {
 }
 
 
-/// Options for configuring `blaze_symbolizer` objects.
+/// Options for configuring [`blaze_symbolizer`] objects.
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_symbolizer_opts {

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -37,8 +37,8 @@ pub struct Output<M> {
 /// By default all features are enabled.
 #[derive(Clone, Debug)]
 pub struct Builder {
-    /// Whether to read and report build IDs as part of the
-    /// normalization process.
+    /// Whether to read and report build IDs as part of the normalization
+    /// process.
     build_ids: bool,
 }
 

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -650,7 +650,7 @@ fn normalize_elf_addr() {
 
 /// Check that we can enable/disable the reading of build IDs.
 #[test]
-fn normalize_build_id_rading() {
+fn normalize_build_id_reading() {
     fn test(read_build_ids: bool) {
         let test_so = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")


### PR DESCRIPTION
This change adds the blaze_normalizer_new_opts() constructor for blaze_normalizer objects to the C API. Using it users can control the availability of build IDs as part of the normalization output.