### PR TITLE
Downgrade addrs: A bound of normalize_sorted_user_addrs_with_entries()

### DIFF
--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -189,7 +189,7 @@ pub(crate) fn normalize_sorted_user_addrs_with_entries<A, E, H, D>(
     data: D,
 ) -> Result<H>
 where
-    A: ExactSizeIterator<Item = Addr> + Clone,
+    A: Iterator<Item = Addr> + Clone,
     E: Iterator<Item = Result<maps::MapsEntry>>,
     H: Handler<D>,
     D: Clone,


### PR DESCRIPTION
Downgrade the addresses iterator from an `ExactSizeIterator` to a more generic one, as there is no need to know the iterator's size inside the function.