### PR TITLE
Use Iterator trait object for MapsEntry sequence

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -668,7 +668,7 @@ impl Symbolizer {
             }
         }
 
-        let entries = maps::parse(pid)?;
+        let mut entries = maps::parse(pid)?;
         let mut handler = SymbolizeHandler {
             symbolizer: self,
             pid,
@@ -684,7 +684,7 @@ impl Symbolizer {
             |sorted_addrs| -> Result<SymbolizeHandler<'_>> {
                 let () = normalize_sorted_user_addrs_with_entries(
                     sorted_addrs,
-                    entries,
+                    &mut entries,
                     &mut handler,
                     Reason::Unmapped,
                 )?;


### PR DESCRIPTION
Similar to what we did earlier for the handler argument to the normalize_sorted_user_addrs_with_entries() function, this change causes us to use a trait object and dynamic dispatch for the MapsEntry iterator argument. In so doing we open the door for using the same instance of the function for different MapsEntry iterator types, minimizing the potential for binary bloat.