### PR TITLE
capi: Bump version to 0.1.0-alpha.1

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.0-alpha.1
+-------------
 - Included `blazesym.h` header file in release package
 
 

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym-c"
 description = "C bindings for blazesym"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Daniel Müller <deso@posteo.net>"]


### PR DESCRIPTION
This change bumps the blazesym-c's version to 0.1.0-alpha.1. The following notable changes have been made since 0.1.0-alpha.0:
- Included blazesym.h header file in release package