### PR TITLE
Remove dependency on circular crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ apk = []
 # environment variables.
 backtrace = []
 # Enable this feature to enable Breakpad support.
-breakpad = ["dep:circular", "dep:nom"]
+breakpad = ["dep:nom"]
 # Enable this feature to get transparent symbol demangling.
 demangle = ["dep:cpp_demangle", "dep:rustc-demangle"]
 # Enable this feature to enable DWARF support.
@@ -90,7 +90,6 @@ lto = false
 codegen-units = 256
 
 [dependencies]
-circular = {version = "0.3", optional = true}
 cpp_demangle = {version = "0.4", optional = true}
 gimli = {version = "0.28", optional = true}
 libc = "0.2.137"

--- a/src/breakpad/file.rs
+++ b/src/breakpad/file.rs
@@ -22,10 +22,6 @@
 // > FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // > DEALINGS IN THE SOFTWARE.
 
-use std::fs::File;
-use std::io::Read;
-
-use crate::log::trace;
 use crate::Error;
 use crate::Result;
 
@@ -33,176 +29,32 @@ use super::parser::SymbolParser;
 use super::types::SymbolFile;
 
 
-// # Streaming
-//
-// This parser streams the input to avoid the need to materialize all of
-// it into memory at once (symbol files can be a gigabyte!). As a result,
-// we need to iteratively parse.
-//
-// We do this by repeatedly filling up a buffer with input and asking the
-// parser to parse it. The parser will return how much of the input it
-// consumed, which we can use to clear space in our buffer and to tell
-// if it successfully consumed the whole input when the Reader runs dry.
-//
-//
-// # Handling EOF / Capacity
-//
-// Having a fix-sized buffer has one fatal issue: if one atomic step
-// of the parser needs more than this amount of data, then we won't
-// be able to parse it.
-//
-// This can result in `buf` filling up and `buf.space()` becoming an
-// empty slice. This in turn will make the reader yield 0 bytes, and
-// we'll treat it like EOF and fail the parse. When this happens, we
-// try to double the buffer's size and request more bytes. If we get
-// more, hooray! If we don't, then it's a "real" EOF.
-//
-// The "atom" of our parser is a line, so we need our buffer to be able
-// to fit any line. However we actually only have roughly
-// *half* this value as our limit, as circular::Buffer will only
-// `shift` the buffer's contents if over half of its capacity has been
-// drained by `consume` -- and `space()` only grows when a `shift` happens.
-//
-// I have in fact seen 8kb function names from Rust (thanks generic
-// combinators!) and 82kb function names from C++ (thanks 'auto' returns!), so
-// we need a buffer size that can grow to at least 200KB. This is a *very* large
-// amount to backshift repeatedly, so to keep this under control, we start
-// with only a 10KB buffer, which is generous but tolerable.
-//
-// We should still have *SOME* limit on this to avoid nasty death spirals,
-// so let's go with 2MB (MAX_BUFFER_CAPACITY), letting you have a horrifying 1MB
-// symbol.
-//
-// But just *dying* when we hit this point is terrible, so lets have an
-// extra layer of robustness: if we ever hit the limit, enter "panic recovery"
-// and just start discarding bytes until we hit a newline. Then resume normal
-// parsing. The net effect of this is that we just treat this one line as
-// corrupt (because statistically it won't even be needed!).
-
-// Allows for at least 80KB symbol names, at most 160KB symbol names (fuzzy
-// because of circular).
-const MAX_BUFFER_CAPACITY: usize = 1024 * 160;
-const INITIAL_BUFFER_CAPACITY: usize = 1024 * 10;
-
-
-// TODO: We should consider adjusting the parser to just work with a
-//       memory mapped file instead and remove the `circular` based
-//       logic.
 impl SymbolFile {
     /// Parse a [`SymbolFile`] from the given Reader.
     ///
     /// The reader is wrapped in a buffer reader so you shouldn't
     /// buffer the input yourself.
-    fn parse<R: Read>(mut input_reader: R) -> Result<SymbolFile> {
-        let mut buf = circular::Buffer::with_capacity(INITIAL_BUFFER_CAPACITY);
+    fn parse(input: &[u8]) -> Result<SymbolFile> {
         let mut parser = SymbolParser::new();
-        let mut fully_consumed = false;
-        let mut tried_to_grow = false;
-        let mut in_panic_recovery = false;
-        let mut just_finished_recovering = false;
-        let mut total_consumed = 0u64;
-        loop {
-            if in_panic_recovery {
-                // PANIC RECOVERY MODE! DISCARD BYTES UNTIL NEWLINE.
-                let input = buf.data();
-                if let Some(new_line_idx) = input.iter().position(|&byte| byte == b'\n') {
-                    // Hooray, we found a new line! Consume up to and including that, and resume.
-                    let amount = new_line_idx + 1;
-                    buf.consume(amount);
-                    total_consumed += amount as u64;
-
-                    // Back to normal!
-                    in_panic_recovery = false;
-                    fully_consumed = false;
-                    just_finished_recovering = true;
-                    parser.lines += 1;
-                    trace!("RECOVERY: complete!");
-                } else {
-                    // No newline, discard everything
-                    let amount = input.len();
-                    buf.consume(amount);
-                    total_consumed += amount as u64;
-
-                    // If the next read returns 0 bytes, then that's a proper EOF!
-                    fully_consumed = true;
-                }
-            }
-
-            // Read the data in, and tell the circular buffer about the new data
-            let size = input_reader.read(buf.space())?;
-            buf.fill(size);
-
-            if size == 0 {
-                // If the reader returned no more bytes, this can be either mean
-                // EOF or the buffer is out of capacity. There are a lot of cases
-                // to consider, so let's go through them one at a time...
-                if just_finished_recovering && !buf.data().is_empty() {
-                    // We just finished PANIC RECOVERY, but there's still bytes
-                    // in the buffer. Assume that is
-                    // parseable and resume normal parsing
-                    // (do nothing, fallthrough to normal path).
-                } else if fully_consumed {
-                    // Success! The last iteration cleared the buffer and we still got
-                    // no more bytes, so that's a proper EOF with a complete parse!
-                    return Ok(parser.finish())
-                } else if !tried_to_grow {
-                    // We still have some stuff in the buffer, assume this is because
-                    // the buffer is full, and try to make it BIGGER and ask for more again.
-                    let new_cap = buf.capacity().saturating_mul(2);
-                    if new_cap > MAX_BUFFER_CAPACITY {
-                        // TIME TO PANIC!!! This line is catastrophically big, just start
-                        // discarding bytes until we hit a newline.
-                        trace!("RECOVERY: discarding enormous line {}", parser.lines);
-                        in_panic_recovery = true;
-                        continue
-                    }
-                    trace!("parser out of space? trying more ({}KB)", new_cap / 1024);
-                    buf.grow(new_cap);
-                    tried_to_grow = true;
-                    continue
-                } else if total_consumed == 0 {
-                    // We grew the buffer and still got no more bytes, so it's a proper EOF.
-                    // But actually, we never consumed any bytes, so this is an empty file?
-                    // Give a better error message for that.
-                    return Err(Error::with_invalid_input(
-                        "empty SymbolFile (probably something wrong with your debuginfo tooling?)",
-                    ))
-                } else {
-                    // Ok give up, this input is just impossible.
-                    return Err(Error::with_invalid_input(
-                        "unexpected EOF during parsing of SymbolFile (or a line was too long?)",
-                    ))
-                }
-            } else {
-                tried_to_grow = false;
-            }
-
-            if in_panic_recovery {
-                // Don't run the normal parser while we're still recovering!
-                continue
-            }
-            just_finished_recovering = false;
-
-            // Ask the parser to parse more of the input
-            let input = buf.data();
-            let consumed = parser.parse_more(input)?;
-            total_consumed += consumed as u64;
-
-            // Remember for the next iteration if all the input was consumed.
-            fully_consumed = input.len() == consumed;
-            buf.consume(consumed);
+        let consumed = parser.parse(input)?;
+        if consumed == 0 {
+            return Err(Error::with_invalid_input(
+                "empty SymbolFile (probably something wrong with your debuginfo tooling?)",
+            ))
         }
+        if consumed != input.len() {
+            return Err(Error::with_invalid_input(
+                "failed to parse input: parser expects more data",
+            ))
+        }
+
+        let file = parser.finish();
+        Ok(file)
     }
 
     /// Parse a [`SymbolFile`] from bytes.
-    #[cfg(test)]
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<SymbolFile> {
         Self::parse(bytes)
-    }
-
-    /// Parse a [`SymbolFile`] from a file.
-    pub fn from_file(file: &File) -> Result<SymbolFile> {
-        Self::parse(file)
     }
 }
 

--- a/src/breakpad/parser.rs
+++ b/src/breakpad/parser.rs
@@ -446,11 +446,7 @@ fn line(input: &[u8]) -> IResult<&[u8], Line, VerboseError<&[u8]>> {
 
 /// A parser for Breakpad symbol files.
 ///
-/// This is basically just a [`SymbolFile`] but with some extra state to handle
-/// streaming parsing.
-///
-/// Use this by repeatedly calling [`parse_more`] until the
-/// whole input is consumed. Then call [`finish`].
+/// This is basically just a [`SymbolFile`] but with some extra state.
 #[derive(Debug, Default)]
 pub struct SymbolParser {
     files: HashMap<u32, String>,
@@ -467,11 +463,8 @@ impl SymbolParser {
         Self::default()
     }
 
-    /// Parses as much of the input as it can, and then returns
-    /// how many bytes of the input was used. The *unused* portion of the
-    /// input must be resubmitted on subsequent calls to parse_more
-    /// (along with more data so we can make progress on the parse).
-    pub fn parse_more(&mut self, mut input: &[u8]) -> Result<usize> {
+    /// Parses and then returns how many bytes of the input was used.
+    pub fn parse(&mut self, mut input: &[u8]) -> Result<usize> {
         // We parse the input line-by-line, so trim away any part of the input
         // that comes after the last newline (this is necessary for streaming
         // parsing, as it can otherwise be impossible to tell if a line is

--- a/src/breakpad/resolver.rs
+++ b/src/breakpad/resolver.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
+use crate::mmap::Mmap;
 use crate::symbolize::AddrCodeInfo;
 use crate::symbolize::CodeInfo;
 use crate::symbolize::IntSym;
@@ -52,9 +53,11 @@ pub(crate) struct BreakpadResolver {
 
 impl BreakpadResolver {
     pub(crate) fn from_file(path: PathBuf, file: &File) -> Result<Self> {
+        let mmap = Mmap::map(file)
+            .with_context(|| format!("failed to memory map breakpad file `{}`", path.display()))?;
         let slf = Self {
-            symbol_file: SymbolFile::from_file(file)
-                .with_context(|| format!("failed to parse Breakpad file `{path:?}`"))?,
+            symbol_file: SymbolFile::from_bytes(&mmap)
+                .with_context(|| format!("failed to parse Breakpad file `{}`", path.display()))?,
             path,
         };
         Ok(slf)


### PR DESCRIPTION
For Breakpad support, we originally adopted a stripped down version of the core logic of rust-minidump, with some modifications. What notably was not modified, was the way in which it ingests source files. Specifically, it uses regular file APIs and then reads into a buffer. The potentially unmaintained (? 5 years since the last release...) circular crate is used for that purpose.
With Breakpad support having gotten a bit of mileage in, this change rips out all the logic relying on file APIs and reading into a buffer and just use our internal memory mapping APIs instead, as we do virtually everywhere else, instead. Doing so greatly simplifies the code, make it easier to test properly (and bumps code coverage), make it less constrained (the 80 KiB/200 KiB limits seem rather arbitrary, even if in practice probably plenty), and remove a conceptually unnecessary dependency. Performance-wise it seems to be a win as well:
```
  > main/symbolize_breakpad
  >                         time:   [208.84 ms 209.31 ms 209.85 ms]
  >                         change: [−29.175% −27.886% −26.628%] (p = 0.00 < 0.02)
  >                         Performance has improved.
```

Closes: #589