### PR TITLE
Test nop rebuilds of entire workspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,13 +104,15 @@ jobs:
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - name: Check incremental rebuilds
+      env:
+        CARGO_OPTS: --features=generate-unit-test-files --workspace --quiet --tests
       run: |
-        cargo check --features=generate-unit-test-files --quiet --tests
+        cargo check ${CARGO_OPTS}
         # We need another build here to have the reference `output` file
         # present. As long as we converge eventually it's probably good
         # enough...
-        cargo check --features=generate-unit-test-files --quiet --tests
-        output=$(CARGO_LOG=cargo::core::compiler::fingerprint=info cargo check --features=generate-unit-test-files --quiet --tests 2>&1)
+        cargo check ${CARGO_OPTS}
+        output=$(CARGO_LOG=cargo::core::compiler::fingerprint=info cargo check ${CARGO_OPTS} 2>&1)
         [ -z "${output}" ] || (echo "!!!! cargo check --tests rebuild was not a no-op: ${output} !!!!" && false)
   test-coverage:
     name: Test and coverage


### PR DESCRIPTION
With an upcoming change we will add more conditional build logic to build scripts that has the potential for screwing with rebuilds. To preempt any screw ups from the start, make sure that our nop-rebuilds job checks the entire workspace.