### PR TITLE
capi: Add crates.io version badge to README

### DIFF
--- a/capi/README.md
+++ b/capi/README.md
@@ -1,4 +1,5 @@
 [![pipeline](https://github.com/libbpf/blazesym/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/libbpf/blazesym/actions/workflows/test.yml)
+[![crates.io](https://img.shields.io/crates/v/blazesym-c.svg)](https://crates.io/crates/blazesym-c)
 [![rustc](https://img.shields.io/badge/rustc-1.65+-blue.svg)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
 
 blazesym-c


### PR DESCRIPTION
Now that we have our first "actual" release of blazesym-c, add a badge showing the version published to crates.io to the README.