### PR TITLE
Optimize cached address normalization further

### DIFF
--- a/src/maps.rs
+++ b/src/maps.rs
@@ -70,6 +70,13 @@ pub(crate) struct MapsEntry {
     pub path_name: Option<PathName>,
 }
 
+impl AsRef<MapsEntry> for MapsEntry {
+    #[inline]
+    fn as_ref(&self) -> &MapsEntry {
+        self
+    }
+}
+
 impl Debug for MapsEntry {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let Self {

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -668,7 +668,7 @@ impl Symbolizer {
             }
         }
 
-        let mut entries = maps::parse(pid)?;
+        let entries = maps::parse(pid)?;
         let mut handler = SymbolizeHandler {
             symbolizer: self,
             pid,
@@ -684,7 +684,7 @@ impl Symbolizer {
             |sorted_addrs| -> Result<SymbolizeHandler<'_>> {
                 let () = normalize_sorted_user_addrs_with_entries(
                     sorted_addrs,
-                    &mut entries,
+                    entries,
                     &mut handler,
                     Reason::Unmapped,
                 )?;


### PR DESCRIPTION
This change optimizes the normalization of addresses using cached /proc/<pid>/maps entries further. Specifically, we eliminate the clone of the potentially large MapsEntry object, which involves a bunch of heap allocations.
In order to do so we end up going back to a world where normalization functions accept the MapsEntry iterator as a generic argument as opposed to a trait object, because doing so allows us to abstract over ownership using the AsRef trait.
As a result of this work, we improve the performance of this path by close to 35%:

```
  > main/normalize_process_no_build_ids_cached
  >      time:   [621.76 ns 624.34 ns 627.07 ns]
  >      change: [−35.120% −34.666% −34.255%] (p = 0.00 < 0.02)
  >      Performance has improved.
```