### PR TITLE
Adjust wording in normalizer documentation slightly

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -51,6 +51,7 @@ which = {version = "6.0.0", optional = true}
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
 blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "demangle", "dwarf", "gsym"]}
+# TODO: Remove dependency one MSRV is 1.77.
 memoffset = "0.9"
 
 [dev-dependencies]

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -118,15 +118,15 @@ impl GsymContext<'_> {
 
             let slf = GsymContext {
                 header: Header {
-                    magic,
-                    version,
+                    _magic: magic,
+                    _version: version,
                     addr_off_size,
-                    uuid_size,
+                    _uuid_size: uuid_size,
                     base_address,
                     num_addrs,
-                    strtab_offset,
-                    strtab_size,
-                    uuid,
+                    _strtab_offset: strtab_offset,
+                    _strtab_size: strtab_size,
+                    _uuid: uuid,
                 },
                 addr_tab,
                 addr_data_off_tab,
@@ -230,11 +230,7 @@ pub fn parse_address_data(mut data: &[u8]) -> impl Iterator<Item = AddrData> {
         // We don't validate `typ` here, because callers will have to dispatch
         // on it anyway.
 
-        Some(AddrData {
-            typ,
-            length: len,
-            data: d,
-        })
+        Some(AddrData { typ, data: d })
     })
 }
 
@@ -364,15 +360,15 @@ mod tests {
 
         let context = GsymContext {
             header: Header {
-                magic: 1196644685,
-                version: 1,
+                _magic: 1196644685,
+                _version: 1,
                 addr_off_size: 2,
-                uuid_size: 20,
+                _uuid_size: 20,
                 base_address: 0,
                 num_addrs: 27,
-                strtab_offset: 224,
-                strtab_size: 697,
-                uuid: [
+                _strtab_offset: 224,
+                _strtab_size: 697,
+                _uuid: [
                     120, 151, 243, 48, 221, 52, 78, 164, 192, 149, 35, 25, 172, 82, 70, 123, 125,
                     239, 78, 50,
                 ],

--- a/src/gsym/types.rs
+++ b/src/gsym/types.rs
@@ -6,15 +6,15 @@ pub const GSYM_VERSION: u16 = 1;
 
 /// GSYM File Header
 pub struct Header {
-    pub magic: u32,
-    pub version: u16,
+    pub _magic: u32,
+    pub _version: u16,
     pub addr_off_size: u8,
-    pub uuid_size: u8,
+    pub _uuid_size: u8,
     pub base_address: u64,
     pub num_addrs: u32,
-    pub strtab_offset: u32,
-    pub strtab_size: u32,
-    pub uuid: [u8; 20],
+    pub _strtab_offset: u32,
+    pub _strtab_size: u32,
+    pub _uuid: [u8; 20],
 }
 
 #[repr(C)]
@@ -36,7 +36,6 @@ pub struct AddrInfo<'a> {
 pub struct AddrData<'a> {
     /// The data type. Its value should be one of `INFO_TYPE_*`.
     pub typ: u32,
-    pub length: u32,
     pub data: &'a [u8],
 }
 

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -192,24 +192,6 @@ impl Normalizer {
         Ok(handler.normalized)
     }
 
-    /// Normalize all `addrs` in a given process to the corresponding file
-    /// offsets, which are suitable for later symbolization. The `addrs`
-    /// array has to be sorted in ascending order or an error will be
-    /// returned.
-    ///
-    /// Unknown addresses are not normalized. They are reported as
-    /// [`Unknown`] meta entries in the returned [`UserOutput`]
-    /// object. The cause of an address to be unknown (and, hence, not
-    /// normalized), could have a few reasons, including, but not limited
-    /// to:
-    /// - user error (if a bogus address was provided)
-    /// - they belonged to an ELF object that has been unmapped since the
-    ///   address was captured
-    ///
-    /// The process' ID should be provided in `pid`.
-    ///
-    /// File offsets are reported in the exact same order in which the
-    /// non-normalized addresses were provided.
     fn normalize_user_addrs_iter<A>(&self, addrs: A, pid: Pid) -> Result<UserOutput>
     where
         A: ExactSizeIterator<Item = Addr> + Clone,
@@ -235,11 +217,12 @@ impl Normalizer {
 
     /// Normalize addresses belonging to a process.
     ///
-    /// Normalize all `addrs` in a given process. The `addrs` array has
-    /// to be sorted in ascending order or an error will be returned. By
-    /// providing a pre-sorted array the library does not have to sort
-    /// internally, which will result in quicker normalization. If you
-    /// don't have sorted addresses, use
+    /// Normalize all `addrs` in a given process to their corresponding
+    /// file offsets, which are suitable for later symbolization. The
+    /// `addrs` array has to be sorted in ascending order or an error
+    /// will be returned. By providing a pre-sorted array the library
+    /// does not have to sort internally, which will result in quicker
+    /// normalization. If you don't have sorted addresses, use
     /// [`Normalizer::normalize_user_addrs`] instead.
     ///
     /// Unknown addresses are not normalized. They are reported as
@@ -253,8 +236,8 @@ impl Normalizer {
     ///
     /// The process' ID should be provided in `pid`.
     ///
-    /// Normalized addresses are reported in the exact same order in which the
-    /// non-normalized ones were provided.
+    /// Normalized outputs are reported in the exact same order (and in
+    /// equal amount) in which the non-normalized ones were provided.
     #[cfg_attr(feature = "tracing", crate::log::instrument(skip(self)))]
     pub fn normalize_user_addrs_sorted(&self, pid: Pid, addrs: &[Addr]) -> Result<UserOutput> {
         self.normalize_user_addrs_iter(addrs.iter().copied(), pid)


### PR DESCRIPTION
Improve a few minor details with the normalization API documentation and remove unnecessary documentation for some internal helper function, which does not really differ from its public counter part.