### PR TITLE
cli: Add --no-build-ids option to 'normalize user' sub-command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Added support for symbolization using Breakpad (`*.sym`) files
 - Added `--no-debug-syms` option to `symbolize elf` sub-command
+- Added `--no-build-ids` option to `normalize user` sub-command
 
 
 0.1.2

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -72,6 +72,9 @@ pub struct User {
     /// The addresses to normalize.
     #[arg(value_parser = parse_addr)]
     pub addrs: Vec<Addr>,
+    /// Disable the reading of build IDs of the corresponding binaries.
+    #[clap(long)]
+    pub no_build_ids: bool,
 }
 
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -40,9 +40,15 @@ fn format_build_id(build_id: Option<&[u8]>) -> String {
 }
 
 fn normalize(normalize: args::Normalize) -> Result<()> {
-    let normalizer = Normalizer::new();
     match normalize {
-        args::Normalize::User(args::User { pid, addrs }) => {
+        args::Normalize::User(args::User {
+            pid,
+            addrs,
+            no_build_ids,
+        }) => {
+            let normalizer = Normalizer::builder()
+                .enable_build_ids(!no_build_ids)
+                .build();
             let normalized = normalizer
                 .normalize_user_addrs(pid, addrs.as_slice())
                 .context("failed to normalize addresses")?;


### PR DESCRIPTION
Introduce the --no-build-ids option to the 'normalize user' sub-command. This way, users can opt out of the reading (and reporting) of build IDs.
```
  $ cargo run -p blazecli -- normalize user --pid=236355 0x7f7aafeeb13f --no-build-ids
  > 0x007f7aafeeb13f: file offset 0x113f in /home/muellerd/local/opt/blazesym/data/libtest-so.so
```