### PR TITLE
Introduce `FileMeta` helper type

### DIFF
--- a/src/insert_map.rs
+++ b/src/insert_map.rs
@@ -15,6 +15,7 @@ pub(crate) struct InsertMap<K, V> {
     /// A proxy member used for making sure that we do not borrow `map` mutably
     /// multiple times.
     refcell: RefCell<()>,
+    /// The actual map containing key-value pairs.
     map: RefCell<HashMap<K, V>>,
 }
 

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -220,13 +220,13 @@ impl Default for Builder {
 /// symbol resolvers.
 ///
 /// An "uncached" resolver is one that is created on the spot. We do so for
-/// cases when we keep the input data, for example (e.g., when we have no
-/// control over its lifetime).
+/// cases when we cannot keep the input data, for example (e.g., when we
+/// have no control over its lifetime).
 /// A "cached" resolver is one that ultimately lives in one of our internal
 /// caches. These caches have the same lifetime as the `Symbolizer` object
 /// itself (represented here as `'slf`).
 ///
-/// Object of this type are at the core of our logic determining whether to
+/// Objects of this type are at the core of our logic determining whether to
 /// heap allocate certain data such as paths or symbol names or whether to just
 /// hand out references to mmap'ed data.
 #[derive(Debug)]


### PR DESCRIPTION
Introduce the `FileMeta` helper type holding all the file meta data attributes that our `FileCache` cares about. Grouping all these fields in a single type will make it easier to work with them in the future.