### PR TITLE
Remove unnecessary cruft from test-wait.c

### DIFF
--- a/data/test-so.c
+++ b/data/test-so.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <time.h>
 
 #include "test-so.h"
 
@@ -12,8 +11,6 @@ int the_ignored_answer(void) {
 }
 
 int await_input(void) {
-  struct timespec ts = {.tv_sec = 60};
-
   fprintf(stdout, "%p\n", &await_input);
   fflush(stdout);
 


### PR DESCRIPTION
The time logic inside of test-wait.c is no longer used. Remove it.