### PR TITLE
Adjust normalize_sorted_user_addrs_with_entries() to work with dyn Ha…

### DIFF
--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -182,16 +182,15 @@ where
 }
 
 
-pub(crate) fn normalize_sorted_user_addrs_with_entries<A, E, H, D>(
+pub(crate) fn normalize_sorted_user_addrs_with_entries<A, E, D>(
     addrs: A,
     entries: E,
-    handler: &mut H,
+    handler: &mut dyn Handler<D>,
     data: D,
 ) -> Result<()>
 where
     A: Iterator<Item = Addr> + Clone,
     E: Iterator<Item = Result<maps::MapsEntry>>,
-    H: Handler<D>,
     D: Clone,
 {
     let mut entries = entries.filter_map(|result| match result {


### PR DESCRIPTION
…ndler

The machinery backing normalize_sorted_user_addrs_with_entries() is increasing in size and with every variation of generic input arguments we end up with a potentially huge swath of code being duplicated for monomorphization.
With this change we convert the handler argument to a dynamically dispatched one, eliminating one potential reason for duplication in the process.