### PR TITLE
capi: Add object sizes to input types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,7 @@ jobs:
     - name: Remove .cargo/config
       run: rm .cargo/config
     - name: Run tests
-      run: cargo miri test --features=dont-generate-unit-test-files -- "insert_map::" "util::"
+      run: cargo miri test --features=dont-generate-unit-test-files -- "insert_map::" "util::" "::elf_src_validity"
   c-header:
     name: Check generated C header
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,9 @@ jobs:
        LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2024-02-04
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - name: Check incremental rebuilds
@@ -121,7 +123,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2024-02-04
     - uses: Swatinem/rust-cache@v2
     - uses: actions/setup-python@v5
       id: py312
@@ -152,7 +156,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2024-02-04
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.sanitizer }}
@@ -193,8 +199,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
       with:
+        toolchain: nightly-2024-02-04
         components: miri
     # Miri would honor our custom test runner, but doesn't work with it. We
     # could conceivably override that by specifying
@@ -226,7 +233,9 @@ jobs:
        LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2024-02-04
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - uses: Swatinem/rust-cache@v2

--- a/capi/.gitignore
+++ b/capi/.gitignore
@@ -1,0 +1,1 @@
+/examples/*.o

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased
 ----------
-- Added `blaze_normalizer_new_opts` function and `blaze_normalizer_opts` type
+- Added constructs for forward & backward compatibility:
+  - Added `type_size` member to input types and `BLAZE_INPUT` macro for
+    initialization
+- Added `blaze_normalizer_new_opts` function and `blaze_normalizer_opts`
+  type
 - Renamed various symbolization functions to closer reflect Rust
   terminology
 - Renamed `BLAZE_SYM_UNKNOWN` enum variant to `BLAZE_SYM_UNDEF`

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
   - Added `type_size` member to input types and `BLAZE_INPUT` macro for
     initialization
   - Reserved trailing padding bytes to ensure zero initialization
+  - Reserved space for future extension in output types
 - Added `blaze_normalizer_new_opts` function and `blaze_normalizer_opts`
   type
 - Renamed various symbolization functions to closer reflect Rust

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 - Added constructs for forward & backward compatibility:
   - Added `type_size` member to input types and `BLAZE_INPUT` macro for
     initialization
+  - Reserved trailing padding bytes to ensure zero initialization
 - Added `blaze_normalizer_new_opts` function and `blaze_normalizer_opts`
   type
 - Renamed various symbolization functions to closer reflect Rust

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -25,6 +25,7 @@ which = {version = "6.0.0", optional = true}
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
 blazesym = {version = "=0.2.0-alpha.10", path = "../", features = ["apk", "demangle", "dwarf", "gsym"]}
+memoffset = "0.9"
 
 [dev-dependencies]
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -10,6 +10,8 @@ rust-version = "1.65"
 crate-type = ["cdylib", "staticlib", "lib"]
 
 [features]
+# Check C code documentation snippets.
+check-doc-snippets = []
 # Enable this feature to re-generate the library's C header file. An
 # up-to-date version of this header should already be available in the
 # include/ directory, so this feature is only necessary when APIs are
@@ -25,6 +27,7 @@ which = {version = "6.0.0", optional = true}
 blazesym = {version = "=0.2.0-alpha.10", path = "../", features = ["apk", "demangle", "dwarf", "gsym"]}
 
 [dev-dependencies]
+blazesym-c = {path = ".", features = ["check-doc-snippets"]}
 env_logger = "0.10"
 libc = "0.2.137"
 test-log = {version = "0.2.13", default-features = false, features = ["trace"]}

--- a/capi/cbindgen.toml
+++ b/capi/cbindgen.toml
@@ -4,6 +4,19 @@ language = "C"
 cpp_compat = true
 include_guard = "__blazesym_h_"
 usize_is_size_t = true
+after_includes = """\
+/* Helper macro to declare and initialize a blazesym input struct.
+ *
+ * Inspired by `LIBBPF_OPTS` macro provided by libbpf.
+ */
+#define BLAZE_INPUT(TYPE, NAME, ...)        \\
+  struct TYPE NAME = ({                     \\
+    (struct TYPE) {                         \\
+      .type_size = sizeof(struct TYPE),     \\
+      __VA_ARGS__                           \\
+    };                                      \\
+  })
+"""
 
 [export]
 item_types = ["globals", "enums", "structs", "unions", "typedefs", "opaque", "functions"]

--- a/capi/examples/input-struct-init.c
+++ b/capi/examples/input-struct-init.c
@@ -1,0 +1,9 @@
+#include <string.h>
+#include "blazesym.h"
+
+int main(int argc, const char* argv[]) {
+  BLAZE_INPUT(blaze_inspect_elf_src, src,
+    .path = "/tmp/some/dir/test.bin",
+    .debug_syms = true,
+  );
+}

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -116,6 +116,11 @@ typedef struct blaze_inspect_elf_src {
    * (if present).
    */
   bool debug_syms;
+  /**
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
+   */
+  uint8_t reserved[7];
 } blaze_inspect_elf_src;
 
 /**
@@ -139,6 +144,11 @@ typedef struct blaze_normalizer_opts {
    * process.
    */
   bool build_ids;
+  /**
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
+   */
+  uint8_t reserved[7];
 } blaze_normalizer_opts;
 
 /**
@@ -289,6 +299,11 @@ typedef struct blaze_symbolizer_opts {
    * the underlying language does not mangle symbols (such as C).
    */
   bool demangle;
+  /**
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
+   */
+  uint8_t reserved[5];
 } blaze_symbolizer_opts;
 
 /**
@@ -431,6 +446,11 @@ typedef struct blaze_symbolize_src_process {
    * procedure.
    */
   bool perf_map;
+  /**
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
+   */
+  uint8_t reserved[2];
 } blaze_symbolize_src_process;
 
 /**
@@ -470,6 +490,11 @@ typedef struct blaze_symbolize_src_kernel {
    * to satisfy the request (if present).
    */
   bool debug_syms;
+  /**
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
+   */
+  uint8_t reserved[7];
 } blaze_symbolize_src_kernel;
 
 /**
@@ -500,6 +525,11 @@ typedef struct blaze_symbolize_src_elf {
    * (if present).
    */
   bool debug_syms;
+  /**
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
+   */
+  uint8_t reserved[7];
 } blaze_symbolize_src_elf;
 
 /**

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -22,7 +22,11 @@
 /**
  * The type of a symbol.
  */
-typedef enum blaze_sym_type {
+enum blaze_sym_type
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
   /**
    * The symbol type is unspecified or unknown.
    *
@@ -39,7 +43,10 @@ typedef enum blaze_sym_type {
    * The symbol is a variable.
    */
   BLAZE_SYM_VAR,
-} blaze_sym_type;
+};
+#ifndef __cplusplus
+typedef uint8_t blaze_sym_type;
+#endif // __cplusplus
 
 /**
  * The valid variant kind in [`blaze_user_meta`].
@@ -86,7 +93,11 @@ typedef struct blaze_sym_info {
   /**
    * See [`inspect::SymInfo::sym_type`].
    */
-  enum blaze_sym_type sym_type;
+  blaze_sym_type sym_type;
+  /**
+   * Unused member available for future expansion.
+   */
+  uint8_t reserved[15];
 } blaze_sym_info;
 
 /**
@@ -160,6 +171,10 @@ typedef struct blaze_user_meta_apk {
    * This member is always present.
    */
   char *path;
+  /**
+   * Unused member available for future expansion.
+   */
+  uint8_t reserved[8];
 } blaze_user_meta_apk;
 
 /**
@@ -178,6 +193,10 @@ typedef struct blaze_user_meta_elf {
    * The optional build ID of the ELF file, if found.
    */
   uint8_t *build_id;
+  /**
+   * Unused member available for future expansion.
+   */
+  uint8_t reserved[8];
 } blaze_user_meta_elf;
 
 /**
@@ -185,9 +204,9 @@ typedef struct blaze_user_meta_elf {
  */
 typedef struct blaze_user_meta_unknown {
   /**
-   * This member is unused.
+   * Unused member available for future expansion.
    */
-  uint8_t _unused;
+  uint8_t reserved[8];
 } blaze_user_meta_unknown;
 
 /**
@@ -260,6 +279,10 @@ typedef struct blaze_normalized_user_output {
    * An array of `output_cnt` objects.
    */
   struct blaze_normalized_output *outputs;
+  /**
+   * Unused member available for future expansion.
+   */
+  uint8_t reserved[8];
 } blaze_normalized_user_output;
 
 /**
@@ -332,6 +355,10 @@ typedef struct blaze_symbolize_code_info {
    * code.
    */
   uint16_t column;
+  /**
+   * Unused member available for future expansion.
+   */
+  uint8_t reserved[10];
 } blaze_symbolize_code_info;
 
 /**
@@ -346,6 +373,10 @@ typedef struct blaze_symbolize_inlined_fn {
    * Source code location information for the inlined function.
    */
   struct blaze_symbolize_code_info code_info;
+  /**
+   * Unused member available for future expansion.
+   */
+  uint8_t reserved[8];
 } blaze_symbolize_inlined_fn;
 
 /**
@@ -393,6 +424,10 @@ typedef struct blaze_sym {
    * An array of `inlined_cnt` symbolized inlined function calls.
    */
   const struct blaze_symbolize_inlined_fn *inlined;
+  /**
+   * Unused member available for future expansion.
+   */
+  uint8_t reserved[8];
 } blaze_sym;
 
 /**

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -6,6 +6,18 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+/* Helper macro to declare and initialize a blazesym input struct.
+ *
+ * Inspired by `LIBBPF_OPTS` macro provided by libbpf.
+ */
+#define BLAZE_INPUT(TYPE, NAME, ...)        \
+  struct TYPE NAME = ({                     \
+    (struct TYPE) {                         \
+      .type_size = sizeof(struct TYPE),     \
+      __VA_ARGS__                           \
+    };                                      \
+  })
+
 
 /**
  * The type of a symbol.
@@ -89,6 +101,13 @@ typedef struct blaze_inspector blaze_inspector;
  */
 typedef struct blaze_inspect_elf_src {
   /**
+   * The size of this object's type.
+   *
+   * Make sure to initialize it to `sizeof(<type>)`. This member is used to
+   * ensure compatibility in the presence of member additions.
+   */
+  size_t type_size;
+  /**
    * The path to the ELF file. This member is always present.
    */
   const char *path;
@@ -108,6 +127,13 @@ typedef struct blaze_normalizer blaze_normalizer;
  * Options for configuring [`blaze_normalizer`] objects.
  */
 typedef struct blaze_normalizer_opts {
+  /**
+   * The size of this object's type.
+   *
+   * Make sure to initialize it to `sizeof(<type>)`. This member is used to
+   * ensure compatibility in the presence of member additions.
+   */
+  size_t type_size;
   /**
    * Whether to read and report build IDs as part of the normalization
    * process.
@@ -238,6 +264,13 @@ typedef struct blaze_symbolizer blaze_symbolizer;
  * Options for configuring [`blaze_symbolizer`] objects.
  */
 typedef struct blaze_symbolizer_opts {
+  /**
+   * The size of this object's type.
+   *
+   * Make sure to initialize it to `sizeof(<type>)`. This member is used to
+   * ensure compatibility in the presence of member additions.
+   */
+  size_t type_size;
   /**
    * Whether to attempt to gather source code location information.
    *
@@ -375,6 +408,13 @@ typedef struct blaze_result {
  */
 typedef struct blaze_symbolize_src_process {
   /**
+   * The size of this object's type.
+   *
+   * Make sure to initialize it to `sizeof(<type>)`. This member is used to
+   * ensure compatibility in the presence of member additions.
+   */
+  size_t type_size;
+  /**
    * It is the PID of a process to symbolize.
    *
    * blazesym will parse `/proc/<pid>/maps` and load all the object
@@ -400,6 +440,13 @@ typedef struct blaze_symbolize_src_process {
  * debug information.
  */
 typedef struct blaze_symbolize_src_kernel {
+  /**
+   * The size of this object's type.
+   *
+   * Make sure to initialize it to `sizeof(<type>)`. This member is used to
+   * ensure compatibility in the presence of member additions.
+   */
+  size_t type_size;
   /**
    * The path of a copy of kallsyms.
    *
@@ -433,6 +480,13 @@ typedef struct blaze_symbolize_src_kernel {
  */
 typedef struct blaze_symbolize_src_elf {
   /**
+   * The size of this object's type.
+   *
+   * Make sure to initialize it to `sizeof(<type>)`. This member is used to
+   * ensure compatibility in the presence of member additions.
+   */
+  size_t type_size;
+  /**
    * The path to the ELF file.
    *
    * The referenced file may be an executable or shared object. For example,
@@ -453,6 +507,13 @@ typedef struct blaze_symbolize_src_elf {
  */
 typedef struct blaze_symbolize_src_gsym_data {
   /**
+   * The size of this object's type.
+   *
+   * Make sure to initialize it to `sizeof(<type>)`. This member is used to
+   * ensure compatibility in the presence of member additions.
+   */
+  size_t type_size;
+  /**
    * The Gsym data.
    */
   const uint8_t *data;
@@ -466,6 +527,13 @@ typedef struct blaze_symbolize_src_gsym_data {
  * The parameters to load symbols and debug information from a Gsym file.
  */
 typedef struct blaze_symbolize_src_gsym_file {
+  /**
+   * The size of this object's type.
+   *
+   * Make sure to initialize it to `sizeof(<type>)`. This member is used to
+   * ensure compatibility in the presence of member additions.
+   */
+  size_t type_size;
   /**
    * The path to a gsym file.
    */

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -120,7 +120,7 @@ impl From<blaze_inspect_elf_src> for Elf {
 
 
 /// The type of a symbol.
-#[repr(C)]
+#[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum blaze_sym_type {
     /// The symbol type is unspecified or unknown.
@@ -163,6 +163,8 @@ pub struct blaze_sym_info {
     pub obj_file_name: *const c_char,
     /// See [`inspect::SymInfo::sym_type`].
     pub sym_type: blaze_sym_type,
+    /// Unused member available for future expansion.
+    pub reserved: [u8; 15],
 }
 
 
@@ -233,6 +235,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
                     sym_type: sym_type.into(),
                     file_offset: file_offset.unwrap_or(0),
                     obj_file_name,
+                    reserved: [0u8; 15],
                 }
             };
             sym_ptr = unsafe { sym_ptr.add(1) };
@@ -245,6 +248,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
                 sym_type: blaze_sym_type::BLAZE_SYM_UNDEF,
                 file_offset: 0,
                 obj_file_name: ptr::null(),
+                reserved: [0u8; 15],
             }
         };
         sym_ptr = unsafe { sym_ptr.add(1) };
@@ -371,6 +375,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn type_sizes() {
         assert_eq!(mem::size_of::<blaze_inspect_elf_src>(), 24);
+        assert_eq!(mem::size_of::<blaze_sym_info>(), 56);
     }
 
     /// Exercise the `Debug` representation of various types.
@@ -394,10 +399,11 @@ mod tests {
             file_offset: 31,
             obj_file_name: ptr::null(),
             sym_type: blaze_sym_type::BLAZE_SYM_VAR,
+            reserved: [0u8; 15],
         };
         assert_eq!(
             format!("{info:?}"),
-            "blaze_sym_info { name: 0x0, addr: 42, size: 1337, file_offset: 31, obj_file_name: 0x0, sym_type: BLAZE_SYM_VAR }"
+            "blaze_sym_info { name: 0x0, addr: 42, size: 1337, file_offset: 31, obj_file_name: 0x0, sym_type: BLAZE_SYM_VAR, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
     }
 

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -20,6 +20,50 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 
+macro_rules! input_zeroed {
+    ($container_ptr:ident, $container_ty:ty) => {{
+        // Each input type's first member is a `usize`.
+        let user_size = unsafe { $container_ptr.cast::<usize>().read() };
+        if user_size < std::mem::size_of_val(&user_size) {
+            false
+        } else {
+            let effective_size = memoffset::offset_of!($container_ty, reserved);
+            unsafe {
+                crate::is_mem_zero(
+                    $container_ptr.cast::<u8>().add(effective_size),
+                    user_size.saturating_sub(effective_size),
+                )
+            }
+        }
+    }};
+}
+
+
+macro_rules! input_sanitize {
+    ($container_ptr:ident, $container_ty:ty) => {
+        unsafe {
+            let user_type_size = (*$container_ptr).type_size;
+            if (user_type_size < std::mem::size_of::<$container_ty>()) {
+                let mut obj = std::mem::MaybeUninit::<$container_ty>::uninit();
+                let buf = obj.as_mut_ptr().cast::<u8>();
+                // Copy user data over local copy.
+                let () =
+                    std::ptr::copy_nonoverlapping($container_ptr.cast::<u8>(), buf, user_type_size);
+
+                let () = std::ptr::write_bytes(
+                    buf.add(user_type_size),
+                    0,
+                    std::mem::size_of::<$container_ty>() - user_type_size,
+                );
+                obj.assume_init()
+            } else {
+                $container_ptr.read()
+            }
+        }
+    };
+}
+
+
 #[allow(non_camel_case_types)]
 mod inspect;
 #[allow(non_camel_case_types)]
@@ -33,6 +77,23 @@ use std::slice;
 pub use inspect::*;
 pub use normalize::*;
 pub use symbolize::*;
+
+
+/// Check whether the given piece of memory is zeroed out.
+///
+/// # Safety
+/// The caller needs to make sure that `mem` points to `len` (or more) bytes of
+/// valid memory.
+pub(crate) unsafe fn is_mem_zero(mut mem: *const u8, mut len: usize) -> bool {
+    while len > 0 {
+        if unsafe { mem.read() } != 0 {
+            return false
+        }
+        mem = unsafe { mem.add(1) };
+        len -= 1;
+    }
+    true
+}
 
 
 /// "Safely" create a slice from a user provided array.
@@ -54,6 +115,22 @@ mod tests {
 
     use std::ptr;
 
+
+    /// Check that `is_mem_zero` works as it should.
+    #[test]
+    fn mem_zeroed_checking() {
+        let mut bytes = [0u8; 64];
+        assert!(
+            unsafe { is_mem_zero(bytes.as_slice().as_ptr(), bytes.len()) },
+            "{bytes:#x?}"
+        );
+
+        bytes[bytes.len() / 2] = 42;
+        assert!(
+            !unsafe { is_mem_zero(bytes.as_slice().as_ptr(), bytes.len()) },
+            "{bytes:#x?}"
+        );
+    }
 
     /// Test the `slice_from_user_array` helper in the presence of various
     /// inputs.

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1,10 +1,21 @@
 //! C API bindings for the library.
+//!
+//! # Compatibility
+//! The library aims to provide forward compatibility with newer
+//! versions and backward compatibility with older ones. To make that
+//! happen, relevant types that are being passed to the library contain
+//! the `type_size` member that is to be set to the type's size. The
+//! `BLAZE_INPUT` macro can be used for convenient initialization:
+//! ```c
+#![doc = include_str!("../examples/input-struct-init.c")]
+//! ```
 
 #![allow(
     clippy::collapsible_if,
     clippy::fn_to_numeric_cast,
     clippy::let_and_return,
-    clippy::let_unit_value
+    clippy::let_unit_value,
+    clippy::manual_non_exhaustive
 )]
 #![deny(unsafe_op_in_unsafe_fn)]
 

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -50,18 +50,33 @@ pub struct blaze_symbolize_src_elf {
     /// Whether or not to consult debug symbols to satisfy the request
     /// (if present).
     pub debug_syms: bool,
+    /// Unused member available for future expansion. Must be initialized
+    /// to zero.
+    pub reserved: [u8; 7],
 }
 
-impl From<&blaze_symbolize_src_elf> for Elf {
-    fn from(elf: &blaze_symbolize_src_elf) -> Self {
+impl Default for blaze_symbolize_src_elf {
+    fn default() -> Self {
+        Self {
+            type_size: mem::size_of::<Self>(),
+            path: ptr::null(),
+            debug_syms: false,
+            reserved: [0; 7],
+        }
+    }
+}
+
+impl From<blaze_symbolize_src_elf> for Elf {
+    fn from(elf: blaze_symbolize_src_elf) -> Self {
         let blaze_symbolize_src_elf {
             type_size: _,
             path,
             debug_syms,
+            reserved: _,
         } = elf;
         Self {
-            path: unsafe { from_cstr(*path) },
-            debug_syms: *debug_syms,
+            path: unsafe { from_cstr(path) },
+            debug_syms,
             _non_exhaustive: (),
         }
     }
@@ -97,20 +112,36 @@ pub struct blaze_symbolize_src_kernel {
     /// Whether or not to consult debug symbols from `kernel_image`
     /// to satisfy the request (if present).
     pub debug_syms: bool,
+    /// Unused member available for future expansion. Must be initialized
+    /// to zero.
+    pub reserved: [u8; 7],
 }
 
-impl From<&blaze_symbolize_src_kernel> for Kernel {
-    fn from(kernel: &blaze_symbolize_src_kernel) -> Self {
+impl Default for blaze_symbolize_src_kernel {
+    fn default() -> Self {
+        Self {
+            type_size: mem::size_of::<Self>(),
+            kallsyms: ptr::null(),
+            kernel_image: ptr::null(),
+            debug_syms: false,
+            reserved: [0; 7],
+        }
+    }
+}
+
+impl From<blaze_symbolize_src_kernel> for Kernel {
+    fn from(kernel: blaze_symbolize_src_kernel) -> Self {
         let blaze_symbolize_src_kernel {
             type_size: _,
             kallsyms,
             kernel_image,
             debug_syms,
+            reserved: _,
         } = kernel;
         Self {
-            kallsyms: (!kallsyms.is_null()).then(|| unsafe { from_cstr(*kallsyms) }),
-            kernel_image: (!kernel_image.is_null()).then(|| unsafe { from_cstr(*kernel_image) }),
-            debug_syms: *debug_syms,
+            kallsyms: (!kallsyms.is_null()).then(|| unsafe { from_cstr(kallsyms) }),
+            kernel_image: (!kernel_image.is_null()).then(|| unsafe { from_cstr(kernel_image) }),
+            debug_syms,
             _non_exhaustive: (),
         }
     }
@@ -140,20 +171,36 @@ pub struct blaze_symbolize_src_process {
     /// Whether to incorporate a process' perf map file into the symbolization
     /// procedure.
     pub perf_map: bool,
+    /// Unused member available for future expansion. Must be initialized
+    /// to zero.
+    pub reserved: [u8; 2],
 }
 
-impl From<&blaze_symbolize_src_process> for Process {
-    fn from(process: &blaze_symbolize_src_process) -> Self {
+impl Default for blaze_symbolize_src_process {
+    fn default() -> Self {
+        Self {
+            type_size: mem::size_of::<Self>(),
+            pid: 0,
+            debug_syms: false,
+            perf_map: false,
+            reserved: [0; 2],
+        }
+    }
+}
+
+impl From<blaze_symbolize_src_process> for Process {
+    fn from(process: blaze_symbolize_src_process) -> Self {
         let blaze_symbolize_src_process {
             type_size: _,
             pid,
             debug_syms,
             perf_map,
+            reserved: _,
         } = process;
         Self {
-            pid: (*pid).into(),
-            debug_syms: *debug_syms,
-            perf_map: *perf_map,
+            pid: pid.into(),
+            debug_syms,
+            perf_map,
             _non_exhaustive: (),
         }
     }
@@ -173,17 +220,31 @@ pub struct blaze_symbolize_src_gsym_data {
     pub data: *const u8,
     /// The size of the Gsym data.
     pub data_len: usize,
+    /// Unused member indicating the last field.
+    pub reserved: (),
 }
 
-impl From<&blaze_symbolize_src_gsym_data> for GsymData<'_> {
-    fn from(gsym: &blaze_symbolize_src_gsym_data) -> Self {
+impl Default for blaze_symbolize_src_gsym_data {
+    fn default() -> Self {
+        Self {
+            type_size: mem::size_of::<Self>(),
+            data: ptr::null(),
+            data_len: 0,
+            reserved: (),
+        }
+    }
+}
+
+impl From<blaze_symbolize_src_gsym_data> for GsymData<'_> {
+    fn from(gsym: blaze_symbolize_src_gsym_data) -> Self {
         let blaze_symbolize_src_gsym_data {
             type_size: _,
             data,
             data_len,
+            reserved: (),
         } = gsym;
         Self {
-            data: unsafe { slice_from_user_array(*data, *data_len) },
+            data: unsafe { slice_from_user_array(data, data_len) },
             _non_exhaustive: (),
         }
     }
@@ -201,13 +262,29 @@ pub struct blaze_symbolize_src_gsym_file {
     pub type_size: usize,
     /// The path to a gsym file.
     pub path: *const c_char,
+    /// Unused member indicating the last field.
+    pub reserved: (),
 }
 
-impl From<&blaze_symbolize_src_gsym_file> for GsymFile {
-    fn from(gsym: &blaze_symbolize_src_gsym_file) -> Self {
-        let blaze_symbolize_src_gsym_file { type_size: _, path } = gsym;
+impl Default for blaze_symbolize_src_gsym_file {
+    fn default() -> Self {
         Self {
-            path: unsafe { from_cstr(*path) },
+            type_size: mem::size_of::<Self>(),
+            path: ptr::null(),
+            reserved: (),
+        }
+    }
+}
+
+impl From<blaze_symbolize_src_gsym_file> for GsymFile {
+    fn from(gsym: blaze_symbolize_src_gsym_file) -> Self {
+        let blaze_symbolize_src_gsym_file {
+            type_size: _,
+            path,
+            reserved: (),
+        } = gsym;
+        Self {
+            path: unsafe { from_cstr(path) },
             _non_exhaustive: (),
         }
     }
@@ -337,6 +414,21 @@ pub struct blaze_symbolizer_opts {
     /// languages are Rust and C++ and the flag will have no effect if
     /// the underlying language does not mangle symbols (such as C).
     pub demangle: bool,
+    /// Unused member available for future expansion. Must be initialized
+    /// to zero.
+    pub reserved: [u8; 5],
+}
+
+impl Default for blaze_symbolizer_opts {
+    fn default() -> Self {
+        Self {
+            type_size: mem::size_of::<Self>(),
+            code_info: false,
+            inlined_fns: false,
+            demangle: false,
+            reserved: [0; 5],
+        }
+    }
 }
 
 
@@ -356,19 +448,23 @@ pub extern "C" fn blaze_symbolizer_new() -> *mut blaze_symbolizer {
 pub unsafe extern "C" fn blaze_symbolizer_new_opts(
     opts: *const blaze_symbolizer_opts,
 ) -> *mut blaze_symbolizer {
-    // SAFETY: The caller ensures that the pointer is valid.
-    let opts = unsafe { &*opts };
+    if !input_zeroed!(opts, blaze_symbolizer_opts) {
+        return ptr::null_mut()
+    }
+    let opts = input_sanitize!(opts, blaze_symbolizer_opts);
+
     let blaze_symbolizer_opts {
         type_size: _,
         code_info,
         inlined_fns,
         demangle,
+        reserved: _,
     } = opts;
 
     let symbolizer = Symbolizer::builder()
-        .enable_code_info(*code_info)
-        .enable_inlined_fns(*inlined_fns)
-        .enable_demangling(*demangle)
+        .enable_code_info(code_info)
+        .enable_inlined_fns(inlined_fns)
+        .enable_demangling(demangle)
         .build();
     let symbolizer_box = Box::new(symbolizer);
     Box::into_raw(symbolizer_box)
@@ -585,8 +681,12 @@ pub unsafe extern "C" fn blaze_symbolize_process_abs_addrs(
     abs_addrs: *const Addr,
     abs_addr_cnt: usize,
 ) -> *const blaze_result {
-    // SAFETY: The caller ensures that the pointer is valid.
-    let src = Source::from(Process::from(unsafe { &*src }));
+    if !input_zeroed!(src, blaze_symbolize_src_process) {
+        return ptr::null_mut()
+    }
+    let src = input_sanitize!(src, blaze_symbolize_src_process);
+    let src = Source::from(Process::from(src));
+
     unsafe { blaze_symbolize_impl(symbolizer, src, Input::AbsAddr(abs_addrs), abs_addr_cnt) }
 }
 
@@ -609,8 +709,12 @@ pub unsafe extern "C" fn blaze_symbolize_kernel_abs_addrs(
     abs_addrs: *const Addr,
     abs_addr_cnt: usize,
 ) -> *const blaze_result {
-    // SAFETY: The caller ensures that the pointer is valid.
-    let src = Source::from(Kernel::from(unsafe { &*src }));
+    if !input_zeroed!(src, blaze_symbolize_src_kernel) {
+        return ptr::null_mut()
+    }
+    let src = input_sanitize!(src, blaze_symbolize_src_kernel);
+    let src = Source::from(Kernel::from(src));
+
     unsafe { blaze_symbolize_impl(symbolizer, src, Input::AbsAddr(abs_addrs), abs_addr_cnt) }
 }
 
@@ -633,8 +737,12 @@ pub unsafe extern "C" fn blaze_symbolize_elf_virt_offsets(
     virt_offsets: *const Addr,
     virt_offset_cnt: usize,
 ) -> *const blaze_result {
-    // SAFETY: The caller ensures that the pointer is valid.
-    let src = Source::from(Elf::from(unsafe { &*src }));
+    if !input_zeroed!(src, blaze_symbolize_src_elf) {
+        return ptr::null_mut()
+    }
+    let src = input_sanitize!(src, blaze_symbolize_src_elf);
+    let src = Source::from(Elf::from(src));
+
     unsafe {
         blaze_symbolize_impl(
             symbolizer,
@@ -664,10 +772,11 @@ pub unsafe extern "C" fn blaze_symbolize_gsym_data_virt_offsets(
     virt_offsets: *const Addr,
     virt_offset_cnt: usize,
 ) -> *const blaze_result {
-    // SAFETY: The caller ensures that the pointer is valid. The `GsymData`
-    //         lifetime is entirely conjured up, but the object only needs to be
-    //         valid for the call.
-    let src = Source::from(GsymData::from(unsafe { &*src }));
+    if !input_zeroed!(src, blaze_symbolize_src_gsym_data) {
+        return ptr::null_mut()
+    }
+    let src = input_sanitize!(src, blaze_symbolize_src_gsym_data);
+    let src = Source::from(GsymData::from(src));
     unsafe {
         blaze_symbolize_impl(
             symbolizer,
@@ -697,8 +806,12 @@ pub unsafe extern "C" fn blaze_symbolize_gsym_file_virt_offsets(
     virt_offsets: *const Addr,
     virt_offset_cnt: usize,
 ) -> *const blaze_result {
-    // SAFETY: The caller ensures that the pointer is valid.
-    let src = Source::from(GsymFile::from(unsafe { &*src }));
+    if !input_zeroed!(src, blaze_symbolize_src_gsym_file) {
+        return ptr::null_mut()
+    }
+    let src = input_sanitize!(src, blaze_symbolize_src_gsym_file);
+    let src = Source::from(GsymFile::from(src));
+
     unsafe {
         blaze_symbolize_impl(
             symbolizer,
@@ -743,58 +856,70 @@ mod tests {
     use blazesym::symbolize::Reason;
 
 
+    /// Check that various types have expected sizes.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn type_sizes() {
+        assert_eq!(mem::size_of::<blaze_symbolize_src_elf>(), 24);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_kernel>(), 32);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_process>(), 16);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_data>(), 24);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_file>(), 16);
+        assert_eq!(mem::size_of::<blaze_symbolizer_opts>(), 16);
+    }
+
     /// Exercise the `Debug` representation of various types.
     #[test]
     fn debug_repr() {
         let elf = blaze_symbolize_src_elf {
             type_size: 24,
-            path: ptr::null(),
-            debug_syms: false,
+            ..Default::default()
         };
         assert_eq!(
             format!("{elf:?}"),
-            "blaze_symbolize_src_elf { type_size: 24, path: 0x0, debug_syms: false }"
+            "blaze_symbolize_src_elf { type_size: 24, path: 0x0, debug_syms: false, reserved: [0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let kernel = blaze_symbolize_src_kernel {
             type_size: 32,
-            kallsyms: ptr::null(),
-            kernel_image: ptr::null(),
             debug_syms: true,
+            ..Default::default()
         };
         assert_eq!(
             format!("{kernel:?}"),
-            "blaze_symbolize_src_kernel { type_size: 32, kallsyms: 0x0, kernel_image: 0x0, debug_syms: true }"
+            "blaze_symbolize_src_kernel { type_size: 32, kallsyms: 0x0, kernel_image: 0x0, debug_syms: true, reserved: [0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let process = blaze_symbolize_src_process {
             type_size: 16,
             pid: 1337,
             debug_syms: true,
-            perf_map: false,
+            ..Default::default()
         };
         assert_eq!(
             format!("{process:?}"),
-            "blaze_symbolize_src_process { type_size: 16, pid: 1337, debug_syms: true, perf_map: false }"
+            "blaze_symbolize_src_process { type_size: 16, pid: 1337, debug_syms: true, perf_map: false, reserved: [0, 0] }"
         );
 
         let gsym_data = blaze_symbolize_src_gsym_data {
-            type_size: mem::size_of::<blaze_symbolize_src_gsym_data>(),
+            type_size: 24,
             data: ptr::null(),
             data_len: 0,
+            reserved: (),
         };
         assert_eq!(
             format!("{gsym_data:?}"),
-            "blaze_symbolize_src_gsym_data { type_size: 24, data: 0x0, data_len: 0 }"
+            "blaze_symbolize_src_gsym_data { type_size: 24, data: 0x0, data_len: 0, reserved: () }"
         );
 
         let gsym_file = blaze_symbolize_src_gsym_file {
             type_size: 16,
             path: ptr::null(),
+            reserved: (),
         };
         assert_eq!(
             format!("{gsym_file:?}"),
-            "blaze_symbolize_src_gsym_file { type_size: 16, path: 0x0 }"
+            "blaze_symbolize_src_gsym_file { type_size: 16, path: 0x0, reserved: () }"
         );
 
         let sym = blaze_sym {
@@ -834,13 +959,12 @@ mod tests {
 
         let opts = blaze_symbolizer_opts {
             type_size: 16,
-            code_info: false,
-            inlined_fns: false,
             demangle: true,
+            ..Default::default()
         };
         assert_eq!(
             format!("{opts:?}"),
-            "blaze_symbolizer_opts { type_size: 16, code_info: false, inlined_fns: false, demangle: true }"
+            "blaze_symbolizer_opts { type_size: 16, code_info: false, inlined_fns: false, demangle: true, reserved: [0, 0, 0, 0, 0] }"
         );
     }
 
@@ -848,23 +972,19 @@ mod tests {
     /// reference into a [`Kernel`].
     #[test]
     fn kernel_conversion() {
-        let kernel = blaze_symbolize_src_kernel {
-            type_size: mem::size_of::<blaze_symbolize_src_kernel>(),
-            kallsyms: ptr::null(),
-            kernel_image: ptr::null(),
-            debug_syms: true,
-        };
-        let kernel = Kernel::from(&kernel);
+        let kernel = blaze_symbolize_src_kernel::default();
+        let kernel = Kernel::from(kernel);
         assert_eq!(kernel.kallsyms, None);
         assert_eq!(kernel.kernel_image, None);
 
         let kernel = blaze_symbolize_src_kernel {
-            type_size: mem::size_of::<blaze_symbolize_src_kernel>(),
             kallsyms: b"/proc/kallsyms\0" as *const _ as *const c_char,
             kernel_image: b"/boot/image\0" as *const _ as *const c_char,
             debug_syms: false,
+            ..Default::default()
         };
-        let kernel = Kernel::from(&kernel);
+
+        let kernel = Kernel::from(kernel);
         assert_eq!(kernel.kallsyms, Some(PathBuf::from("/proc/kallsyms")));
         assert_eq!(kernel.kernel_image, Some(PathBuf::from("/boot/image")));
     }
@@ -999,11 +1119,10 @@ mod tests {
     #[test]
     fn symbolizer_creation_with_opts() {
         let opts = blaze_symbolizer_opts {
-            type_size: mem::size_of::<blaze_symbolizer_opts>(),
-            code_info: false,
-            inlined_fns: false,
             demangle: true,
+            ..Default::default()
         };
+
         let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };
         let () = unsafe { blaze_symbolizer_free(symbolizer) };
     }
@@ -1057,10 +1176,11 @@ mod tests {
             .join("test-stable-addresses-no-dwarf.bin");
         let path_c = CString::new(path.to_str().unwrap()).unwrap();
         let elf_src = blaze_symbolize_src_elf {
-            type_size: mem::size_of::<blaze_symbolize_src_elf>(),
             path: path_c.as_ptr(),
             debug_syms: true,
+            ..Default::default()
         };
+
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
             blaze_symbolize_elf_virt_offsets(symbolizer, &elf_src, addrs, addr_cnt)
         };
@@ -1072,10 +1192,11 @@ mod tests {
             .join("test-stable-addresses-dwarf-only.bin");
         let path_c = CString::new(path.to_str().unwrap()).unwrap();
         let elf_src = blaze_symbolize_src_elf {
-            type_size: mem::size_of::<blaze_symbolize_src_elf>(),
             path: path_c.as_ptr(),
             debug_syms: true,
+            ..Default::default()
         };
+
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
             blaze_symbolize_elf_virt_offsets(symbolizer, &elf_src, addrs, addr_cnt)
         };
@@ -1087,9 +1208,10 @@ mod tests {
             .join("test-stable-addresses.gsym");
         let path_c = CString::new(path.to_str().unwrap()).unwrap();
         let gsym_src = blaze_symbolize_src_gsym_file {
-            type_size: mem::size_of::<blaze_symbolize_src_gsym_file>(),
             path: path_c.as_ptr(),
+            ..Default::default()
         };
+
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
             blaze_symbolize_gsym_file_virt_offsets(symbolizer, &gsym_src, addrs, addr_cnt)
         };
@@ -1101,10 +1223,11 @@ mod tests {
             .join("test-stable-addresses.gsym");
         let data = read_file(path).unwrap();
         let gsym_src = blaze_symbolize_src_gsym_data {
-            type_size: mem::size_of::<blaze_symbolize_src_gsym_data>(),
             data: data.as_ptr(),
             data_len: data.len(),
+            ..Default::default()
         };
+
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
             blaze_symbolize_gsym_data_virt_offsets(symbolizer, &gsym_src, addrs, addr_cnt)
         };
@@ -1117,18 +1240,18 @@ mod tests {
     fn symbolize_dwarf_demangle() {
         fn test(path: &Path, addr: Addr) -> Result<(), ()> {
             let opts = blaze_symbolizer_opts {
-                type_size: mem::size_of::<blaze_symbolizer_opts>(),
                 code_info: true,
                 inlined_fns: true,
-                demangle: false,
+                ..Default::default()
             };
 
             let path_c = CString::new(path.to_str().unwrap()).unwrap();
             let elf_src = blaze_symbolize_src_elf {
-                type_size: mem::size_of::<blaze_symbolize_src_elf>(),
                 path: path_c.as_ptr(),
                 debug_syms: true,
+                ..Default::default()
             };
+
             let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };
             let addrs = [addr];
             let result = unsafe {
@@ -1166,10 +1289,10 @@ mod tests {
 
             // Do it again, this time with demangling enabled.
             let opts = blaze_symbolizer_opts {
-                type_size: mem::size_of::<blaze_symbolizer_opts>(),
                 code_info: true,
                 inlined_fns: true,
                 demangle: true,
+                ..Default::default()
             };
 
             let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };
@@ -1239,10 +1362,10 @@ mod tests {
     #[test]
     fn symbolize_in_process() {
         let process_src = blaze_symbolize_src_process {
-            type_size: mem::size_of::<blaze_symbolize_src_process>(),
             pid: 0,
             debug_syms: true,
             perf_map: true,
+            ..Default::default()
         };
 
         let symbolizer = blaze_symbolizer_new();

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -35,6 +35,11 @@ use crate::slice_from_user_array;
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_symbolize_src_elf {
+    /// The size of this object's type.
+    ///
+    /// Make sure to initialize it to `sizeof(<type>)`. This member is used to
+    /// ensure compatibility in the presence of member additions.
+    pub type_size: usize,
     /// The path to the ELF file.
     ///
     /// The referenced file may be an executable or shared object. For example,
@@ -49,7 +54,11 @@ pub struct blaze_symbolize_src_elf {
 
 impl From<&blaze_symbolize_src_elf> for Elf {
     fn from(elf: &blaze_symbolize_src_elf) -> Self {
-        let blaze_symbolize_src_elf { path, debug_syms } = elf;
+        let blaze_symbolize_src_elf {
+            type_size: _,
+            path,
+            debug_syms,
+        } = elf;
         Self {
             path: unsafe { from_cstr(*path) },
             debug_syms: *debug_syms,
@@ -66,6 +75,11 @@ impl From<&blaze_symbolize_src_elf> for Elf {
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_symbolize_src_kernel {
+    /// The size of this object's type.
+    ///
+    /// Make sure to initialize it to `sizeof(<type>)`. This member is used to
+    /// ensure compatibility in the presence of member additions.
+    pub type_size: usize,
     /// The path of a copy of kallsyms.
     ///
     /// It can be `"/proc/kallsyms"` for the running kernel on the
@@ -88,6 +102,7 @@ pub struct blaze_symbolize_src_kernel {
 impl From<&blaze_symbolize_src_kernel> for Kernel {
     fn from(kernel: &blaze_symbolize_src_kernel) -> Self {
         let blaze_symbolize_src_kernel {
+            type_size: _,
             kallsyms,
             kernel_image,
             debug_syms,
@@ -109,6 +124,11 @@ impl From<&blaze_symbolize_src_kernel> for Kernel {
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_symbolize_src_process {
+    /// The size of this object's type.
+    ///
+    /// Make sure to initialize it to `sizeof(<type>)`. This member is used to
+    /// ensure compatibility in the presence of member additions.
+    pub type_size: usize,
     /// It is the PID of a process to symbolize.
     ///
     /// blazesym will parse `/proc/<pid>/maps` and load all the object
@@ -125,6 +145,7 @@ pub struct blaze_symbolize_src_process {
 impl From<&blaze_symbolize_src_process> for Process {
     fn from(process: &blaze_symbolize_src_process) -> Self {
         let blaze_symbolize_src_process {
+            type_size: _,
             pid,
             debug_syms,
             perf_map,
@@ -143,6 +164,11 @@ impl From<&blaze_symbolize_src_process> for Process {
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_symbolize_src_gsym_data {
+    /// The size of this object's type.
+    ///
+    /// Make sure to initialize it to `sizeof(<type>)`. This member is used to
+    /// ensure compatibility in the presence of member additions.
+    pub type_size: usize,
     /// The Gsym data.
     pub data: *const u8,
     /// The size of the Gsym data.
@@ -151,7 +177,11 @@ pub struct blaze_symbolize_src_gsym_data {
 
 impl From<&blaze_symbolize_src_gsym_data> for GsymData<'_> {
     fn from(gsym: &blaze_symbolize_src_gsym_data) -> Self {
-        let blaze_symbolize_src_gsym_data { data, data_len } = gsym;
+        let blaze_symbolize_src_gsym_data {
+            type_size: _,
+            data,
+            data_len,
+        } = gsym;
         Self {
             data: unsafe { slice_from_user_array(*data, *data_len) },
             _non_exhaustive: (),
@@ -164,13 +194,18 @@ impl From<&blaze_symbolize_src_gsym_data> for GsymData<'_> {
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_symbolize_src_gsym_file {
+    /// The size of this object's type.
+    ///
+    /// Make sure to initialize it to `sizeof(<type>)`. This member is used to
+    /// ensure compatibility in the presence of member additions.
+    pub type_size: usize,
     /// The path to a gsym file.
     pub path: *const c_char,
 }
 
 impl From<&blaze_symbolize_src_gsym_file> for GsymFile {
     fn from(gsym: &blaze_symbolize_src_gsym_file) -> Self {
-        let blaze_symbolize_src_gsym_file { path } = gsym;
+        let blaze_symbolize_src_gsym_file { type_size: _, path } = gsym;
         Self {
             path: unsafe { from_cstr(*path) },
             _non_exhaustive: (),
@@ -285,6 +320,11 @@ pub(crate) unsafe fn from_cstr(cstr: *const c_char) -> PathBuf {
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_symbolizer_opts {
+    /// The size of this object's type.
+    ///
+    /// Make sure to initialize it to `sizeof(<type>)`. This member is used to
+    /// ensure compatibility in the presence of member additions.
+    pub type_size: usize,
     /// Whether to attempt to gather source code location information.
     ///
     /// This setting implies `debug_syms` (and forces it to `true`).
@@ -319,6 +359,7 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
     // SAFETY: The caller ensures that the pointer is valid.
     let opts = unsafe { &*opts };
     let blaze_symbolizer_opts {
+        type_size: _,
         code_info,
         inlined_fns,
         demangle,
@@ -706,47 +747,54 @@ mod tests {
     #[test]
     fn debug_repr() {
         let elf = blaze_symbolize_src_elf {
+            type_size: 24,
             path: ptr::null(),
             debug_syms: false,
         };
         assert_eq!(
             format!("{elf:?}"),
-            "blaze_symbolize_src_elf { path: 0x0, debug_syms: false }"
+            "blaze_symbolize_src_elf { type_size: 24, path: 0x0, debug_syms: false }"
         );
 
         let kernel = blaze_symbolize_src_kernel {
+            type_size: 32,
             kallsyms: ptr::null(),
             kernel_image: ptr::null(),
             debug_syms: true,
         };
         assert_eq!(
             format!("{kernel:?}"),
-            "blaze_symbolize_src_kernel { kallsyms: 0x0, kernel_image: 0x0, debug_syms: true }"
+            "blaze_symbolize_src_kernel { type_size: 32, kallsyms: 0x0, kernel_image: 0x0, debug_syms: true }"
         );
 
         let process = blaze_symbolize_src_process {
+            type_size: 16,
             pid: 1337,
             debug_syms: true,
             perf_map: false,
         };
         assert_eq!(
             format!("{process:?}"),
-            "blaze_symbolize_src_process { pid: 1337, debug_syms: true, perf_map: false }"
+            "blaze_symbolize_src_process { type_size: 16, pid: 1337, debug_syms: true, perf_map: false }"
         );
 
         let gsym_data = blaze_symbolize_src_gsym_data {
+            type_size: mem::size_of::<blaze_symbolize_src_gsym_data>(),
             data: ptr::null(),
             data_len: 0,
         };
         assert_eq!(
             format!("{gsym_data:?}"),
-            "blaze_symbolize_src_gsym_data { data: 0x0, data_len: 0 }"
+            "blaze_symbolize_src_gsym_data { type_size: 24, data: 0x0, data_len: 0 }"
         );
 
-        let gsym_file = blaze_symbolize_src_gsym_file { path: ptr::null() };
+        let gsym_file = blaze_symbolize_src_gsym_file {
+            type_size: 16,
+            path: ptr::null(),
+        };
         assert_eq!(
             format!("{gsym_file:?}"),
-            "blaze_symbolize_src_gsym_file { path: 0x0 }"
+            "blaze_symbolize_src_gsym_file { type_size: 16, path: 0x0 }"
         );
 
         let sym = blaze_sym {
@@ -785,13 +833,14 @@ mod tests {
         assert_eq!(format!("{result:?}"), "blaze_result { cnt: 0, syms: [] }");
 
         let opts = blaze_symbolizer_opts {
+            type_size: 16,
             code_info: false,
             inlined_fns: false,
             demangle: true,
         };
         assert_eq!(
             format!("{opts:?}"),
-            "blaze_symbolizer_opts { code_info: false, inlined_fns: false, demangle: true }"
+            "blaze_symbolizer_opts { type_size: 16, code_info: false, inlined_fns: false, demangle: true }"
         );
     }
 
@@ -800,6 +849,7 @@ mod tests {
     #[test]
     fn kernel_conversion() {
         let kernel = blaze_symbolize_src_kernel {
+            type_size: mem::size_of::<blaze_symbolize_src_kernel>(),
             kallsyms: ptr::null(),
             kernel_image: ptr::null(),
             debug_syms: true,
@@ -809,6 +859,7 @@ mod tests {
         assert_eq!(kernel.kernel_image, None);
 
         let kernel = blaze_symbolize_src_kernel {
+            type_size: mem::size_of::<blaze_symbolize_src_kernel>(),
             kallsyms: b"/proc/kallsyms\0" as *const _ as *const c_char,
             kernel_image: b"/boot/image\0" as *const _ as *const c_char,
             debug_syms: false,
@@ -948,6 +999,7 @@ mod tests {
     #[test]
     fn symbolizer_creation_with_opts() {
         let opts = blaze_symbolizer_opts {
+            type_size: mem::size_of::<blaze_symbolizer_opts>(),
             code_info: false,
             inlined_fns: false,
             demangle: true,
@@ -1005,6 +1057,7 @@ mod tests {
             .join("test-stable-addresses-no-dwarf.bin");
         let path_c = CString::new(path.to_str().unwrap()).unwrap();
         let elf_src = blaze_symbolize_src_elf {
+            type_size: mem::size_of::<blaze_symbolize_src_elf>(),
             path: path_c.as_ptr(),
             debug_syms: true,
         };
@@ -1019,6 +1072,7 @@ mod tests {
             .join("test-stable-addresses-dwarf-only.bin");
         let path_c = CString::new(path.to_str().unwrap()).unwrap();
         let elf_src = blaze_symbolize_src_elf {
+            type_size: mem::size_of::<blaze_symbolize_src_elf>(),
             path: path_c.as_ptr(),
             debug_syms: true,
         };
@@ -1033,6 +1087,7 @@ mod tests {
             .join("test-stable-addresses.gsym");
         let path_c = CString::new(path.to_str().unwrap()).unwrap();
         let gsym_src = blaze_symbolize_src_gsym_file {
+            type_size: mem::size_of::<blaze_symbolize_src_gsym_file>(),
             path: path_c.as_ptr(),
         };
         let symbolize = |symbolizer, addrs, addr_cnt| unsafe {
@@ -1046,6 +1101,7 @@ mod tests {
             .join("test-stable-addresses.gsym");
         let data = read_file(path).unwrap();
         let gsym_src = blaze_symbolize_src_gsym_data {
+            type_size: mem::size_of::<blaze_symbolize_src_gsym_data>(),
             data: data.as_ptr(),
             data_len: data.len(),
         };
@@ -1061,6 +1117,7 @@ mod tests {
     fn symbolize_dwarf_demangle() {
         fn test(path: &Path, addr: Addr) -> Result<(), ()> {
             let opts = blaze_symbolizer_opts {
+                type_size: mem::size_of::<blaze_symbolizer_opts>(),
                 code_info: true,
                 inlined_fns: true,
                 demangle: false,
@@ -1068,6 +1125,7 @@ mod tests {
 
             let path_c = CString::new(path.to_str().unwrap()).unwrap();
             let elf_src = blaze_symbolize_src_elf {
+                type_size: mem::size_of::<blaze_symbolize_src_elf>(),
                 path: path_c.as_ptr(),
                 debug_syms: true,
             };
@@ -1108,6 +1166,7 @@ mod tests {
 
             // Do it again, this time with demangling enabled.
             let opts = blaze_symbolizer_opts {
+                type_size: mem::size_of::<blaze_symbolizer_opts>(),
                 code_info: true,
                 inlined_fns: true,
                 demangle: true,
@@ -1128,7 +1187,6 @@ mod tests {
                 unsafe { CStr::from_ptr(sym.name) },
                 CStr::from_bytes_with_nul(b"test::test_function\0").unwrap()
             );
-
 
             assert_eq!(sym.inlined_cnt, 1);
             assert_eq!(
@@ -1181,6 +1239,7 @@ mod tests {
     #[test]
     fn symbolize_in_process() {
         let process_src = blaze_symbolize_src_process {
+            type_size: mem::size_of::<blaze_symbolize_src_process>(),
             pid: 0,
             debug_syms: true,
             perf_map: true,


### PR DESCRIPTION
In order to ensure some level of forward & backward compatibility, this change extends all our input types with a member holding the objects size. Users need to set this member to the size of the type. The library can then ignore unsupported fields (forward compatibility) or provide reasonable defaults for fields not provided (backward compatibility).