### PR TITLE
Fix normalizer maps caching default value

### DIFF
--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -86,7 +86,7 @@ impl Builder {
 impl Default for Builder {
     fn default() -> Self {
         Self {
-            cache_maps: true,
+            cache_maps: false,
             build_ids: true,
         }
     }


### PR DESCRIPTION
We intended for the maps caching to be disabled by default, but missed to negate the value when negating the associated flag's meaning ("reevaluate_maps" -> "cache_maps"). Make caching disabled by default.