### PR TITLE
Fix read buffer when reading `/proc/<pid>/maps`

### DIFF
--- a/src/maps.rs
+++ b/src/maps.rs
@@ -217,7 +217,9 @@ where
     R: Read,
 {
     MapsEntryIter {
-        reader: BufReader::new(reader),
+        // No real rationale for the buffer capacity, other than fixing it to a
+        // certain value and not making it too small to cause too many reads.
+        reader: BufReader::with_capacity(16 * 1024, reader),
         line: String::new(),
         pid,
     }


### PR DESCRIPTION
The standard library's BufReader currently, by default, uses an 8 KiB buffer size, but that may change in the future. Switch to specifying the capacity to use explicitly (as opposed to relying on a default) and bump it to 16 KiB, which seems like a reasonable size on today's systems (though benchmarks didn't indicate any discernible difference).