### PR TITLE
Increase benchmark name width constant

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -26,7 +26,7 @@ use criterion::criterion_main;
 use criterion::Criterion;
 
 
-const BENCH_NAME_WIDTH: usize = 42;
+const BENCH_NAME_WIDTH: usize = 52;
 
 
 fn bench_fn_name(name: &str) -> String {


### PR DESCRIPTION
With the recent addition of longer named benchmarks for the normalization functionality, we reached and exceeded our previously set name width, causing the summary to look somewhat garbled. Increase the constant to make things look nice again.