### PR TITLE
Automatically build blazecli artifacts on publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -55,3 +55,6 @@ jobs:
       run: cargo publish --package blazecli --token "${CARGO_REGISTRY_TOKEN}"
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  build-artifacts:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit


### PR DESCRIPTION
We generally can and do trigger blazecli builds manually, whenever there is a need. However, it most certainly makes sense to have artifacts around whenever we release a new version.
Automatically trigger the build workflow from the publish-cli CI job to make that happen. Note that ideally we'd attach all those build artifacts to the release, but that is a royal hassle with GitHub Actions.