### PR TITLE
Revert "Pin nightly toolchain in CI"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,9 +100,7 @@ jobs:
        LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: nightly-2024-02-04
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - name: Check incremental rebuilds
@@ -123,9 +121,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: nightly-2024-02-04
+    - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
     - uses: actions/setup-python@v5
       id: py312
@@ -156,9 +152,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: nightly-2024-02-04
+    - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.sanitizer }}
@@ -202,9 +196,8 @@ jobs:
       MIRIFLAGS: '-Zmiri-disable-stacked-borrows'
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly-2024-02-04
         components: miri
     # Miri would honor our custom test runner, but doesn't work with it. We
     # could conceivably override that by specifying
@@ -236,9 +229,7 @@ jobs:
        LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: nightly-2024-02-04
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Nightly Rust has been fixed and the issue necessitating pinning the version is no longer present. Revert the change pinning the version.

This reverts commit db01d98008ad09c2683490ae21eedba218f91aa2.