### PR TITLE
Use maps file entry for in-process APK symbolization

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -561,7 +561,7 @@ impl Symbolizer {
                 file_off: u64,
                 entry_path: &EntryPath,
             ) -> Result<()> {
-                let apk_path = &entry_path.symbolic_path;
+                let apk_path = &entry_path.maps_file;
                 match self
                     .symbolizer
                     .apk_resolver(apk_path, file_off, self.debug_syms)?


### PR DESCRIPTION
It seems incorrect for us to use the symbolic path as the APK path when symbolizing an address in a process. Similar to what we do for ELF files, we should work with the maps file entry instead.