### PR TITLE
capi: Include blazesym.h in published package

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Included `blazesym.h` header file in release package
+
+
 0.1.0-alpha.0
 -------------
 - Added constructs for forward & backward compatibility:

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -22,7 +22,7 @@ keywords = [
   "stacktrace",
   "tracing",
 ]
-include = ["src/**/*", "!**/examples/**/*", "README.md", "CHANGELOG.md", "examples/input-struct-init.c", "build.rs"]
+include = ["src/**/*", "include/**/*", "!**/examples/**/*", "README.md", "CHANGELOG.md", "examples/input-struct-init.c", "build.rs"]
 autobenches = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Make sure to include the blazesym.h header file in the published package, to make it easier to work with only the crates.io package, even when building a C program.