### PR TITLE
cli: Add --no-debug-syms option to 'symbolize elf' sub-command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added support for symbolization using Breakpad (`*.sym`) files
+- Added `--no-debug-syms` option to `symbolize elf` sub-command
 
 
 0.1.2

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -102,6 +102,9 @@ pub struct Elf {
     /// The path to the ELF file.
     #[clap(short, long)]
     pub path: PathBuf,
+    /// Disable the use of debug symbols.
+    #[clap(long)]
+    pub no_debug_syms: bool,
     /// The addresses to symbolize.
     ///
     /// Addresses are assumed to already be normalized to the file

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -117,8 +117,14 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
             let input = symbolize::Input::FileOffset(addrs);
             (src, input, addrs)
         }
-        args::Symbolize::Elf(args::Elf { path, ref addrs }) => {
-            let src = symbolize::Source::from(symbolize::Elf::new(path));
+        args::Symbolize::Elf(args::Elf {
+            path,
+            no_debug_syms,
+            ref addrs,
+        }) => {
+            let mut elf = symbolize::Elf::new(path);
+            elf.debug_syms = !no_debug_syms;
+            let src = symbolize::Source::from(elf);
             let addrs = addrs.as_slice();
             let input = symbolize::Input::VirtOffset(addrs);
             (src, input, addrs)


### PR DESCRIPTION
Introduce the --no-debug-syms option to the 'symbolize elf' sub-command, so that users can opt out of the usage of debug symbols.