### PR TITLE
capi: Enable `unsafe_op_in_unsafe_fn` lint

### DIFF
--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -6,6 +6,8 @@
     clippy::let_and_return,
     clippy::let_unit_value
 )]
+#![deny(unsafe_op_in_unsafe_fn)]
+
 
 #[allow(non_camel_case_types)]
 mod inspect;

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -300,12 +300,12 @@ impl blaze_user_meta {
 
     unsafe fn free(self) {
         match self.kind {
-            blaze_user_meta_kind::BLAZE_USER_META_APK => {
-                ManuallyDrop::into_inner(unsafe { self.variant.apk }).free()
-            }
-            blaze_user_meta_kind::BLAZE_USER_META_ELF => {
-                ManuallyDrop::into_inner(unsafe { self.variant.elf }).free()
-            }
+            blaze_user_meta_kind::BLAZE_USER_META_APK => unsafe {
+                ManuallyDrop::into_inner(self.variant.apk).free()
+            },
+            blaze_user_meta_kind::BLAZE_USER_META_ELF => unsafe {
+                ManuallyDrop::into_inner(self.variant.elf).free()
+            },
             blaze_user_meta_kind::BLAZE_USER_META_UNKNOWN => {
                 ManuallyDrop::into_inner(unsafe { self.variant.unknown }).free()
             }


### PR DESCRIPTION
Enable the `unsafe_op_in_unsafe_fn` lint. Refer to commit 0f4b25dd43fd ("Make unsafe blocks explicit") for details.