### PR TITLE
Reduce number of allocations for address normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Reduced number of allocations performed on address normalization and
+  process symbolization paths
+
+
 0.2.0-alpha.11
 --------------
 - Added support for Breakpad format behind `breakpad` feature (disabled

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -92,11 +92,14 @@ impl Debug for MapsEntry {
 fn parse_maps_line<'line>(line: &'line str, pid: Pid) -> Result<MapsEntry> {
     let full_line = line;
 
-    let split_once = |line: &'line str, component| -> Result<(&'line str, &'line str)> {
+    let split_once_opt = |line: &'line str| -> Option<(&'line str, &'line str)> {
         line.split_once(|c: char| c.is_ascii_whitespace())
-            .ok_or_invalid_data(|| {
-                format!("failed to find {component} in proc maps line: {line}\n{full_line}")
-            })
+    };
+
+    let split_once = |line: &'line str, component| -> Result<(&'line str, &'line str)> {
+        split_once_opt(line).ok_or_invalid_data(|| {
+            format!("failed to find {component} in proc maps line: {line}\n{full_line}")
+        })
     };
 
     // Lines have the following format:
@@ -141,7 +144,7 @@ fn parse_maps_line<'line>(line: &'line str, pid: Pid) -> Result<MapsEntry> {
     let (_dev, line) = split_once(line, "device component")?;
     // Note that by design, a path may not be present and so we may not be able
     // to successfully split.
-    let path_str = split_once(line, "inode component")
+    let path_str = split_once_opt(line)
         .map(|(_inode, line)| line.trim())
         .unwrap_or("");
 


### PR DESCRIPTION
The last component in a /proc/<pid>/maps line is optional. We treat it this way, but by using the split_once() function, which produces nice errors, we unnecessarily create an Error object just to throw it away subsequently. Because Errors are heap allocated, we incur some heap allocations on the happy path, which is not the intention. Remove them by working only with Option objects at the location in question. For the normalize_process test, this reduces the number of allocations by 20 (47 down to 27) on my system:

```
  > $ cargo test --test=allocs -- normalize_process --nocapture
  > Stats: Stats {
  >     allocations: 27,
  >     deallocations: 27,
  >     reallocations: 7,
  >     bytes_allocated: 18322,
  >     bytes_deallocated: 18322,
  >     bytes_reallocated: 252,
  > }
```