### PR TITLE
Update README-devel to suggest testing the entire workspace

### DIFF
--- a/README-devel.md
+++ b/README-devel.md
@@ -15,7 +15,7 @@ $ cargo check --package blazesym-c --features=generate-c-header
 ## Testing
 All our testing is `cargo` based and a simple
 ```sh
-$ cargo test
+$ cargo test --workspace
 ```
 runs the vast majority of tests. Tests require `sudo` to be set up properly, as
 some of the functionality we rely on is privileged. Test artifacts are


### PR DESCRIPTION
The suggestion of running `cargo test` to test "everything" isn't really accurate anymore, because of the split into multiple crates a while back.
Let's suggest the usage of `cargo test --workspace` instead, making it obvious that there is more than just the core library.