### PR TITLE
Resolve function names across DWARF units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased
   - Made it non-exhaustive
   - Moved it out of `inspect` module
   - Renamed `Unknown` variant to `Undefined`
+- Fixed DWARF symbolization in the presence of cross compilation unit
+  references
 
 
 0.2.0-alpha.10

--- a/build.rs
+++ b/build.rs
@@ -412,6 +412,22 @@ fn prepare_test_files(crate_root: &Path) {
             src_cu2,
         ],
     );
+    cc(
+        &src,
+        "test-stable-addresses-lto.bin",
+        &[
+            // NB: Keep DWARF 4 for this binary. Cross unit references
+            //     as this binary aims to produce only seem to appear in
+            //     this version.
+            "-gdwarf-4",
+            "-T",
+            ld_script,
+            "-O0",
+            "-nostdlib",
+            "-flto",
+            src_cu2,
+        ],
+    );
 
     let src = crate_root.join("data").join("test-stable-addresses.bin");
     gsym(&src, "test-stable-addresses.gsym");

--- a/src/dwarf/function.rs
+++ b/src/dwarf/function.rs
@@ -101,8 +101,11 @@ fn name_attr<'dwarf>(
 
     match attr {
         gimli::AttributeValue::UnitRef(offset) => name_entry(unit, offset, units, recursion_limit),
-        // TODO: Need to handle `AttributeValue::DebugInfoRef` and
-        //       `AttributeValue::DebugInfoRefSup`.
+        gimli::AttributeValue::DebugInfoRef(offset) => {
+            let (unit, offset) = units.find_unit(offset)?;
+            name_entry(unit, offset, units, recursion_limit)
+        }
+        // TODO: Need to handle `AttributeValue::DebugInfoRefSup`.
         _ => Ok(None),
     }
 }

--- a/src/dwarf/location.rs
+++ b/src/dwarf/location.rs
@@ -31,8 +31,8 @@ use std::path::Path;
 
 use super::lines::LineSequence;
 use super::lines::Lines;
-use super::reader::R;
 use super::unit::Unit;
+use super::units::Units;
 
 
 /// A source location.
@@ -60,11 +60,11 @@ pub(super) struct LocationRangeUnitIter<'unit, 'dwarf> {
 impl<'unit, 'dwarf> LocationRangeUnitIter<'unit, 'dwarf> {
     pub(super) fn new(
         unit: &'unit Unit<'dwarf>,
-        sections: &gimli::Dwarf<R<'dwarf>>,
+        units: &Units<'dwarf>,
         probe_low: u64,
         probe_high: u64,
     ) -> Result<Option<Self>, gimli::Error> {
-        let lines = unit.parse_lines(sections)?;
+        let lines = unit.parse_lines(units)?;
 
         if let Some(lines) = lines {
             // Find index for probe_low.

--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -44,6 +44,7 @@ pub(super) struct UnitRange {
 
 
 pub(super) struct Unit<'dwarf> {
+    offset: gimli::DebugInfoOffset<<R<'dwarf> as gimli::Reader>::Offset>,
     dw_unit: gimli::Unit<R<'dwarf>>,
     lang: Option<gimli::DwLang>,
     lines: OnceCell<Lines<'dwarf>>,
@@ -52,11 +53,13 @@ pub(super) struct Unit<'dwarf> {
 
 impl<'dwarf> Unit<'dwarf> {
     pub(super) fn new(
+        offset: gimli::DebugInfoOffset<<R<'dwarf> as gimli::Reader>::Offset>,
         unit: gimli::Unit<R<'dwarf>>,
         lang: Option<gimli::DwLang>,
         lines: OnceCell<Lines<'dwarf>>,
     ) -> Self {
         Self {
+            offset,
             dw_unit: unit,
             lang,
             lines,

--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -165,7 +165,13 @@ impl<'dwarf> Unit<'dwarf> {
         Ok(None)
     }
 
-    /// Attempt to retrieve the compilation unit's source code language.
+    /// Retrieve the unit's debug info offset.
+    #[inline]
+    pub(super) fn offset(&self) -> gimli::DebugInfoOffset<<R<'dwarf> as gimli::Reader>::Offset> {
+        self.offset
+    }
+
+    /// Retrieve the underlying [`gimli::Unit`] object.
     #[inline]
     pub(super) fn dw_unit(&self) -> &gimli::Unit<R<'dwarf>> {
         &self.dw_unit

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -207,7 +207,7 @@ impl<'dwarf> Units<'dwarf> {
                 }
             }
 
-            res_units.push(Unit::new(dw_unit, lang, lines))
+            res_units.push(Unit::new(offset, dw_unit, lang, lines))
         }
 
         // Sort this for faster lookups.

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -132,6 +132,12 @@ fn symbolize_elf_dwarf_gsym() {
 
     let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
+        .join("test-stable-addresses-lto.bin");
+    let src = symbolize::Source::Elf(symbolize::Elf::new(path));
+    test(src, true);
+
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
         .join("test-stable-addresses.gsym");
     let src = symbolize::Source::from(symbolize::GsymFile::new(&path));
     test(src, true);


### PR DESCRIPTION
When a DWARF debug information contains a DW_TAG_subprogram entry with
an DW_AT_abstract_origin that is outside the current compilation unit,
function name retrieval fails, because cross unit lookups of this form
were not covered by our existing logic. E.g.,

```
0x0000000b: DW_TAG_compile_unit
              DW_AT_producer    ("GNU GIMPLE [...]")
              DW_AT_language    (DW_LANG_C99)
              DW_AT_name        ("<artificial>")
              ...

0x00000066:   DW_TAG_subprogram
                DW_AT_abstract_origin   (0x000000000000026d "factorial")
                DW_AT_low_pc    (0x0000000002000100)
                DW_AT_high_pc   (0x000000000200012b)
                ...

0x0000019b: DW_TAG_compile_unit
              DW_AT_producer    ("GNU C17 [...]")
              DW_AT_language    (DW_LANG_C99)
                ...

0x0000026d:   DW_TAG_subprogram
                DW_AT_external  (true)
                DW_AT_name      ("factorial")
                ...
```

This change fixes this short coming, by adding the necessary cross unit
name resolution logic.
