### PR TITLE
capi: Add CHANGELOG entry for #569

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 - Added `cache_maps` attribute to `blaze_normalizer_opts`
 - Introduced `blaze_normalize_reason` type and extended
   - Added `reason` attribute to `blaze_user_meta_unknown`
+- Added `blaze_symbolize_elf_file_offsets` function for symbolization of
+  file offsets
 
 
 0.1.0-alpha.1


### PR DESCRIPTION
This change adds a CHANGELOG entry for the contribution made over in #569.