### PR TITLE
Add support for compressed ELF sections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
           - runs-on: ubuntu-latest
             rust: stable
             profile: dev
+            args: "--lib --no-default-features --features=zlib"
+          - runs-on: ubuntu-latest
+            rust: stable
+            profile: dev
             args: "--package=blazecli"
           - runs-on: ubuntu-latest
             rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
   type
   - Adjusted normalization logic to return references to cached build
     IDs if `cache_build_ids` is `true`
+- Added support for compressed debug information
+  - Added default enabled `zlib` feature
 - Introduced `normalize::Reason` enum to provide best guess at why normalization
   was not successful as part of the `normalize::UserMeta::Unknown` variant
 - Reduced number of allocations performed on address normalization and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ default = [
   "backtrace",
   "demangle",
   "dwarf",
+  "zlib",
 ]
 # Enable this feature to enable APK support (mostly relevant for
 # Android).
@@ -55,6 +56,9 @@ demangle = ["dep:cpp_demangle", "dep:rustc-demangle"]
 dwarf = ["dep:gimli"]
 # Enable this feature to enable Gsym support.
 gsym = []
+# Enable this feature to enable support for zlib decompression. This is
+# currently only used for handling compressed debug information.
+zlib = ["dep:miniz_oxide"]
 
 # Below here are dev-mostly features that should not be needed by
 # regular users.
@@ -89,10 +93,18 @@ codegen-units = 1
 lto = false
 codegen-units = 256
 
+[build-dependencies]
+dump_syms = {version = "2.3", optional = true, default-features = false}
+libc = "0.2.137"
+reqwest = {version = "0.12.0", optional = true, features = ["blocking"]}
+xz2 = {version = "0.1.7", optional = true}
+zip = {version = "0.6.4", optional = true, default-features = false}
+
 [dependencies]
 cpp_demangle = {version = "0.4", optional = true}
 gimli = {version = "0.28", optional = true}
 libc = "0.2.137"
+miniz_oxide = {version = "0.7", default-features = false, features = ["simd", "with-alloc"], optional = true}
 nom = {version = "7", optional = true}
 rustc-demangle = {version = "0.1.4", optional = true}
 tracing = {version = "0.1.27", default-features = false, features = ["attributes"], optional = true}
@@ -110,12 +122,12 @@ stats_alloc = {version = "0.1.1", features = ["nightly"]}
 tempfile = "3.4"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
 
-[build-dependencies]
-dump_syms = {version = "2.3", optional = true, default-features = false}
-libc = "0.2.137"
-reqwest = {version = "0.12.0", optional = true, features = ["blocking"]}
-xz2 = {version = "0.1.7", optional = true}
-zip = {version = "0.6.4", optional = true, default-features = false}
+# A set of unused dependencies that we require to force correct minimum versions
+# of transitive dependencies, for cases where our dependencies have incorrect
+# dependency specifications themselves.
+# > 22 |     let mut hash = simd_adler32::Adler32::from_checksum(adler);
+# >    |                                           ^^^^^^^^^^^^^ function or associated item not found in `Adler32`
+_simd-adler32_unused = { package = "simd-adler32", version = "0.3.3" }
 
 # https://docs.rs/about/metadata
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Here is rough roadmap of currently planned features (in no particular order):
     - [x] Support inlined function lookup for DWARF (https://github.com/libbpf/blazesym/issues/192)
 - [x] Support symbolization of addresses in APKs (relevant for Android) (https://github.com/libbpf/blazesym/pull/222 & https://github.com/libbpf/blazesym/pull/227)
 - [ ] Support ELF32 binaries (https://github.com/libbpf/blazesym/issues/53)
-- [ ] Support handling of compressed debug information (https://github.com/libbpf/blazesym/issues/581)
+- [x] Support handling of compressed debug information (https://github.com/libbpf/blazesym/issues/581)
 - [x] Support demangling of Rust & C++ symbol names (https://github.com/libbpf/blazesym/issues/50)
 - [x] Support remote symbolization (https://github.com/libbpf/blazesym/issues/61)
   - [x] Add APIs for address normalization (https://github.com/libbpf/blazesym/pull/114, https://github.com/libbpf/blazesym/pull/128, ...)

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -50,7 +50,7 @@ which = {version = "6.0.0", optional = true}
 
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
-blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "demangle", "dwarf", "gsym"]}
+blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "zlib"]}
 # TODO: Remove dependency one MSRV is 1.77.
 memoffset = "0.9"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ grev = "0.1.3"
 
 [dependencies]
 anyhow = "1.0.68"
-blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing"]}
+blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
 clap = {version = "4.1.7", features = ["derive"]}
 clap_complete = {version = "4.1.1", optional = true}
 tracing = "0.1"

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -486,6 +486,7 @@ mod tests {
             "test-dwarf-v3.bin",
             "test-dwarf-v4.bin",
             "test-dwarf-v5.bin",
+            "test-dwarf-v5-zlib.bin",
         ];
 
         for binary in binaries {
@@ -524,6 +525,7 @@ mod tests {
             "test-dwarf-v3.bin",
             "test-dwarf-v4.bin",
             "test-dwarf-v5.bin",
+            "test-dwarf-v5-zlib.bin",
         ];
 
         for binary in binaries {

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -74,6 +74,8 @@ pub(crate) struct Elf64_Shdr {
 // SAFETY: `Elf64_Shdr` is valid for any bit pattern.
 unsafe impl Pod for Elf64_Shdr {}
 
+pub(crate) const SHF_COMPRESSED: u64 = 0x800;
+
 pub(crate) const SHN_UNDEF: u16 = 0;
 pub(crate) const SHN_LORESERVE: u16 = 0xff00;
 pub(crate) const SHN_XINDEX: u16 = 0xffff;
@@ -145,6 +147,30 @@ pub(crate) struct Elf64_Nhdr {
 
 // SAFETY: `Elf64_Nhdr` is valid for any bit pattern.
 unsafe impl Pod for Elf64_Nhdr {}
+
+
+#[derive(Debug)]
+#[repr(C)]
+pub(crate) struct Elf64_Chdr {
+    /// Compression format.
+    ///
+    /// See `ELFCOMPRESS_*` constants for supported values.
+    pub ch_type: Elf64_Word,
+    pub ch_reserved: Elf64_Word,
+    /// Uncompressed data size.
+    pub ch_size: Elf64_Xword,
+    /// Uncompressed data alignment.
+    pub ch_addralign: Elf64_Xword,
+}
+
+// SAFETY: `Elf64_Chdr` is valid for any bit pattern.
+unsafe impl Pod for Elf64_Chdr {}
+
+
+/// zlib/deflate algorithm.
+pub(crate) const ELFCOMPRESS_ZLIB: u32 = 1;
+/// zstd algorithm.
+pub(crate) const ELFCOMPRESS_ZSTD: u32 = 2;
 
 
 #[cfg(test)]

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -124,17 +124,17 @@ fn symbolize_elf_dwarf_gsym() {
     let src = symbolize::Source::Elf(symbolize::Elf::new(path));
     test(src, false);
 
-    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
-        .join("data")
-        .join("test-stable-addresses-dwarf-only.bin");
-    let src = symbolize::Source::Elf(symbolize::Elf::new(path));
-    test(src, true);
-
-    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
-        .join("data")
-        .join("test-stable-addresses-lto.bin");
-    let src = symbolize::Source::Elf(symbolize::Elf::new(path));
-    test(src, true);
+    for file in [
+        "test-stable-addresses-dwarf-only.bin",
+        "test-stable-addresses-lto.bin",
+        "test-stable-addresses-compressed-debug-zlib.bin",
+    ] {
+        let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join(file);
+        let src = symbolize::Source::Elf(symbolize::Elf::new(path));
+        test(src, true);
+    }
 
     let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
@@ -344,12 +344,17 @@ fn symbolize_dwarf_gsym_inlined() {
     test(src.clone(), true);
     test(src, false);
 
-    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
-        .join("data")
-        .join("test-stable-addresses-dwarf-only.bin");
-    let src = symbolize::Source::from(symbolize::Elf::new(path));
-    test(src.clone(), true);
-    test(src, false);
+    for file in [
+        "test-stable-addresses-dwarf-only.bin",
+        "test-stable-addresses-compressed-debug-zlib.bin",
+    ] {
+        let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join(file);
+        let src = symbolize::Source::from(symbolize::Elf::new(path));
+        test(src.clone(), true);
+        test(src, false);
+    }
 }
 
 /// Make sure that we report (enabled) or don't report (disabled) inlined


### PR DESCRIPTION
Add support for working with compressed ELF sections ([0] [1]). To the best of my knowledge, these are currently only used in conjunction with compressed DWARF information. This change only adds support zlib compressed sections. zstd is another algorithm supported by ELF and should be easy to add as a follow up.
Decompression currently happens entirely at the ELF layer. This makes it a trivial addition. However, it means that we have to decompress the entire section data in advance. Doing so may be less controversial than one might think, though: generally there is no random access into compressed data and while it may be possible to build something resembling random-access for certain formats (e.g., [2]), none of the zlib Rust crates evaluated seemed to sport random-access support in any shape or form.
In general, if we wanted to implement a more gradual approach, where we decompress only blocks containing data being of interest, we would need to make far reaching changes to the DWARF parsing code (because right now the parsing code works on a raw slice of bytes and once that is no longer the case data ownership will get tricky quickly). In addition to requiring aforementioned lower-level support for random access at the compression layer.

Additional notes:
- we do not support the legacy "GNU" zlib compression format (in whatever way it is different; documentation seems to be even more sparse than for other compression bits)
- we do not support dealing with renamed sections (e.g., .zdebug); as per my understanding section renaming has been superseded by usage of the SHF_COMPRESSED flag and no contemporary toolchain should do that anymore (check for instance [3])
- we currently use the miniz_oxide crate for zlib support; it is also used by the slightly higher level flate2 crate, which is maintained by the Rust team
  - we could consider switching to something else if need be, e.g., zip (which effectively is one of our dev-dependencies at this point) also seems to support zlib

[0] https://man.freebsd.org/cgi/man.cgi?elf(5)
[1] https://maskray.me/blog/2022-01-23-compressed-debug-sections
[2] https://github.com/madler/zlib/blob/51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf/examples/zran.h
[3] https://github.com/golang/go/issues/50796

Closes: #581