### PR TITLE
Remove a bunch of redundant imports

### DIFF
--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -360,11 +360,8 @@ pub unsafe extern "C" fn blaze_inspector_free(inspector: *mut blaze_inspector) {
 mod tests {
     use super::*;
 
-    use std::ffi::CStr;
-    use std::ffi::CString;
     use std::mem::MaybeUninit;
     use std::path::Path;
-    use std::ptr;
     use std::ptr::addr_of;
     use std::slice;
 

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -868,12 +868,9 @@ pub unsafe extern "C" fn blaze_result_free(results: *const blaze_result) {
 mod tests {
     use super::*;
 
-    use std::ffi::CStr;
     use std::ffi::CString;
     use std::fs::read as read_file;
     use std::hint::black_box;
-    use std::path::Path;
-    use std::ptr;
     use std::slice;
 
     use blazesym::inspect;

--- a/src/breakpad/resolver.rs
+++ b/src/breakpad/resolver.rs
@@ -218,8 +218,6 @@ impl Debug for BreakpadResolver {
 mod tests {
     use super::*;
 
-    use std::path::Path;
-
     use test_log::test;
 
     use crate::ErrorKind;

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -245,10 +245,6 @@ impl Debug for ElfResolver {
 mod tests {
     use super::*;
 
-    use std::path::Path;
-
-    use crate::dwarf::DwarfResolver;
-
 
     /// Exercise the `Debug` representation of various types.
     #[test]

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -185,7 +185,9 @@ impl Default for Inspector {
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "breakpad"))]
     use std::path::Path;
+    #[cfg(not(feature = "breakpad"))]
     use std::rc::Rc;
 
     use crate::ErrorKind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,12 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "nightly", feature(test))]
 #![cfg_attr(
-    not(all(feature = "apk", feature = "dwarf", feature = "gsym")),
+    not(all(
+        feature = "apk",
+        feature = "breakpad",
+        feature = "dwarf",
+        feature = "gsym"
+    )),
     allow(dead_code, unused_imports)
 )]
 

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1173,12 +1173,9 @@ mod tests {
 
     use std::mem::transmute;
 
-    use crate::elf::ElfParser;
     use crate::inspect::FindAddrOpts;
-    use crate::mmap::Mmap;
     use crate::symbolize;
     use crate::symbolize::CodeInfo;
-    use crate::symbolize::Symbolizer;
     use crate::SymType;
 
     use test_log::test;

--- a/src/util.rs
+++ b/src/util.rs
@@ -392,7 +392,6 @@ impl<'data> ReadRaw<'data> for &'data [u8] {
 mod tests {
     use super::*;
 
-    use std::cmp::Ordering;
     #[cfg(feature = "nightly")]
     use std::hint::black_box;
     use std::os::fd::AsRawFd as _;


### PR DESCRIPTION
We have a bunch of redundant imports in test modules that were not flagged by earlier version of rustc. Remove them so that once we upgrade we don't see any warnings/errors.