### PR TITLE
Run elf_src_validity in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,9 @@ jobs:
   test-miri:
     name: Test with Miri
     runs-on: ubuntu-latest
+    env:
+      # Stack borrows are very experimental. Disable for now.
+      MIRIFLAGS: '-Zmiri-disable-stacked-borrows'
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
@@ -211,7 +214,7 @@ jobs:
     - name: Remove .cargo/config
       run: rm .cargo/config
     - name: Run tests
-      run: cargo miri test --features=dont-generate-unit-test-files -- "insert_map::" "util::" "::elf_src_validity"
+      run: cargo miri test --workspace --features=dont-generate-unit-test-files -- "insert_map::" "util::" "::elf_src_validity"
   c-header:
     name: Check generated C header
     runs-on: ubuntu-latest

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -365,6 +365,7 @@ mod tests {
     use std::mem::MaybeUninit;
     use std::path::Path;
     use std::ptr;
+    use std::ptr::addr_of;
     use std::slice;
 
     use test_log::test;
@@ -436,7 +437,7 @@ mod tests {
         src.type_size = mem::size_of::<elf_src_with_ext>();
         src.debug_syms = true;
 
-        let src_ptr = &src as *const _ as *const blaze_inspect_elf_src;
+        let src_ptr = addr_of!(src).cast::<blaze_inspect_elf_src>();
         assert!(input_zeroed!(src_ptr, blaze_inspect_elf_src));
 
         src.reserved[0] = 1;


### PR DESCRIPTION
The test was meant to be run, but because we did not execute Miri on the entire workspace, it actually wasn't. Make sure to test the workspace. Also disable stacked borrows for the time being, because it seems to cause a false positive. Or at least I can't find an issue with it. Lastly, use addr_of! macro for good measure. We should probably do that throughout the code base eventually.