### PR TITLE
capi: Add benchmark for address normalization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,14 +246,14 @@ jobs:
       shell: bash
       run: |
         echo '```' >> $GITHUB_STEP_SUMMARY
-        cargo bench --features=nightly -- bench_ | tee --append $GITHUB_STEP_SUMMARY
+        cargo bench --workspace --features=nightly -- bench_ | tee --append $GITHUB_STEP_SUMMARY
         # We use bencher format here for better relation to the above
         # but also because it emits less other crap into our summary.
         # Note that because libtest does not understand the
         # `--output-format` option, we need to specify the benchmark
         # binary (`main`) here and have a different invocation for
         # libtest style benchmarks above. Sigh.
-        cargo bench --bench=main --features=generate-large-test-files,dont-generate-unit-test-files -- --output-format=bencher | tee --append $GITHUB_STEP_SUMMARY
+        cargo bench --workspace --bench=main --bench=capi --features=generate-large-test-files,dont-generate-unit-test-files -- --output-format=bencher | tee --append $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
   clippy:
     name: Lint with clippy

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -3,6 +3,7 @@ name = "blazesym-c"
 version = "0.0.0"
 edition = "2021"
 rust-version = "1.65"
+autobenches = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,6 +19,11 @@ check-doc-snippets = []
 # changed.
 generate-c-header = ["cbindgen", "which"]
 
+[[bench]]
+name = "capi"
+path = "benches/capi.rs"
+harness = false
+
 [build-dependencies]
 cbindgen = {version = "0.26", optional = true}
 which = {version = "6.0.0", optional = true}
@@ -29,6 +35,8 @@ memoffset = "0.9"
 
 [dev-dependencies]
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}
+# TODO: Use 0.5.2 once released.
+criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}
 env_logger = "0.10"
 libc = "0.2.137"
 test-log = {version = "0.2.13", default-features = false, features = ["trace"]}

--- a/capi/benches/capi.rs
+++ b/capi/benches/capi.rs
@@ -1,0 +1,38 @@
+#![allow(clippy::let_and_return, clippy::let_unit_value)]
+
+macro_rules! bench_fn {
+    ($group:expr, $bench_fn:ident) => {
+        $group.bench_function(crate::bench_fn_name(stringify!($bench_fn)), |b| {
+            b.iter($bench_fn)
+        });
+    };
+}
+
+
+mod normalize;
+
+use std::time::Duration;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+
+
+const BENCH_NAME_WIDTH: usize = 42;
+
+
+fn bench_fn_name(name: &str) -> String {
+    format!("{name:<BENCH_NAME_WIDTH$}")
+}
+
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("capi");
+    group.warm_up_time(Duration::from_secs(1));
+    group.confidence_level(0.98);
+    group.significance_level(0.02);
+    normalize::benchmark(&mut group);
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/capi/benches/normalize.rs
+++ b/capi/benches/normalize.rs
@@ -1,0 +1,72 @@
+#![allow(clippy::fn_to_numeric_cast)]
+
+use std::hint::black_box;
+use std::ptr;
+
+use blazesym::Addr;
+
+use blazesym_c::blaze_normalize_user_addrs_sorted;
+use blazesym_c::blaze_normalizer_free;
+use blazesym_c::blaze_normalizer_new_opts;
+use blazesym_c::blaze_normalizer_opts;
+use blazesym_c::blaze_user_output_free;
+
+use criterion::measurement::Measurement;
+use criterion::BenchmarkGroup;
+
+
+fn normalize_process_impl(read_build_ids: bool) {
+    let mut addrs = [
+        libc::__errno_location as Addr,
+        libc::dlopen as Addr,
+        libc::fopen as Addr,
+        blaze_normalizer_new_opts as Addr,
+        blaze_normalize_user_addrs_sorted as Addr,
+    ];
+    let () = addrs.sort();
+
+    let opts = blaze_normalizer_opts {
+        build_ids: read_build_ids,
+        ..Default::default()
+    };
+    let normalizer = unsafe { blaze_normalizer_new_opts(&opts) };
+    assert_ne!(normalizer, ptr::null_mut());
+
+    let pid = 0;
+    let result = unsafe {
+        blaze_normalize_user_addrs_sorted(
+            normalizer,
+            black_box(pid),
+            black_box(addrs.as_slice().as_ptr()),
+            black_box(addrs.len()),
+        )
+    };
+    assert_ne!(result, ptr::null_mut());
+
+    let user_addrs = unsafe { &*result };
+    assert_eq!(user_addrs.meta_cnt, 2);
+    assert_eq!(user_addrs.output_cnt, 5);
+
+    let () = unsafe { blaze_user_output_free(result) };
+    let () = unsafe { blaze_normalizer_free(normalizer) };
+}
+
+
+/// Normalize addresses in the current process, and read build IDs as part of
+/// the normalization.
+fn normalize_process() {
+    normalize_process_impl(true)
+}
+
+/// Normalize addresses in the current process, but don't read build IDs.
+fn normalize_process_no_build_ids() {
+    normalize_process_impl(false)
+}
+
+pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
+where
+    M: Measurement,
+{
+    bench_fn!(group, normalize_process);
+    bench_fn!(group, normalize_process_no_build_ids);
+}


### PR DESCRIPTION
This change adds a benchmark for the normalization of addresses using the C API.