### PR TITLE
capi: Remove `BLAZE_INPUT` macro

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
   - Added `reason` attribute to `blaze_user_meta_unknown`
 - Added `blaze_symbolize_elf_file_offsets` function for symbolization of
   file offsets
+- Removed `BLAZE_INPUT` macro
 
 
 0.1.0-alpha.1

--- a/capi/cbindgen.toml
+++ b/capi/cbindgen.toml
@@ -6,19 +6,6 @@ cpp_compat = true
 #header = "/* ... */"
 include_guard = "__blazesym_h_"
 usize_is_size_t = true
-after_includes = """\
-/* Helper macro to declare and initialize a blazesym input struct.
- *
- * Inspired by `LIBBPF_OPTS` macro provided by libbpf.
- */
-#define BLAZE_INPUT(TYPE, NAME, ...)        \\
-  struct TYPE NAME = ({                     \\
-    (struct TYPE) {                         \\
-      .type_size = sizeof(struct TYPE),     \\
-      __VA_ARGS__                           \\
-    };                                      \\
-  })
-"""
 
 [export]
 item_types = ["globals", "enums", "structs", "unions", "typedefs", "opaque", "functions"]

--- a/capi/examples/input-struct-init.c
+++ b/capi/examples/input-struct-init.c
@@ -1,9 +1,9 @@
-#include <string.h>
 #include "blazesym.h"
 
 int main(int argc, const char* argv[]) {
-  BLAZE_INPUT(blaze_inspect_elf_src, src,
+  blaze_inspect_elf_src src = {
+    .type_size = sizeof(src),
     .path = "/tmp/some/dir/test.bin",
     .debug_syms = true,
-  );
+  };
 }

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -13,18 +13,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
-/* Helper macro to declare and initialize a blazesym input struct.
- *
- * Inspired by `LIBBPF_OPTS` macro provided by libbpf.
- */
-#define BLAZE_INPUT(TYPE, NAME, ...)        \
-  struct TYPE NAME = ({                     \
-    (struct TYPE) {                         \
-      .type_size = sizeof(struct TYPE),     \
-      __VA_ARGS__                           \
-    };                                      \
-  })
-
 
 /**
  * The reason why normalization failed.

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -14,8 +14,7 @@
 //! The library aims to provide forward compatibility with newer
 //! versions and backward compatibility with older ones. To make that
 //! happen, relevant types that are being passed to the library contain
-//! the `type_size` member that is to be set to the type's size. The
-//! `BLAZE_INPUT` macro can be used for convenient initialization:
+//! the `type_size` member that is to be set to the type's size, e.g.:
 //! ```c
 #![doc = include_str!("../examples/input-struct-init.c")]
 //! ```


### PR DESCRIPTION
The macro no longer adds any value as we can just rely on padding bytes being zero initialized because they are explicitly declared now. Instead just obfuscates what is going on. Remove it.