### PR TITLE
Use dump_syms::Config::with_output() constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ tempfile = "3.4"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
 
 [build-dependencies]
-dump_syms = {version = "2.2", optional = true, default-features = false}
+dump_syms = {version = "2.3", optional = true, default-features = false}
 libc = "0.2.137"
 reqwest = {version = "0.11.18", optional = true, features = ["blocking"]}
 xz2 = {version = "0.1.7", optional = true}

--- a/build.rs
+++ b/build.rs
@@ -208,8 +208,6 @@ fn dwarf(src: &Path, dst: impl AsRef<OsStr>) {
 /// Generate a Breakpad .sym file for the given source.
 #[cfg(feature = "dump_syms")]
 fn syms(src: &Path, dst: impl AsRef<OsStr>) {
-    use std::env::consts::ARCH;
-
     use dump_syms::dumper;
     use dump_syms::dumper::Config;
     use dump_syms::dumper::FileOutput;
@@ -217,20 +215,9 @@ fn syms(src: &Path, dst: impl AsRef<OsStr>) {
 
     let dst = src.with_file_name(dst);
 
-    let config = Config {
-        output: Output::File(FileOutput::Path(dst)),
-        symbol_server: None,
-        debug_id: None,
-        code_id: None,
-        arch: ARCH,
-        num_jobs: 1,
-        check_cfi: false,
-        emit_inlines: true,
-        mapping_var: None,
-        mapping_src: None,
-        mapping_dest: None,
-        mapping_file: None,
-    };
+    let mut config = Config::with_output(Output::File(FileOutput::Path(dst)));
+    config.check_cfi = false;
+
     let path = src.to_str().unwrap();
     let () = dumper::single_file(&config, path).unwrap();
 }


### PR DESCRIPTION
As part of https://github.com/mozilla/dump_syms/pull/667 the Config::with_output() constructor was introduced as a short hand to exhaustively specifying all fields. This functionality is now contained in version 2.3 of the crate.
This change adjusts our build script to use it.