### PR TITLE
capi: Rename BLAZE_SYM_UNDEFINED to BLAZE_SYM_UNDEF

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -3,5 +3,5 @@ Unreleased
 - Added `blaze_normalizer_new_opts` function and `blaze_normalizer_opts` type
 - Renamed various symbolization functions to closer reflect Rust
   terminology
-- Renamed `BLAZE_SYM_UNKNOWN` enum variant to `BLAZE_SYM_UNDEFINED`
+- Renamed `BLAZE_SYM_UNKNOWN` enum variant to `BLAZE_SYM_UNDEF`
 - Added `perf_map` member to `blaze_symbolize_src_process` function

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -18,7 +18,7 @@ typedef enum blaze_sym_type {
    * other variants (functions and variables), whereas in output
    * contexts it means that the type is not known.
    */
-  BLAZE_SYM_UNDEFINED,
+  BLAZE_SYM_UNDEF,
   /**
    * The symbol is a function.
    */

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -98,7 +98,7 @@ pub enum blaze_sym_type {
     /// In input contexts this variant can be used to encompass all
     /// other variants (functions and variables), whereas in output
     /// contexts it means that the type is not known.
-    BLAZE_SYM_UNDEFINED,
+    BLAZE_SYM_UNDEF,
     /// The symbol is a function.
     BLAZE_SYM_FUNC,
     /// The symbol is a variable.
@@ -108,7 +108,7 @@ pub enum blaze_sym_type {
 impl From<SymType> for blaze_sym_type {
     fn from(other: SymType) -> Self {
         match other {
-            SymType::Undefined => blaze_sym_type::BLAZE_SYM_UNDEFINED,
+            SymType::Undefined => blaze_sym_type::BLAZE_SYM_UNDEF,
             SymType::Function => blaze_sym_type::BLAZE_SYM_FUNC,
             SymType::Variable => blaze_sym_type::BLAZE_SYM_VAR,
             _ => unreachable!(),
@@ -212,7 +212,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
                 name: ptr::null(),
                 addr: 0,
                 size: 0,
-                sym_type: blaze_sym_type::BLAZE_SYM_UNDEFINED,
+                sym_type: blaze_sym_type::BLAZE_SYM_UNDEF,
                 file_offset: 0,
                 obj_file_name: ptr::null(),
             }


### PR DESCRIPTION
Given our abbreviated names `BLAZE_SYM_FUNC` and `BLAZE_SYM_VAR`, it makes sense to shorten `BLAZE_SYM_UNDEFINED` to `BLAZE_SYM_UNDEF`. Rename the variant accordingly.