### PR TITLE
Bump version to 0.2.0-alpha.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.2.0-alpha.11
+--------------
 - Added support for Breakpad format behind `breakpad` feature (disabled
   by default)
 - Added support for usage of perf map files as part of process symbolization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
-version = "0.2.0-alpha.10"
+version = "0.2.0-alpha.11"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "=0.2.0-alpha.10"
+blazesym = "=0.2.0-alpha.11"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -30,7 +30,7 @@ which = {version = "6.0.0", optional = true}
 
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
-blazesym = {version = "=0.2.0-alpha.10", path = "../", features = ["apk", "demangle", "dwarf", "gsym"]}
+blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "demangle", "dwarf", "gsym"]}
 memoffset = "0.9"
 
 [dev-dependencies]

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 - Added support for symbolization using Breakpad (`*.sym`) files
 - Added `--no-debug-syms` option to `symbolize elf` sub-command
 - Added `--no-build-ids` option to `normalize user` sub-command
+- Bumped `blazesym` dependency to `0.2.0-alpha.11`
 
 
 0.1.2

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ grev = "0.1.3"
 
 [dependencies]
 anyhow = "1.0.68"
-blazesym = {version = "=0.2.0-alpha.10", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing"]}
+blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing"]}
 clap = {version = "4.1.7", features = ["derive"]}
 clap_complete = {version = "4.1.1", optional = true}
 tracing = "0.1"

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,5 +59,5 @@ refer to the help text (`--help`) of the `shell-complete` program for
 the list of supported shells.
 
 [blazesym]: https://crates.io/crates/blazesym
-[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.10/blazesym/symbolize/struct.Symbolizer.html
-[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.10/blazesym/symbolize/enum.Source.html#variant.Elf
+[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.11/blazesym/symbolize/struct.Symbolizer.html
+[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.11/blazesym/symbolize/enum.Source.html#variant.Elf


### PR DESCRIPTION
This change bumps the version of the crate to 0.2.0-alpha.11.