### PR TITLE
Factor out maps::parse_filtered() helper

### DIFF
--- a/src/maps.rs
+++ b/src/maps.rs
@@ -260,6 +260,16 @@ pub(crate) fn filter_map_relevant(entry: MapsEntry) -> Option<MapsEntry> {
     }
 }
 
+/// Parse the maps file for the process with the given PID and make sure
+/// to filter out unnecessary entries by applying `filter_map_relevant`.
+pub(crate) fn parse_filtered(pid: Pid) -> Result<impl Iterator<Item = Result<MapsEntry>>> {
+    let entries = parse(pid)?.filter_map(|result| match result {
+        Ok(entry) => filter_map_relevant(entry).map(Ok),
+        Err(err) => Some(Err(err)),
+    });
+    Ok(entries)
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -183,21 +183,14 @@ impl Normalizer {
         A: ExactSizeIterator<Item = Addr> + Clone,
     {
         if !self.cache_maps {
-            let entries = maps::parse(pid)?.filter_map(|result| match result {
-                Ok(entry) => maps::filter_map_relevant(entry).map(Ok),
-                Err(err) => Some(Err(err)),
-            });
+            let entries = maps::parse_filtered(pid)?;
             self.normalize_user_addrs_impl(addrs, entries)
         } else {
             let parsed = self.cached_entries.get_or_try_insert(pid, || {
                 // If we use the cached maps entries but don't have anything
                 // cached yet, then just parse the file eagerly and take it from
                 // there.
-                let parsed = maps::parse(pid)?
-                    .filter_map(|result| match result {
-                        Ok(entry) => maps::filter_map_relevant(entry).map(Ok),
-                        Err(err) => Some(Err(err)),
-                    })
+                let parsed = maps::parse_filtered(pid)?
                     .collect::<Result<Vec<_>>>()?
                     .into_boxed_slice();
                 Result::<Box<[maps::MapsEntry]>>::Ok(parsed)


### PR DESCRIPTION
The normalization logic uses the
```
  maps::parse(..)
    .filter_map(..
       maps::filter_map_relevant(entry)
    ..)
```
construct in two locations. Let's introduce the maps::parse_filtered() helper to simplify the code at these two call sites.