### PR TITLE
Fix 'cblazesym' mention in documentation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -591,7 +591,7 @@ impl ErrorExt for io::Error {
 }
 
 
-/// A trait providing conversion shortcuts for creating `Error`
+/// A trait providing conversion shortcuts for creating [`Error`]
 /// instances.
 pub trait IntoError<T>: private::Sealed
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@
 //! - [`normalize`] exposes address normalization functionality
 //!
 //! C API bindings are defined in a cross-cutting manner as part of the
-//! `cblazesym` crate (note that Rust code should not have to consume
-//! these functions and on the ABI level this module organization has no
+//! `blazesym-c` crate (note that Rust code should not have to consume
+//! these functions and at the ABI level this module organization has no
 //! relevance for C).
 
 #![allow(


### PR DESCRIPTION
There is no cblazesym crate, it is now called blazesym-c. Fix the typo and clean up a few other minor bits.