### PR TITLE
Don't create features for various dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,11 @@ apk = []
 # environment variables.
 backtrace = []
 # Enable this feature to enable Breakpad support.
-breakpad = ["circular", "nom"]
+breakpad = ["dep:circular", "dep:nom"]
 # Enable this feature to get transparent symbol demangling.
-demangle = ["cpp_demangle", "rustc-demangle"]
+demangle = ["dep:cpp_demangle", "dep:rustc-demangle"]
 # Enable this feature to enable DWARF support.
-dwarf = ["gimli"]
+dwarf = ["dep:gimli"]
 # Enable this feature to enable Gsym support.
 gsym = []
 


### PR DESCRIPTION
Some of our higher level features depend on third-party dependencies. Currently, the way these dependencies are specified causes an implicit crate feature to be created as well. This has been recognized as a bad design decision. To that end, The next edition of Rust will change this behavior and stop the creation of implicit features. With this change we opt into this new behavior via the 'dep:' syntax, which in turn has been stable for a while. We don't use it for our "dev" features, though, which actively rely on implicit features being available.