### PR TITLE
Advertise prebuilt blazecli binaries more

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,9 @@ cargo run -p blazecli -- symbolize elf --path /lib64/libc.so.6 00000000000caee1
 Please refer to its [`README`](cli/README.md) as well as the help text
 for additional information and usage instructions.
 
+Statically linked binaries for various target triples are available on-demand
+[here][blazecli-bins].
 
+
+[blazecli-bins]: https://github.com/libbpf/blazesym/actions/workflows/build.yml
 [cargo-semver]: https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility

--- a/cli/README.md
+++ b/cli/README.md
@@ -40,6 +40,9 @@ Similarly, to symbolize an address inside a process the `symbolize
 process` sub-command can be used. Please refer to the program's help
 text for additional details.
 
+Pre-built, statically linked binaries for various target triples are available
+on-demand [here][blazecli-bins].
+
 
 ### Shell Completion
 **blazecli** comes with shell completion support (for various shells). A
@@ -58,6 +61,7 @@ Completion scripts for other shells work in a similar manner. Please
 refer to the help text (`--help`) of the `shell-complete` program for
 the list of supported shells.
 
+[blazecli-bins]: https://github.com/libbpf/blazesym/actions/workflows/build.yml
 [blazesym]: https://crates.io/crates/blazesym
 [blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.11/blazesym/symbolize/struct.Symbolizer.html
 [blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.11/blazesym/symbolize/enum.Source.html#variant.Elf


### PR DESCRIPTION
Enhance the various README files with some links to our prebuilt blazecli binary CI job.