### PR TITLE
Add infrastructure for capturing allocation statistics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Enable backtraces for panics but not for "regular" errors.
   RUST_BACKTRACE: 1
+  RUST_LIB_BACKTRACE: 0
   RUSTFLAGS: '-D warnings'
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ blazesym = {path = ".", features = ["generate-unit-test-files", "apk", "breakpad
 # TODO: Use 0.5.2 once released.
 criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}
 scopeguard = "1.2"
+stats_alloc = {version = "0.1.1", features = ["nightly"]}
 tempfile = "3.4"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
 

--- a/tests/allocs.rs
+++ b/tests/allocs.rs
@@ -1,0 +1,85 @@
+#![allow(
+    clippy::fn_to_numeric_cast,
+    clippy::let_and_return,
+    clippy::let_unit_value
+)]
+
+use std::alloc::GlobalAlloc;
+use std::alloc::Layout;
+use std::alloc::System;
+use std::backtrace::Backtrace;
+use std::backtrace::BacktraceStatus;
+use std::hint::black_box;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread_local;
+
+use blazesym::normalize::Normalizer;
+use blazesym::Addr;
+
+use stats_alloc::Region;
+use stats_alloc::StatsAlloc;
+
+#[global_allocator]
+static GLOBAL: StatsAlloc<TracingAlloc> = StatsAlloc::new(TracingAlloc);
+
+thread_local! {
+  static TRACING: AtomicBool = AtomicBool::new(false);
+}
+
+
+/// An allocator that prints a backtrace for each allocation being made.
+struct TracingAlloc;
+
+unsafe impl GlobalAlloc for TracingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // Capturing a backtrace will allocate itself. Prevent infinite
+        // recursion with a flag.
+        if !TRACING.with(|tracing| tracing.swap(true, Ordering::Relaxed)) {
+            let bt = Backtrace::capture();
+            if let BacktraceStatus::Captured = bt.status() {
+                println!("{layout:?}:\n{bt}");
+            }
+            let () = TRACING.with(|tracing| tracing.store(false, Ordering::Relaxed));
+        }
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+}
+
+
+/// Normalize addresses in the current process and print allocation
+/// statistics.
+#[test]
+fn normalize_process() {
+    let region = Region::new(&GLOBAL);
+
+    {
+        let normalizer = Normalizer::builder().build();
+        let mut addrs = [
+            libc::__errno_location as Addr,
+            libc::dlopen as Addr,
+            libc::fopen as Addr,
+            normalize_process as Addr,
+            Normalizer::normalize_user_addrs_sorted as Addr,
+        ];
+        let () = addrs.sort();
+
+        let normalized = normalizer
+            .normalize_user_addrs_sorted(black_box(0.into()), black_box(addrs.as_slice()))
+            .unwrap();
+        assert_eq!(normalized.meta.len(), 2);
+        assert_eq!(normalized.outputs.len(), 5);
+    }
+
+    // We can't make many assumptions about the allocations here,
+    // because a lot of it is system dependent. E.g., more entries in
+    // `/proc/<pid>/maps` likely means more allocations. Even the order
+    // may have an influence, to the point that ASLR could change
+    // results.
+    let stats = region.change();
+    println!("Stats: {stats:#?}");
+}


### PR DESCRIPTION
This change adds some infrastructure that we can use for capturing memory allocation statistics. As a first step we capture such statistics for the address normalization path. We include the means for printing backtraces for each allocation being made, which can help with better understanding the reported numbers.

```
  > $ cargo test --test=allocs -- normalize_process --nocapture
  > Stats: Stats {
  >   allocations: 47,
  >   deallocations: 47,
  >   reallocations: 11,
  >   bytes_allocated: 19742,
  >   bytes_deallocated: 19742,
  >   bytes_reallocated: 540,
  > }
  > $ RUST_BACKTRACE=1 cargo test --test=allocs -- normalize_process --nocapture
  > ...
```