### PR TITLE
Check meta count in normalization benchmarks

### DIFF
--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -25,6 +25,7 @@ fn normalize_process_impl(read_build_ids: bool) {
     let normalized = normalizer
         .normalize_user_addrs_sorted(black_box(0.into()), black_box(addrs.as_slice()))
         .unwrap();
+    assert_eq!(normalized.meta.len(), 2);
     assert_eq!(normalized.outputs.len(), 5);
 }
 


### PR DESCRIPTION
As a tiny addition, also check the meta count in the normalization benchmarks, to make sure that we get ballpark correct results.