### PR TITLE
Add Breakpad support to inspect APIs

### DIFF
--- a/src/breakpad/parser.rs
+++ b/src/breakpad/parser.rs
@@ -61,6 +61,7 @@ use nom::Needed;
 use super::types::*;
 
 use crate::error::IntoCowStr;
+use crate::once::OnceCell;
 use crate::Error;
 use crate::ErrorExt;
 use crate::Result;
@@ -651,6 +652,7 @@ impl SymbolParser {
         SymbolFile {
             files: self.files,
             functions: self.functions,
+            by_name_idx: OnceCell::new(),
             inline_origins: self.inline_origins,
         }
     }

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -25,6 +25,8 @@ use crate::Addr;
 use crate::SymType;
 
 pub use inspector::Inspector;
+#[cfg(feature = "breakpad")]
+pub use source::Breakpad;
 pub use source::Elf;
 pub use source::Source;
 

--- a/src/inspect/source.rs
+++ b/src/inspect/source.rs
@@ -2,6 +2,35 @@ use std::path::Path;
 use std::path::PathBuf;
 
 
+cfg_breakpad! {
+/// A Breakpad file.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Breakpad {
+    /// The path to the Breakpad (*.sym) file.
+    pub path: PathBuf,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
+}
+
+impl Breakpad {
+    /// Create a new [`Breakpad`] object, referencing the provided path.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<Breakpad> for Source {
+    fn from(breakpad: Breakpad) -> Self {
+        Source::Breakpad(breakpad)
+    }
+}
+}
+
+
 /// An ELF file.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Elf {
@@ -39,6 +68,10 @@ impl From<Elf> for Source {
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Source {
+    /// The source is a Breakpad file.
+    #[cfg(feature = "breakpad")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "breakpad")))]
+    Breakpad(Breakpad),
     /// The source is an ELF file.
     Elf(Elf),
 }
@@ -47,6 +80,8 @@ impl Source {
     /// Retrieve the path to the source, if it has any.
     pub fn path(&self) -> Option<&Path> {
         match self {
+            #[cfg(feature = "breakpad")]
+            Self::Breakpad(breakpad) => Some(&breakpad.path),
             Self::Elf(elf) => Some(&elf.path),
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,6 +13,30 @@ use std::path::Path;
 use std::slice;
 
 
+#[cfg(feature = "breakpad")]
+#[derive(Clone, Debug)]
+pub(crate) enum Either<A, B> {
+    A(A),
+    B(B),
+}
+
+#[cfg(feature = "breakpad")]
+impl<A, B, T> Iterator for Either<A, B>
+where
+    A: Iterator<Item = T>,
+    B: Iterator<Item = T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::A(a) => a.next(),
+            Self::B(b) => b.next(),
+        }
+    }
+}
+
+
 /// Reorder elements of `array` based on index information in `indices`.
 fn reorder<T, U>(array: &mut [T], indices: Vec<(U, usize)>) {
     debug_assert_eq!(array.len(), indices.len());


### PR DESCRIPTION
This change adds inspection support for the Breakpad format. Specifically, We support look up by name as well as iteration of symbols. Note, though, that only functions are contained in the Breakpad file, and so these are all that we support as well. And even there disclaimers abound, as GNU indirect functions, for example, are not necessarily contained and public symbols may not carry sufficient information to be reported either.