### PR TITLE
capi: Document normalizer/symbolizer/inspector creation APIs a bit more

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -720,6 +720,8 @@ void blaze_inspect_syms_free(const struct blaze_sym_info *const *syms);
  *
  * The returned pointer should be released using
  * [`blaze_inspector_free`] once it is no longer needed.
+ *
+ * C ABI compatible version of [`blazesym::inspect::Inspector::new()`].
  */
 blaze_inspector *blaze_inspector_new(void);
 
@@ -740,6 +742,9 @@ void blaze_inspector_free(blaze_inspector *inspector);
  *
  * The returned pointer should be released using [`blaze_normalizer_free`] once
  * it is no longer needed.
+ *
+ * C ABI compatible version of [`blazesym::normalize::Normalizer::new()`].
+ * Please refer to its documentation for the default configuration in use.
  */
 blaze_normalizer *blaze_normalizer_new(void);
 
@@ -825,6 +830,9 @@ void blaze_user_output_free(struct blaze_normalized_user_output *output);
 
 /**
  * Create an instance of a symbolizer.
+ *
+ * C ABI compatible version of [`blazesym::symbolize::Symbolizer::new()`].
+ * Please refer to its documentation for the default configuration in use.
  */
 blaze_symbolizer *blaze_symbolizer_new(void);
 

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -330,6 +330,8 @@ pub unsafe extern "C" fn blaze_inspect_syms_free(syms: *const *const blaze_sym_i
 ///
 /// The returned pointer should be released using
 /// [`blaze_inspector_free`] once it is no longer needed.
+///
+/// C ABI compatible version of [`blazesym::inspect::Inspector::new()`].
 #[no_mangle]
 pub extern "C" fn blaze_inspector_new() -> *mut blaze_inspector {
     let inspector = Inspector::new();

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -72,6 +72,9 @@ impl Default for blaze_normalizer_opts {
 ///
 /// The returned pointer should be released using [`blaze_normalizer_free`] once
 /// it is no longer needed.
+///
+/// C ABI compatible version of [`blazesym::normalize::Normalizer::new()`].
+/// Please refer to its documentation for the default configuration in use.
 #[no_mangle]
 pub extern "C" fn blaze_normalizer_new() -> *mut blaze_normalizer {
     let normalizer = Normalizer::new();

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -455,6 +455,9 @@ impl Default for blaze_symbolizer_opts {
 
 
 /// Create an instance of a symbolizer.
+///
+/// C ABI compatible version of [`blazesym::symbolize::Symbolizer::new()`].
+/// Please refer to its documentation for the default configuration in use.
 #[no_mangle]
 pub extern "C" fn blaze_symbolizer_new() -> *mut blaze_symbolizer {
     let symbolizer = Symbolizer::new();


### PR DESCRIPTION
Improve the documentation of the normalizer/symbolizer/inspector creation APIs, so that it is easier to find out what default options are enabled or not.