### PR TITLE
capi: Include link to documentation in generated header

### DIFF
--- a/capi/build.rs
+++ b/capi/build.rs
@@ -143,9 +143,21 @@ fn main() {
         use std::fs::copy;
         use std::fs::write;
 
+        let mut config = cbindgen::Config::from_root_or_default(&crate_dir);
+        config.header = Some(format!(
+            r#"/*
+ * Please refer to the documentation hosted at
+ *
+ *   https://docs.rs/{name}/{version}
+ */
+"#,
+            name = env::var("CARGO_PKG_NAME").unwrap(),
+            version = env::var("CARGO_PKG_VERSION").unwrap(),
+        ));
+
         cbindgen::Builder::new()
             .with_crate(&crate_dir)
-            .with_config(cbindgen::Config::from_root_or_default(&crate_dir))
+            .with_config(config)
             .generate()
             .expect("Unable to generate bindings")
             .write_to_file(crate_dir.join("include").join("blazesym.h"));

--- a/capi/cbindgen.toml
+++ b/capi/cbindgen.toml
@@ -2,6 +2,8 @@
 
 language = "C"
 cpp_compat = true
+# The header attribute is set in the build script.
+#header = "/* ... */"
 include_guard = "__blazesym_h_"
 usize_is_size_t = true
 after_includes = """\

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1,3 +1,10 @@
+/*
+ * Please refer to the documentation hosted at
+ *
+ *   https://docs.rs/blazesym-c/0.1.0-alpha.1
+ */
+
+
 #ifndef __blazesym_h_
 #define __blazesym_h_
 


### PR DESCRIPTION
We don't really want users to understand the generated header file as the library's documentation (despite it coming with some explanations), because links won't be resolved and additional context won't be provided.
With this change we make sure to include a link to the docs.rs documentation prominently at the top of the header file.