### PR TITLE
Introduce `blaze_err` enum and adjusted all fallible functions to return it

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Introduced `blaze_err` enum and adjusted all fallible functions to
   set a thread local error
   - Introduced `blaze_err_last` to retrieve the last error
+  - Introduced `blaze_err_str` function to convert errors to textual
+    representation
 - Introduced `blaze_normalize_reason` type and extended
   - Added `reason` attribute to `blaze_user_meta_unknown`
 - Added `blaze_symbolize_elf_file_offsets` function for symbolization of

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 - Added `cache_maps` attribute to `blaze_normalizer_opts`
+- Introduced `blaze_err` enum and adjusted all fallible functions to
+  set a thread local error
+  - Introduced `blaze_err_last` to retrieve the last error
 - Introduced `blaze_normalize_reason` type and extended
   - Added `reason` attribute to `blaze_user_meta_unknown`
 - Added `blaze_symbolize_elf_file_offsets` function for symbolization of

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -15,6 +15,75 @@
 #include <stdlib.h>
 
 /**
+ * An enum providing a rough classification of errors.
+ *
+ * C ABI compatible version of [`blazesym::ErrorKind`].
+ */
+typedef enum blaze_err {
+  /**
+   * The operation was successful.
+   */
+  BLAZE_ERR_OK = 0,
+  /**
+   * An entity was not found, often a file.
+   */
+  BLAZE_ERR_NOT_FOUND = -2,
+  /**
+   * The operation lacked the necessary privileges to complete.
+   */
+  BLAZE_ERR_PERMISSION_DENIED = -1,
+  /**
+   * An entity already exists, often a file.
+   */
+  BLAZE_ERR_ALREADY_EXISTS = -17,
+  /**
+   * The operation needs to block to complete, but the blocking
+   * operation was requested to not occur.
+   */
+  BLAZE_ERR_WOULD_BLOCK = -11,
+  /**
+   * Data not valid for the operation were encountered.
+   */
+  BLAZE_ERR_INVALID_DATA = -22,
+  /**
+   * The I/O operation's timeout expired, causing it to be canceled.
+   */
+  BLAZE_ERR_TIMED_OUT = -110,
+  /**
+   * This operation is unsupported on this platform.
+   */
+  BLAZE_ERR_UNSUPPORTED = -95,
+  /**
+   * An operation could not be completed, because it failed
+   * to allocate enough memory.
+   */
+  BLAZE_ERR_OUT_OF_MEMORY = -12,
+  /**
+   * A parameter was incorrect.
+   */
+  BLAZE_ERR_INVALID_INPUT = -256,
+  /**
+   * An error returned when an operation could not be completed
+   * because a call to [`write`] returned [`Ok(0)`].
+   */
+  BLAZE_ERR_WRITE_ZERO = -257,
+  /**
+   * An error returned when an operation could not be completed
+   * because an "end of file" was reached prematurely.
+   */
+  BLAZE_ERR_UNEXPECTED_EOF = -258,
+  /**
+   * DWARF input data was invalid.
+   */
+  BLAZE_ERR_INVALID_DWARF = -259,
+  /**
+   * A custom error that does not fall under any other I/O error
+   * kind.
+   */
+  BLAZE_ERR_OTHER = -260,
+} blaze_err;
+
+/**
  * The reason why normalization failed.
  *
  * The reason is generally only meant as a hint. Reasons reported may change
@@ -671,6 +740,11 @@ typedef struct blaze_symbolize_src_gsym_file {
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
+
+/**
+ * Retrieve the error reported by the last fallible API function invoked.
+ */
+enum blaze_err blaze_err_last(void);
 
 /**
  * Lookup symbol information in an ELF file.

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -780,10 +780,17 @@ void blaze_inspect_syms_free(const struct blaze_sym_info *const *syms);
 /**
  * Create an instance of a blazesym inspector.
  *
- * The returned pointer should be released using
+ * C ABI compatible version of [`blazesym::inspect::Inspector::new()`].
+ * Please refer to its documentation for the default configuration in
+ * use.
+ *
+ * On success, the function creates a new [`blaze_inspector`] object
+ * and returns it. The resulting object should be released using
  * [`blaze_inspector_free`] once it is no longer needed.
  *
- * C ABI compatible version of [`blazesym::inspect::Inspector::new()`].
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  */
 blaze_inspector *blaze_inspector_new(void);
 

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -807,25 +807,35 @@ blaze_inspector *blaze_inspector_new(void);
 void blaze_inspector_free(blaze_inspector *inspector);
 
 /**
- * Create an instance of a blazesym normalizer.
- *
- * The returned pointer should be released using [`blaze_normalizer_free`] once
- * it is no longer needed.
+ * Create an instance of a blazesym normalizer in the default
+ * configuration.
  *
  * C ABI compatible version of [`blazesym::normalize::Normalizer::new()`].
  * Please refer to its documentation for the default configuration in use.
+ *
+ * On success, the function creates a new [`blaze_normalizer`] object and
+ * returns it. The resulting object should be released using
+ * [`blaze_normalizer_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  */
 blaze_normalizer *blaze_normalizer_new(void);
 
 /**
  * Create an instance of a blazesym normalizer.
  *
- * The returned pointer should be released using [`blaze_normalizer_free`] once
- * it is no longer needed.
+ * On success, the function creates a new [`blaze_normalizer`] object and
+ * returns it. The resulting object should be released using
+ * [`blaze_normalizer_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * The provided pointer needs to point to a valid [`blaze_normalizer_opts`]
- * instance.
+ * - `opts` needs to point to a valid [`blaze_normalizer_opts`] object
  */
 blaze_normalizer *blaze_normalizer_new_opts(const struct blaze_normalizer_opts *opts);
 

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -965,15 +965,18 @@ void blaze_symbolizer_free(blaze_symbolizer *symbolizer);
 /**
  * Symbolize a list of process absolute addresses.
  *
- * Return an array of [`blaze_result`] with the same size as the number
- * of input addresses. The caller should free the returned array by
- * calling [`blaze_result_free`].
+ * On success, the function returns an array of [`blaze_result`] with
+ * `abs_addr_cnt` elements. The returned object should be released using
+ * [`blaze_result_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
- * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blaze_symbolize_src_process`] object. `addrs` must represent an array of
- * `addr_cnt` objects.
+ * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
+ * - `src` needs to point to a valid [`blaze_symbolize_src_process`] object
+ * -`abs_addrs` point to an array of `abs_addr_cnt` addresses
  */
 const struct blaze_result *blaze_symbolize_process_abs_addrs(blaze_symbolizer *symbolizer,
                                                              const struct blaze_symbolize_src_process *src,
@@ -983,15 +986,18 @@ const struct blaze_result *blaze_symbolize_process_abs_addrs(blaze_symbolizer *s
 /**
  * Symbolize a list of kernel absolute addresses.
  *
- * Return an array of [`blaze_result`] with the same size as the number
- * of input addresses. The caller should free the returned array by
- * calling [`blaze_result_free`].
+ * On success, the function returns an array of [`blaze_result`] with
+ * `abs_addr_cnt` elements. The returned object should be released using
+ * [`blaze_result_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
- * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blaze_symbolize_src_kernel`] object. `addrs` must represent an array of
- * `addr_cnt` objects.
+ * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
+ * - `src` needs to point to a valid [`blaze_symbolize_src_kernel`] object
+ * -`abs_addrs` point to an array of `abs_addr_cnt` addresses
  */
 const struct blaze_result *blaze_symbolize_kernel_abs_addrs(blaze_symbolizer *symbolizer,
                                                             const struct blaze_symbolize_src_kernel *src,
@@ -1001,15 +1007,18 @@ const struct blaze_result *blaze_symbolize_kernel_abs_addrs(blaze_symbolizer *sy
 /**
  * Symbolize virtual offsets in an ELF file.
  *
- * Return an array of [`blaze_result`] with the same size as the number
- * of input addresses. The caller should free the returned array by
- * calling [`blaze_result_free`].
+ * On success, the function returns an array of [`blaze_result`] with
+ * `virt_offset_cnt` elements. The returned object should be released using
+ * [`blaze_result_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
- * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blaze_symbolize_src_elf`] object. `addrs` must represent an array of
- * `addr_cnt` objects.
+ * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
+ * - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
+ * -`virt_offsets` point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_result *blaze_symbolize_elf_virt_offsets(blaze_symbolizer *symbolizer,
                                                             const struct blaze_symbolize_src_elf *src,
@@ -1019,15 +1028,18 @@ const struct blaze_result *blaze_symbolize_elf_virt_offsets(blaze_symbolizer *sy
 /**
  * Symbolize file offsets in an ELF file.
  *
- * Return an array of [`blaze_result`] with the same size as the number
- * of input addresses. The caller should free the returned array by
- * calling [`blaze_result_free`].
+ * On success, the function returns an array of [`blaze_result`] with
+ * `file_offset_cnt` elements. The returned object should be released using
+ * [`blaze_result_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
- * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blaze_symbolize_src_elf`] object. `addrs` must represent an array of
- * `addr_cnt` objects.
+ * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
+ * - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
+ * -`file_offsets` point to an array of `file_offset_cnt` addresses
  */
 const struct blaze_result *blaze_symbolize_elf_file_offsets(blaze_symbolizer *symbolizer,
                                                             const struct blaze_symbolize_src_elf *src,
@@ -1037,15 +1049,18 @@ const struct blaze_result *blaze_symbolize_elf_file_offsets(blaze_symbolizer *sy
 /**
  * Symbolize virtual offsets using "raw" Gsym data.
  *
- * Return an array of [`blaze_result`] with the same size as the
- * number of input addresses. The caller should free the returned array by
- * calling [`blaze_result_free`].
+ * On success, the function returns an array of [`blaze_result`] with
+ * `virt_offset_cnt` elements. The returned object should be released using
+ * [`blaze_result_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
- * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blaze_symbolize_src_gsym_data`] object. `addrs` must represent an array of
- * `addr_cnt` objects.
+ * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
+ * - `src` needs to point to a valid [`blaze_symbolize_src_gsym_data`] object
+ * -`virt_offsets` point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_result *blaze_symbolize_gsym_data_virt_offsets(blaze_symbolizer *symbolizer,
                                                                   const struct blaze_symbolize_src_gsym_data *src,
@@ -1055,15 +1070,18 @@ const struct blaze_result *blaze_symbolize_gsym_data_virt_offsets(blaze_symboliz
 /**
  * Symbolize virtual offsets in a Gsym file.
  *
- * Return an array of [`blaze_result`] with the same size as the number
- * of input addresses. The caller should free the returned array by
- * calling [`blaze_result_free`].
+ * On success, the function returns an array of [`blaze_result`] with
+ * `virt_offset_cnt` elements. The returned object should be released using
+ * [`blaze_result_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * `symbolizer` must have been allocated using [`blaze_symbolizer_new`] or
- * [`blaze_symbolizer_new_opts`]. `src` must point to a valid
- * [`blaze_symbolize_src_gsym_file`] object. `addrs` must represent an array of
- * `addr_cnt` objects.
+ * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
+ * - `src` needs to point to a valid [`blaze_symbolize_src_gsym_file`] object
+ * -`virt_offsets` point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_result *blaze_symbolize_gsym_file_virt_offsets(blaze_symbolizer *symbolizer,
                                                                   const struct blaze_symbolize_src_gsym_file *src,

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -747,6 +747,11 @@ extern "C" {
 enum blaze_err blaze_err_last(void);
 
 /**
+ * Retrieve a textual representation of the error code, if any.
+ */
+const char *blaze_err_str(enum blaze_err err);
+
+/**
  * Lookup symbol information in an ELF file.
  *
  * On success, returns an array with `name_cnt` elements. Each such element, in

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -854,19 +854,27 @@ void blaze_normalizer_free(blaze_normalizer *normalizer);
 /**
  * Normalize a list of user space addresses.
  *
+ * C ABI compatible version of [`Normalizer::normalize_user_addrs`].
+ *
+ * `pid` should describe the PID of the process to which the addresses
+ * belongs. It may be `0` if they belong to the calling process.
+ *
+ * On success, the function creates a new [`blaze_normalized_user_output`]
+ * object and returns it. The resulting object should be released using
+ * [`blaze_user_output_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
+ *
  * Contrary to [`blaze_normalize_user_addrs_sorted`] the provided
  * `addrs` array does not have to be sorted, but otherwise the
  * functions behave identically. If you happen to know that `addrs` is
  * sorted, using [`blaze_normalize_user_addrs_sorted`] instead will
  * result in slightly faster normalization.
  *
- * C ABI compatible version of [`Normalizer::normalize_user_addrs`].
- * Returns `NULL` on error. The resulting object should be freed using
- * [`blaze_user_output_free`].
- *
  * # Safety
- * Callers need to pass in a valid `addrs` pointer, pointing to memory of
- * `addr_cnt` addresses.
+ * - `addrs` needs to be a valid pointer to `addr_cnt` addresses
  */
 struct blaze_normalized_user_output *blaze_normalize_user_addrs(const blaze_normalizer *normalizer,
                                                                 uint32_t pid,
@@ -876,21 +884,26 @@ struct blaze_normalized_user_output *blaze_normalize_user_addrs(const blaze_norm
 /**
  * Normalize a list of user space addresses.
  *
+ * C ABI compatible version of [`Normalizer::normalize_user_addrs_sorted`].
+ *
+ * `pid` should describe the PID of the process to which the addresses
+ * belongs. It may be `0` if they belong to the calling process.
+ *
  * The `addrs` array has to be sorted in ascending order. By providing
  * a pre-sorted array the library does not have to sort internally,
  * which will result in quicker normalization. If you don't have sorted
  * addresses, use [`blaze_normalize_user_addrs`] instead.
  *
- * `pid` should describe the PID of the process to which the addresses
- * belongs. It may be `0` if they belong to the calling process.
+ * On success, the function creates a new [`blaze_normalized_user_output`]
+ * object and returns it. The resulting object should be released using
+ * [`blaze_user_output_free`] once it is no longer needed.
  *
- * C ABI compatible version of [`Normalizer::normalize_user_addrs_sorted`].
- * Returns `NULL` on error. The resulting object should be freed using
- * [`blaze_user_output_free`].
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * Callers need to pass in a valid `addrs` pointer, pointing to memory of
- * `addr_cnt` addresses.
+ * - `addrs` needs to be a valid pointer to `addr_cnt` addresses
  */
 struct blaze_normalized_user_output *blaze_normalize_user_addrs_sorted(const blaze_normalizer *normalizer,
                                                                        uint32_t pid,

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -749,19 +749,19 @@ enum blaze_err blaze_err_last(void);
 /**
  * Lookup symbol information in an ELF file.
  *
- * Return an array with the same size as the input names. The caller should
- * free the returned array by calling [`blaze_inspect_syms_free`].
+ * On success, returns an array with `name_cnt` elements. Each such element, in
+ * turn, is NULL terminated array comprised of each symbol found. The returned
+ * object should be released using [`blaze_inspect_syms_free`] once it is no
+ * longer needed.
  *
- * Every name in the input name list may have more than one address.
- * The respective entry in the returned array is an array containing
- * all addresses and ended with a null (0x0).
- *
- * The returned pointer should be freed by [`blaze_inspect_syms_free`].
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  *
  * # Safety
- * The `inspector` object should have been created using
- * [`blaze_inspector_new`], `src` needs to point to a valid object, and `names`
- * needs to be a valid pointer to `name_cnt` strings.
+ * - `inspector` needs to point to an initialized [`blaze_inspector`] object
+ * - `src` needs to point to an initialized [`blaze_inspect_syms_elf`] object
+ * - `names` needs to be a valid pointer to `name_cnt` NUL terminated strings
  */
 const struct blaze_sym_info *const *blaze_inspect_syms_elf(const blaze_inspector *inspector,
                                                            const struct blaze_inspect_elf_src *src,

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -895,14 +895,30 @@ void blaze_user_output_free(struct blaze_normalized_user_output *output);
  *
  * C ABI compatible version of [`blazesym::symbolize::Symbolizer::new()`].
  * Please refer to its documentation for the default configuration in use.
+ *
+ * On success, the function creates a new [`blaze_symbolizer`] object
+ * and returns it. The resulting object should be released using
+ * [`blaze_symbolizer_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
  */
 blaze_symbolizer *blaze_symbolizer_new(void);
 
 /**
  * Create an instance of a symbolizer with configurable options.
  *
+ * On success, the function creates a new [`blaze_symbolizer`] object
+ * and returns it. The resulting object should be released using
+ * [`blaze_symbolizer_free`] once it is no longer needed.
+ *
+ * On error, the function returns `NULL` and sets the thread's last error to
+ * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+ * error.
+ *
  * # Safety
- * `opts` needs to be a valid pointer.
+ * - `opts` needs to point to a valid [`blaze_symbolizer_opts`] object
  */
 blaze_symbolizer *blaze_symbolizer_new_opts(const struct blaze_symbolizer_opts *opts);
 

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -24,7 +24,11 @@ use blazesym::inspect::SymInfo;
 use blazesym::Addr;
 use blazesym::SymType;
 
+use crate::blaze_err;
+#[cfg(doc)]
+use crate::blaze_err_last;
 use crate::from_cstr;
+use crate::set_last_err;
 use crate::slice_from_user_array;
 
 
@@ -328,14 +332,22 @@ pub unsafe extern "C" fn blaze_inspect_syms_free(syms: *const *const blaze_sym_i
 
 /// Create an instance of a blazesym inspector.
 ///
-/// The returned pointer should be released using
+/// C ABI compatible version of [`blazesym::inspect::Inspector::new()`].
+/// Please refer to its documentation for the default configuration in
+/// use.
+///
+/// On success, the function creates a new [`blaze_inspector`] object
+/// and returns it. The resulting object should be released using
 /// [`blaze_inspector_free`] once it is no longer needed.
 ///
-/// C ABI compatible version of [`blazesym::inspect::Inspector::new()`].
+/// On error, the function returns `NULL` and sets the thread's last error to
+/// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+/// error.
 #[no_mangle]
 pub extern "C" fn blaze_inspector_new() -> *mut blaze_inspector {
     let inspector = Inspector::new();
     let inspector_box = Box::new(inspector);
+    let () = set_last_err(blaze_err::BLAZE_ERR_OK);
     Box::into_raw(inspector_box)
 }
 

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -590,6 +590,28 @@ mod tests {
         let () = unsafe { blaze_inspector_free(inspector) };
     }
 
+    /// Check that we see the expected error being reported when a source file
+    /// does not exist.
+    #[test]
+    fn non_present_file() {
+        let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("data")
+            .join("does-not-exist");
+
+        let src = blaze_inspect_elf_src::from(Elf::new(path));
+        let factorial = CString::new("factorial").unwrap();
+        let names = [factorial.as_ptr()];
+        let inspector = blaze_inspector_new();
+
+        let result =
+            unsafe { blaze_inspect_syms_elf(inspector, &*src, names.as_ptr(), names.len()) };
+        let () = unsafe { ManuallyDrop::into_inner(src).free() };
+        assert_eq!(result, ptr::null());
+
+        let () = unsafe { blaze_inspector_free(inspector) };
+    }
+
     /// Make sure that we can lookup a function's address using DWARF
     /// information.
     #[test]

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -266,19 +266,19 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
 
 /// Lookup symbol information in an ELF file.
 ///
-/// Return an array with the same size as the input names. The caller should
-/// free the returned array by calling [`blaze_inspect_syms_free`].
+/// On success, returns an array with `name_cnt` elements. Each such element, in
+/// turn, is NULL terminated array comprised of each symbol found. The returned
+/// object should be released using [`blaze_inspect_syms_free`] once it is no
+/// longer needed.
 ///
-/// Every name in the input name list may have more than one address.
-/// The respective entry in the returned array is an array containing
-/// all addresses and ended with a null (0x0).
-///
-/// The returned pointer should be freed by [`blaze_inspect_syms_free`].
+/// On error, the function returns `NULL` and sets the thread's last error to
+/// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+/// error.
 ///
 /// # Safety
-/// The `inspector` object should have been created using
-/// [`blaze_inspector_new`], `src` needs to point to a valid object, and `names`
-/// needs to be a valid pointer to `name_cnt` strings.
+/// - `inspector` needs to point to an initialized [`blaze_inspector`] object
+/// - `src` needs to point to an initialized [`blaze_inspect_syms_elf`] object
+/// - `names` needs to be a valid pointer to `name_cnt` NUL terminated strings
 #[no_mangle]
 pub unsafe extern "C" fn blaze_inspect_syms_elf(
     inspector: *const blaze_inspector,
@@ -287,6 +287,7 @@ pub unsafe extern "C" fn blaze_inspect_syms_elf(
     name_cnt: usize,
 ) -> *const *const blaze_sym_info {
     if !input_zeroed!(src, blaze_inspect_elf_src) {
+        let () = set_last_err(blaze_err::BLAZE_ERR_INVALID_INPUT);
         return ptr::null()
     }
     let src = input_sanitize!(src, blaze_inspect_elf_src);
@@ -307,8 +308,15 @@ pub unsafe extern "C" fn blaze_inspect_syms_elf(
         .collect::<Vec<_>>();
     let result = inspector.lookup(&src, &names);
     match result {
-        Ok(syms) => convert_syms_list_to_c(syms),
-        Err(_err) => ptr::null(),
+        Ok(syms) => {
+            let sym_info = convert_syms_list_to_c(syms);
+            let () = set_last_err(blaze_err::BLAZE_ERR_OK);
+            sym_info
+        }
+        Err(err) => {
+            let () = set_last_err(err.kind().into());
+            ptr::null()
+        }
     }
 }
 

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -152,6 +152,11 @@ pub extern "C" fn blaze_err_last() -> blaze_err {
     LAST_ERR.with(|cell| cell.get())
 }
 
+/// Retrieve the error reported by the last fallible API function invoked.
+fn set_last_err(err: blaze_err) {
+    LAST_ERR.with(|cell| cell.set(err))
+}
+
 /// Check whether the given piece of memory is zeroed out.
 ///
 /// # Safety

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -493,19 +493,27 @@ impl blaze_normalized_user_output {
 
 /// Normalize a list of user space addresses.
 ///
+/// C ABI compatible version of [`Normalizer::normalize_user_addrs`].
+///
+/// `pid` should describe the PID of the process to which the addresses
+/// belongs. It may be `0` if they belong to the calling process.
+///
+/// On success, the function creates a new [`blaze_normalized_user_output`]
+/// object and returns it. The resulting object should be released using
+/// [`blaze_user_output_free`] once it is no longer needed.
+///
+/// On error, the function returns `NULL` and sets the thread's last error to
+/// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+/// error.
+///
 /// Contrary to [`blaze_normalize_user_addrs_sorted`] the provided
 /// `addrs` array does not have to be sorted, but otherwise the
 /// functions behave identically. If you happen to know that `addrs` is
 /// sorted, using [`blaze_normalize_user_addrs_sorted`] instead will
 /// result in slightly faster normalization.
 ///
-/// C ABI compatible version of [`Normalizer::normalize_user_addrs`].
-/// Returns `NULL` on error. The resulting object should be freed using
-/// [`blaze_user_output_free`].
-///
 /// # Safety
-/// Callers need to pass in a valid `addrs` pointer, pointing to memory of
-/// `addr_cnt` addresses.
+/// - `addrs` needs to be a valid pointer to `addr_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_normalize_user_addrs(
     normalizer: *const blaze_normalizer,
@@ -521,31 +529,43 @@ pub unsafe extern "C" fn blaze_normalize_user_addrs(
     let addrs = unsafe { slice_from_user_array(addrs, addr_cnt) };
     let result = normalizer.normalize_user_addrs(pid.into(), addrs);
     match result {
-        Ok(addrs) => Box::into_raw(Box::new(ManuallyDrop::into_inner(
-            blaze_normalized_user_output::from(addrs),
-        ))),
-        Err(_err) => ptr::null_mut(),
+        Ok(addrs) => {
+            let output_box = Box::new(ManuallyDrop::into_inner(
+                blaze_normalized_user_output::from(addrs),
+            ));
+            let () = set_last_err(blaze_err::BLAZE_ERR_OK);
+            Box::into_raw(output_box)
+        }
+        Err(err) => {
+            let () = set_last_err(err.kind().into());
+            ptr::null_mut()
+        }
     }
 }
 
 
 /// Normalize a list of user space addresses.
 ///
+/// C ABI compatible version of [`Normalizer::normalize_user_addrs_sorted`].
+///
+/// `pid` should describe the PID of the process to which the addresses
+/// belongs. It may be `0` if they belong to the calling process.
+///
 /// The `addrs` array has to be sorted in ascending order. By providing
 /// a pre-sorted array the library does not have to sort internally,
 /// which will result in quicker normalization. If you don't have sorted
 /// addresses, use [`blaze_normalize_user_addrs`] instead.
 ///
-/// `pid` should describe the PID of the process to which the addresses
-/// belongs. It may be `0` if they belong to the calling process.
+/// On success, the function creates a new [`blaze_normalized_user_output`]
+/// object and returns it. The resulting object should be released using
+/// [`blaze_user_output_free`] once it is no longer needed.
 ///
-/// C ABI compatible version of [`Normalizer::normalize_user_addrs_sorted`].
-/// Returns `NULL` on error. The resulting object should be freed using
-/// [`blaze_user_output_free`].
+/// On error, the function returns `NULL` and sets the thread's last error to
+/// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
+/// error.
 ///
 /// # Safety
-/// Callers need to pass in a valid `addrs` pointer, pointing to memory of
-/// `addr_cnt` addresses.
+/// - `addrs` needs to be a valid pointer to `addr_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_normalize_user_addrs_sorted(
     normalizer: *const blaze_normalizer,
@@ -561,12 +581,20 @@ pub unsafe extern "C" fn blaze_normalize_user_addrs_sorted(
     let addrs = unsafe { slice_from_user_array(addrs, addr_cnt) };
     let result = normalizer.normalize_user_addrs_sorted(pid.into(), addrs);
     match result {
-        Ok(addrs) => Box::into_raw(Box::new(ManuallyDrop::into_inner(
-            blaze_normalized_user_output::from(addrs),
-        ))),
-        Err(_err) => ptr::null_mut(),
+        Ok(addrs) => {
+            let output_box = Box::new(ManuallyDrop::into_inner(
+                blaze_normalized_user_output::from(addrs),
+            ));
+            let () = set_last_err(blaze_err::BLAZE_ERR_OK);
+            Box::into_raw(output_box)
+        }
+        Err(err) => {
+            let () = set_last_err(err.kind().into());
+            ptr::null_mut()
+        }
     }
 }
+
 
 /// Free an object as returned by [`blaze_normalize_user_addrs`] or
 /// [`blaze_normalize_user_addrs_sorted`].

--- a/src/error.rs
+++ b/src/error.rs
@@ -310,6 +310,28 @@ pub enum ErrorKind {
     Other,
 }
 
+impl ErrorKind {
+    #[doc(hidden)]
+    #[inline]
+    pub fn as_bytes(&self) -> &'static [u8] {
+        match self {
+            Self::AlreadyExists => b"entity already exists\0",
+            Self::InvalidData => b"invalid data\0",
+            Self::InvalidInput => b"invalid input parameter\0",
+            Self::NotFound => b"entity not found\0",
+            Self::Other => b"other error\0",
+            Self::OutOfMemory => b"out of memory\0",
+            Self::PermissionDenied => b"permission denied\0",
+            Self::TimedOut => b"timed out\0",
+            Self::UnexpectedEof => b"unexpected end of file\0",
+            Self::Unsupported => b"unsupported\0",
+            Self::WouldBlock => b"operation would block\0",
+            Self::WriteZero => b"write zero\0",
+            Self::InvalidDwarf => b"DWARF data invalid\0",
+        }
+    }
+}
+
 
 /// The error type used by the library.
 ///


### PR DESCRIPTION
Our fallible API functions currently simply return a pointer that can be
NULL, conveying failure but not what kind of failure. This can make it
unnecessarily hard to understand problems.

With this change we introduce the blaze_error enum, mirroring the
ErrorKind type of the Rust crate, that categorizes the error at a high
level. We also adjust all fallible functions to return this error.