### PR TITLE
Add support for caching build IDs in address normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
-- Added `cache_maps` property to `normalize::Normalizer` type
+- Added `cache_maps` and `cache_build_ids` properties to `normalize::Normalizer`
+  type
 - Introduced `normalize::Reason` enum to provide best guess at why normalization
   was not successful as part of the `normalize::UserMeta::Unknown` variant
 - Reduced number of allocations performed on address normalization and

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -203,10 +203,15 @@ typedef struct blaze_normalizer_opts {
    */
   bool build_ids;
   /**
+   * Whether or not to cache build IDs. This flag only has an effect
+   * if build ID reading is enabled in the first place.
+   */
+  bool cache_build_ids;
+  /**
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[6];
+  uint8_t reserved[5];
 } blaze_normalizer_opts;
 
 /**

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -46,9 +46,12 @@ pub struct blaze_normalizer_opts {
     /// Whether to read and report build IDs as part of the normalization
     /// process.
     pub build_ids: bool,
+    /// Whether or not to cache build IDs. This flag only has an effect
+    /// if build ID reading is enabled in the first place.
+    pub cache_build_ids: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 6],
+    pub reserved: [u8; 5],
 }
 
 impl Default for blaze_normalizer_opts {
@@ -57,7 +60,8 @@ impl Default for blaze_normalizer_opts {
             type_size: size_of::<Self>(),
             cache_maps: false,
             build_ids: false,
-            reserved: [0; 6],
+            cache_build_ids: false,
+            reserved: [0; 5],
         }
     }
 }
@@ -96,12 +100,14 @@ pub unsafe extern "C" fn blaze_normalizer_new_opts(
         type_size: _,
         cache_maps,
         build_ids,
+        cache_build_ids,
         reserved: _,
     } = opts;
 
     let normalizer = Normalizer::builder()
         .enable_maps_caching(cache_maps)
         .enable_build_ids(build_ids)
+        .enable_build_id_caching(cache_build_ids)
         .build();
     let normalizer_box = Box::new(normalizer);
     Box::into_raw(normalizer_box)

--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -94,19 +94,12 @@ fn read_build_id_impl(parser: &ElfParser) -> Result<Option<Vec<u8>>> {
 
 pub(super) trait BuildIdReader {
     fn read_build_id_from_elf(&self, path: &Path) -> Result<Option<Vec<u8>>>;
-    fn read_build_id(&self, parser: &ElfParser) -> Result<Option<Vec<u8>>>;
 }
 
 
 pub(super) struct DefaultBuildIdReader;
 
 impl BuildIdReader for DefaultBuildIdReader {
-    /// Attempt to read an ELF binary's build ID.
-    #[cfg_attr(feature = "tracing", crate::log::instrument(skip(self)))]
-    fn read_build_id(&self, parser: &ElfParser) -> Result<Option<Vec<u8>>> {
-        read_build_id_impl(parser)
-    }
-
     /// Attempt to read an ELF binary's build ID from a file.
     #[cfg_attr(feature = "tracing", crate::log::instrument(skip(self)))]
     fn read_build_id_from_elf(&self, path: &Path) -> Result<Option<Vec<u8>>> {
@@ -121,11 +114,6 @@ pub(super) struct NoBuildIdReader;
 impl BuildIdReader for NoBuildIdReader {
     #[inline]
     fn read_build_id_from_elf(&self, _path: &Path) -> Result<Option<Vec<u8>>> {
-        Ok(None)
-    }
-
-    #[inline]
-    fn read_build_id(&self, _parser: &ElfParser) -> Result<Option<Vec<u8>>> {
         Ok(None)
     }
 }

--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -93,7 +93,7 @@ fn read_build_id_impl(parser: &ElfParser) -> Result<Option<Vec<u8>>> {
 }
 
 pub(super) trait BuildIdReader {
-    fn read_build_id_from_elf(&self, path: &Path) -> Result<Option<Vec<u8>>>;
+    fn read_build_id(&self, path: &Path) -> Result<Option<Vec<u8>>>;
 }
 
 
@@ -102,7 +102,7 @@ pub(super) struct DefaultBuildIdReader;
 impl BuildIdReader for DefaultBuildIdReader {
     /// Attempt to read an ELF binary's build ID from a file.
     #[cfg_attr(feature = "tracing", crate::log::instrument(skip(self)))]
-    fn read_build_id_from_elf(&self, path: &Path) -> Result<Option<Vec<u8>>> {
+    fn read_build_id(&self, path: &Path) -> Result<Option<Vec<u8>>> {
         let parser = ElfParser::open(path)?;
         read_build_id_impl(&parser)
     }
@@ -113,7 +113,7 @@ pub(super) struct NoBuildIdReader;
 
 impl BuildIdReader for NoBuildIdReader {
     #[inline]
-    fn read_build_id_from_elf(&self, _path: &Path) -> Result<Option<Vec<u8>>> {
+    fn read_build_id(&self, _path: &Path) -> Result<Option<Vec<u8>>> {
         Ok(None)
     }
 }

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -26,7 +26,7 @@ use super::Reason;
 fn make_elf_meta(entry_path: &EntryPath, build_id_reader: &dyn BuildIdReader) -> Result<UserMeta> {
     let elf = Elf {
         path: entry_path.symbolic_path.to_path_buf(),
-        build_id: build_id_reader.read_build_id_from_elf(&entry_path.maps_file)?,
+        build_id: build_id_reader.read_build_id(&entry_path.maps_file)?,
         _non_exhaustive: (),
     };
     let meta = UserMeta::Elf(elf);


### PR DESCRIPTION
Build ID caching, on top of normalization reason logic (https://github.com/libbpf/blazesym/pull/560).

Benchmark results:
```
      > main/normalize_process_uncached_build_ids_uncached_maps
      >     time:   [32.616 µs 32.638 µs 32.666 µs]
      > main/normalize_process_uncached_build_ids_cached_maps
      >     time:   [20.211 µs 20.251 µs 20.303 µs]
      > main/normalize_process_cached_build_ids_uncached_maps
      >     time:   [52.176 µs 52.275 µs 52.403 µs]
      > main/normalize_process_cached_build_ids_cached_maps
      >     time:   [3.4718 µs 3.4760 µs 3.4808 µs]
      > main/normalize_process_no_build_ids_uncached_maps
      >     time:   [29.789 µs 29.812 µs 29.846 µs]
      > main/normalize_process_no_build_ids_cached_maps
      >     time:   [921.03 ns 921.65 ns 922.41 ns]
```