### PR TITLE
Optionally cache parsed `/proc/<pid>/maps` entries during normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added `cache_maps` property to `normalize::Normalizer` type
 - Reduced number of allocations performed on address normalization and
   process symbolization paths
 

--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -52,10 +52,24 @@ where
     normalize_process_impl(&normalizer, b)
 }
 
+/// Normalize addresses in the current process, read and parse the
+/// `/proc/self/maps` file only once, and don't read build IDs.
+fn normalize_process_no_build_ids_cached<M>(b: &mut Bencher<'_, M>)
+where
+    M: Measurement,
+{
+    let normalizer = Normalizer::builder()
+        .enable_maps_caching(true)
+        .enable_build_ids(false)
+        .build();
+    normalize_process_impl(&normalizer, b)
+}
+
 pub fn benchmark<M>(group: &mut BenchmarkGroup<'_, M>)
 where
     M: Measurement,
 {
     bench_sub_fn!(group, normalize_process);
     bench_sub_fn!(group, normalize_process_no_build_ids);
+    bench_sub_fn!(group, normalize_process_no_build_ids_cached);
 }

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `cache_maps` attribute to `blaze_normalizer_opts`
+
+
 0.1.0-alpha.1
 -------------
 - Included `blazesym.h` header file in release package

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -151,6 +151,15 @@ typedef struct blaze_normalizer_opts {
    */
   size_t type_size;
   /**
+   * Whether or not to cache `/proc/<pid>/maps` contents.
+   *
+   * Setting this flag to `true` is not generally recommended, because it
+   * could result in addresses corresponding to mappings added after caching
+   * may not be normalized successfully, as there is no reasonable way of
+   * detecting staleness.
+   */
+  bool cache_maps;
+  /**
    * Whether to read and report build IDs as part of the normalization
    * process.
    */
@@ -159,7 +168,7 @@ typedef struct blaze_normalizer_opts {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[7];
+  uint8_t reserved[6];
 } blaze_normalizer_opts;
 
 /**

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -17,7 +17,7 @@ use crate::Pid;
 use crate::Result;
 
 
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct EntryPath {
     /// The path of the file backing the maps entry via a
     /// `/proc/<xxx>/map_files/` component.
@@ -36,7 +36,7 @@ pub(crate) struct EntryPath {
 
 /// The "pathname" component in a proc maps entry. See `proc(5)` section
 /// `/proc/[pid]/maps`.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum PathName {
     Path(EntryPath),
     Component(String),
@@ -61,6 +61,7 @@ impl PathName {
 }
 
 
+#[derive(Clone)]
 pub(crate) struct MapsEntry {
     /// The virtual address range covered by this entry.
     pub range: Range<Addr>,

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -360,6 +360,7 @@ mod tests {
 
         let normalizer = Normalizer::builder().enable_maps_caching(true).build();
         test(&normalizer);
+        test(&normalizer);
     }
 
     /// Check that we can normalize user addresses in our own shared object.

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -189,11 +189,6 @@ where
     A: Iterator<Item = Addr> + Clone,
     D: Clone,
 {
-    let mut entries = entries.filter_map(|result| match result {
-        Ok(entry) => maps::filter_map_relevant(entry).map(Ok),
-        Err(err) => Some(Err(err)),
-    });
-
     let mut entry = entries.next().ok_or_else(|| {
         Error::new(
             ErrorKind::UnexpectedEof,
@@ -290,7 +285,11 @@ mod tests {
             let pid = Pid::Slf;
             let addrs = [unknown_addr as Addr];
 
-            let mut entries = maps::parse_file(maps.as_bytes(), pid);
+            let mut entries =
+                maps::parse_file(maps.as_bytes(), pid).filter_map(|result| match result {
+                    Ok(entry) => maps::filter_map_relevant(entry).map(Ok),
+                    Err(err) => Some(Err(err)),
+                });
             let mut handler = NormalizationHandler::<NoBuildIdReader>::new(addrs.len());
             let () = normalize_sorted_user_addrs_with_entries(
                 addrs.as_slice().iter().copied(),

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -6,7 +6,7 @@ use std::process;
 
 
 /// An enumeration identifying a process.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Pid {
     /// The current process.
     Slf,


### PR DESCRIPTION
This change adds the necessary logic for caching the parsed
`/proc/<pid>/maps` data on a per-process basis, when the Normalizer's
'reevaluate_maps' property is `false`.
Having caching in place can help speed up repeated address normalization
for the process, but because there does not appear to be a way to detect
up-to-dateness of the cached `/proc/<pid>/maps`, there exists the
potential for correctness issues.

```
  main/normalize_process
       time:   [36.494 µs 37.249 µs 38.141 µs]

  main/normalize_process_no_build_ids
       time:   [28.232 µs 28.482 µs 28.709 µs]

  main/normalize_process_no_build_ids_cached
       time:   [1.1735 µs 1.1839 µs 1.1934 µs]
```
