### PR TITLE
Use const block in thread_local! macro

### DIFF
--- a/tests/allocs.rs
+++ b/tests/allocs.rs
@@ -24,7 +24,7 @@ use stats_alloc::StatsAlloc;
 static GLOBAL: StatsAlloc<TracingAlloc> = StatsAlloc::new(TracingAlloc);
 
 thread_local! {
-  static TRACING: AtomicBool = AtomicBool::new(false);
+  static TRACING: AtomicBool = const { AtomicBool::new(false) };
 }
 
 


### PR DESCRIPTION
Use a const block in our usage of the thread_local! macro to silence a newly reported warning [0].

[0] https://rust-lang.github.io/rust-clippy/master/index.html#/thread_local_initializer_can_be_made_const