### PR TITLE
Add benchmark for normalizing without reading of build IDs

### DIFF
--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -9,8 +9,7 @@ use criterion::measurement::Measurement;
 use criterion::BenchmarkGroup;
 
 
-/// Normalize addresses in the current process.
-fn normalize_process() {
+fn normalize_process_impl(read_build_ids: bool) {
     let mut addrs = [
         libc::__errno_location as Addr,
         libc::dlopen as Addr,
@@ -20,11 +19,25 @@ fn normalize_process() {
     ];
     let () = addrs.sort();
 
-    let normalizer = Normalizer::new();
+    let normalizer = Normalizer::builder()
+        .enable_build_ids(read_build_ids)
+        .build();
     let normalized = normalizer
         .normalize_user_addrs_sorted(black_box(0.into()), black_box(addrs.as_slice()))
         .unwrap();
     assert_eq!(normalized.outputs.len(), 5);
+}
+
+
+/// Normalize addresses in the current process, and read build IDs as part of
+/// the normalization.
+fn normalize_process() {
+    normalize_process_impl(true)
+}
+
+/// Normalize addresses in the current process, but don't read build IDs.
+fn normalize_process_no_build_ids() {
+    normalize_process_impl(false)
 }
 
 pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
@@ -32,4 +45,5 @@ where
     M: Measurement,
 {
     bench_fn!(group, normalize_process);
+    bench_fn!(group, normalize_process_no_build_ids);
 }

--- a/src/breakpad/parser.rs
+++ b/src/breakpad/parser.rs
@@ -28,7 +28,6 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::mem;
 use std::ops::BitOr;

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use crate::util::Pod;
 use crate::SymType;
 


### PR DESCRIPTION
Add a benchmark for normalizing a set of addresses without reading of build IDs. This way we can easily assess the impact that reading of build IDs has on normalization performance.