### PR TITLE
capi: Bump version to 0.1.0-alpha.0

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,15 +1,19 @@
-Unreleased
-----------
+0.1.0-alpha.0
+-------------
 - Added constructs for forward & backward compatibility:
   - Added `type_size` member to input types and `BLAZE_INPUT` macro for
     initialization
   - Reserved trailing padding bytes to ensure zero initialization
   - Reserved space for future extension in output types
-- Added `blaze_normalizer_new_opts` function and `blaze_normalizer_opts`
-  type
+- Added `blaze_normalizer_new_opts` function and `blaze_normalizer_opts` type
 - Added `auto_reload` attribute to `blaze_symbolizer_opts`
-- Renamed various symbolization functions to closer reflect Rust
-  terminology
+- Renamed various symbolization functions to closer reflect Rust terminology
 - Renamed `BLAZE_SYM_UNKNOWN` enum variant to `BLAZE_SYM_UNDEF`
-- Added `perf_map` and `map_files` members to
-  `blaze_symbolize_src_process` type
+- Added `perf_map` and `map_files` members to `blaze_symbolize_src_process` type
+
+
+blazesym-0.2.0-alpha.8
+----------------------
+- Latest `blazesym` release containing C API bindings
+  - Moving forward these bindings will be versioned and published separately
+    from the `blazesym` Rust library

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,8 +1,28 @@
 [package]
 name = "blazesym-c"
-version = "0.0.0"
+description = "C bindings for blazesym"
+version = "0.1.0-alpha.0"
 edition = "2021"
 rust-version = "1.65"
+authors = ["Daniel Müller <deso@posteo.net>"]
+license = "BSD-3-Clause"
+repository = "https://github.com/libbpf/blazesym"
+readme = "README.md"
+categories = [
+  "algorithms",
+  "api-bindings",
+  "development-tools::debugging",
+  "os::unix-apis",
+  "value-formatting",
+]
+keywords = [
+  "dwarf",
+  "elf",
+  "gsym",
+  "stacktrace",
+  "tracing",
+]
+include = ["src/**/*", "!**/examples/**/*", "README.md", "CHANGELOG.md", "examples/input-struct-init.c", "build.rs"]
 autobenches = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This change bumps the blazesym-c's version to 0.1.0-alpha.0. The following notable changes have been made since the decoupling from blazesym proper (version 0.2.0-alpha.8):
- Added constructs for forward & backward compatibility:
  - Added type_size member to input types and BLAZE_INPUT macro for initialization
  - Reserved trailing padding bytes to ensure zero initialization
  - Reserved space for future extension in output types
- Added blaze_normalizer_new_opts function and blaze_normalizer_opts type
- Added auto_reload attribute to blaze_symbolizer_opts
- Renamed various symbolization functions to closer reflect Rust terminology
- Renamed BLAZE_SYM_UNKNOWN enum variant to BLAZE_SYM_UNDEF
- Added perf_map and map_files members to blaze_symbolize_src_process type