### PR TITLE
Declare two more functions #[inline]

### DIFF
--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -118,9 +118,12 @@ impl BuildIdReader for DefaultBuildIdReader {
 pub(super) struct NoBuildIdReader;
 
 impl BuildIdReader for NoBuildIdReader {
+    #[inline]
     fn read_build_id_from_elf(_path: &Path) -> Result<Option<Vec<u8>>> {
         Ok(None)
     }
+
+    #[inline]
     fn read_build_id(_parser: &ElfParser) -> Result<Option<Vec<u8>>> {
         Ok(None)
     }


### PR DESCRIPTION
All methods on the `NoBuildIdReader` type are no-ops. As such, it's probably not a bad idea to declare them as `#[inline]`, to increase chances of them vanishing entirely.