### PR TITLE
Adjust normalize_sorted_user_addrs_with_entries() to work with &mut Handler

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -669,7 +669,7 @@ impl Symbolizer {
         }
 
         let entries = maps::parse(pid)?;
-        let handler = SymbolizeHandler {
+        let mut handler = SymbolizeHandler {
             symbolizer: self,
             pid,
             debug_syms,
@@ -681,13 +681,14 @@ impl Symbolizer {
         let handler = util::with_ordered_elems(
             addrs,
             |handler: &mut SymbolizeHandler<'_>| handler.all_symbols.as_mut_slice(),
-            |sorted_addrs| {
-                normalize_sorted_user_addrs_with_entries(
+            |sorted_addrs| -> Result<SymbolizeHandler<'_>> {
+                let () = normalize_sorted_user_addrs_with_entries(
                     sorted_addrs,
                     entries,
-                    handler,
+                    &mut handler,
                     Reason::Unmapped,
-                )
+                )?;
+                Ok(handler)
             },
         )?;
         Ok(handler.all_symbols)


### PR DESCRIPTION
The normalize_sorted_user_addrs_with_entries() currently accepts a Handler and returns said Handler once done. That's a reasonable pattern to employ conceptually, but it makes it hard to use dynamic dispatch on the handler, as that would require boxing the object in the return position.
With this change we switch the
normalize_sorted_user_addrs_with_entries() function over to accepting a &mut Handler instead, removing the return argument in the process. In so doing we sidestep this issue and open the door for using runtime dispatch moving forward.