### PR TITLE
Only read file meta-data in FileCache on happy-path

### DIFF
--- a/src/insert_map.rs
+++ b/src/insert_map.rs
@@ -35,28 +35,6 @@ impl<K, V> InsertMap<K, V> {
     /// The `init` function should not use functionality provided by the
     /// object this method operates on, recursively, or a runtime panic
     /// may be the result.
-    pub(crate) fn get_or_insert<F>(&self, key: K, init: F) -> &V
-    where
-        K: Eq + Hash,
-        F: FnOnce() -> V,
-    {
-        let _borrow = self.map.borrow_mut();
-        // SAFETY: We are sure to not borrow mutably twice because the `_borrow`
-        //         guard protects us.
-        let map = unsafe { self.map.as_ptr().as_mut() }.unwrap();
-        match map.entry(key) {
-            hash_map::Entry::Occupied(occupied) => occupied.into_mut(),
-            hash_map::Entry::Vacant(vacancy) => vacancy.insert(init()),
-        }
-    }
-
-    /// Retrieve a value mapping to a key, if already present, or insert
-    /// it and return it then.
-    ///
-    /// # Panics
-    /// The `init` function should not use functionality provided by the
-    /// object this method operates on, recursively, or a runtime panic
-    /// may be the result.
     pub(crate) fn get_or_try_insert<F>(&self, key: K, init: F) -> Result<&V>
     where
         K: Eq + Hash,
@@ -99,6 +77,7 @@ mod tests {
     #[test]
     fn insertion() {
         let map = InsertMap::<usize, &'static str>::new();
+
         let s = map
             .get_or_try_insert(42, || Ok("you win the price"))
             .unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,7 @@ use std::mem::align_of;
 use std::mem::size_of;
 use std::mem::MaybeUninit;
 use std::os::unix::ffi::OsStrExt as _;
+#[cfg(test)]
 use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::slice;
@@ -71,7 +72,8 @@ pub(crate) fn stat(path: &Path) -> io::Result<libc::stat> {
 }
 
 
-pub(crate) fn fstat(fd: RawFd) -> io::Result<libc::stat> {
+#[cfg(test)]
+fn fstat(fd: RawFd) -> io::Result<libc::stat> {
     let mut dst = MaybeUninit::uninit();
     let rc = unsafe { libc::fstat(fd, dst.as_mut_ptr()) };
     if rc < 0 {


### PR DESCRIPTION
All our symbolization requests are funneled through our `FileCache`. Assuming "auto reloading" is enabled, we open the symbolization source in question, read its meta-data (modification time etc.), and insert a new entry only if the meta data changed.
In most cases we expect there to be no change, in which case we unnecessarily opened the file and closed it. It is more efficient to just read only its meta-data by default, but potentially do that work twice if we found that the file did indeed change.
With this change we adjust the `FileCache::entry()` method accordingly.
