### PR TITLE
cli: Introduce 'inspect' command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `inspect` command
+
+
 0.1.3
 -----
 - Added support for symbolization using Breakpad (`*.sym`) files

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -47,12 +47,61 @@ pub struct Args {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    /// Inspect a symbol source.
+    #[command(subcommand)]
+    Inspect(inspect::Inspect),
     /// Normalize one or more addresses.
     #[command(subcommand)]
     Normalize(normalize::Normalize),
     /// Symbolize one or more addresses.
     #[command(subcommand)]
     Symbolize(symbolize::Symbolize),
+}
+
+
+pub mod inspect {
+    use super::*;
+
+
+    /// A type representing the `inspect` command.
+    #[derive(Debug, Subcommand)]
+    pub enum Inspect {
+        #[command(subcommand)]
+        Dump(Dump),
+        #[command(subcommand)]
+        Lookup(Lookup),
+    }
+
+    /// A type representing the `inspect lookup` sub-command.
+    #[derive(Debug, Subcommand)]
+    pub enum Lookup {
+        /// Lookup symbols in a ELF file by name.
+        Elf(ElfLookup),
+    }
+
+
+    /// A type representing the `inspect dump` sub-command.
+    #[derive(Debug, Subcommand)]
+    pub enum Dump {
+        /// Dump all symbols in an ELF file.
+        Elf(ElfDump),
+    }
+
+    #[derive(Debug, Arguments)]
+    pub struct ElfLookup {
+        /// The path to the ELF file.
+        #[clap(short, long)]
+        pub path: PathBuf,
+        /// A list of names of symbols.
+        pub names: Vec<String>,
+    }
+
+    #[derive(Debug, Arguments)]
+    pub struct ElfDump {
+        /// The path to the ELF file.
+        #[clap(short, long)]
+        pub path: PathBuf,
+    }
 }
 
 

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -49,99 +49,109 @@ pub struct Args {
 pub enum Command {
     /// Normalize one or more addresses.
     #[command(subcommand)]
-    Normalize(Normalize),
+    Normalize(normalize::Normalize),
     /// Symbolize one or more addresses.
     #[command(subcommand)]
-    Symbolize(Symbolize),
+    Symbolize(symbolize::Symbolize),
 }
 
 
-/// A type representing the `normalize` command.
-#[derive(Debug, Subcommand)]
-pub enum Normalize {
-    /// Normalize user space addresses.
-    User(User),
+pub mod normalize {
+    use super::*;
+
+
+    /// A type representing the `normalize` command.
+    #[derive(Debug, Subcommand)]
+    pub enum Normalize {
+        /// Normalize user space addresses.
+        User(User),
+    }
+
+    #[derive(Debug, Arguments)]
+    pub struct User {
+        /// The PID of the process the provided addresses belong to.
+        #[clap(short, long)]
+        #[arg(value_parser = parse_pid)]
+        pub pid: Pid,
+        /// The addresses to normalize.
+        #[arg(value_parser = parse_addr)]
+        pub addrs: Vec<Addr>,
+        /// Disable the reading of build IDs of the corresponding binaries.
+        #[clap(long)]
+        pub no_build_ids: bool,
+    }
 }
 
-#[derive(Debug, Arguments)]
-pub struct User {
-    /// The PID of the process the provided addresses belong to.
-    #[clap(short, long)]
-    #[arg(value_parser = parse_pid)]
-    pub pid: Pid,
-    /// The addresses to normalize.
-    #[arg(value_parser = parse_addr)]
-    pub addrs: Vec<Addr>,
-    /// Disable the reading of build IDs of the corresponding binaries.
-    #[clap(long)]
-    pub no_build_ids: bool,
-}
+
+pub mod symbolize {
+    use super::*;
 
 
-/// A type representing the `symbolize` command.
-#[derive(Debug, Subcommand)]
-pub enum Symbolize {
-    Breakpad(Breakpad),
-    Elf(Elf),
-    Gsym(Gsym),
-    Process(Process),
-}
+    /// A type representing the `symbolize` command.
+    #[derive(Debug, Subcommand)]
+    pub enum Symbolize {
+        Breakpad(Breakpad),
+        Elf(Elf),
+        Gsym(Gsym),
+        Process(Process),
+    }
 
-#[derive(Debug, Arguments)]
-pub struct Breakpad {
-    /// The path to the Breakpad (*.sym) file.
-    #[clap(short, long)]
-    pub path: PathBuf,
-    /// The addresses to symbolize.
-    ///
-    /// Addresses are assumed to be file offsets as they would be used on the
-    /// original (ELF/DWARF/...) source file.
-    #[arg(value_parser = parse_addr)]
-    pub addrs: Vec<Addr>,
-}
+    #[derive(Debug, Arguments)]
+    pub struct Breakpad {
+        /// The path to the Breakpad (*.sym) file.
+        #[clap(short, long)]
+        pub path: PathBuf,
+        /// The addresses to symbolize.
+        ///
+        /// Addresses are assumed to be file offsets as they would be used on
+        /// the original (ELF/DWARF/...) source file.
+        #[arg(value_parser = parse_addr)]
+        pub addrs: Vec<Addr>,
+    }
 
-#[derive(Debug, Arguments)]
-pub struct Elf {
-    /// The path to the ELF file.
-    #[clap(short, long)]
-    pub path: PathBuf,
-    /// Disable the use of debug symbols.
-    #[clap(long)]
-    pub no_debug_syms: bool,
-    /// The addresses to symbolize.
-    ///
-    /// Addresses are assumed to already be normalized to the file
-    /// itself (i.e., with relocation and address randomization effects
-    /// removed).
-    #[arg(value_parser = parse_addr)]
-    pub addrs: Vec<Addr>,
-}
+    #[derive(Debug, Arguments)]
+    pub struct Elf {
+        /// The path to the ELF file.
+        #[clap(short, long)]
+        pub path: PathBuf,
+        /// Disable the use of debug symbols.
+        #[clap(long)]
+        pub no_debug_syms: bool,
+        /// The addresses to symbolize.
+        ///
+        /// Addresses are assumed to already be normalized to the file
+        /// itself (i.e., with relocation and address randomization effects
+        /// removed).
+        #[arg(value_parser = parse_addr)]
+        pub addrs: Vec<Addr>,
+    }
 
-#[derive(Debug, Arguments)]
-pub struct Gsym {
-    /// The path to the Gsym file.
-    #[clap(short, long)]
-    pub path: PathBuf,
-    /// The addresses to symbolize.
-    ///
-    /// Addresses are assumed to already be normalized to the file
-    /// itself (i.e., with relocation and address randomization effects
-    /// removed).
-    #[arg(value_parser = parse_addr)]
-    pub addrs: Vec<Addr>,
-}
+    #[derive(Debug, Arguments)]
+    pub struct Gsym {
+        /// The path to the Gsym file.
+        #[clap(short, long)]
+        pub path: PathBuf,
+        /// The addresses to symbolize.
+        ///
+        /// Addresses are assumed to already be normalized to the file
+        /// itself (i.e., with relocation and address randomization effects
+        /// removed).
+        #[arg(value_parser = parse_addr)]
+        pub addrs: Vec<Addr>,
+    }
 
-#[derive(Debug, Arguments)]
-pub struct Process {
-    /// The PID of the process the provided addresses belong to.
-    #[clap(short, long)]
-    #[arg(value_parser = parse_pid)]
-    pub pid: Pid,
-    /// The addresses to symbolize.
-    #[arg(value_parser = parse_addr)]
-    pub addrs: Vec<Addr>,
-    /// Disable the use of `/proc/<pid>/map_files/` entries and use
-    /// symbolic paths instead.
-    #[clap(long)]
-    pub no_map_files: bool,
+    #[derive(Debug, Arguments)]
+    pub struct Process {
+        /// The PID of the process the provided addresses belong to.
+        #[clap(short, long)]
+        #[arg(value_parser = parse_pid)]
+        pub pid: Pid,
+        /// The addresses to symbolize.
+        #[arg(value_parser = parse_addr)]
+        pub addrs: Vec<Addr>,
+        /// Disable the use of `/proc/<pid>/map_files/` entries and use
+        /// symbolic paths instead.
+        #[clap(long)]
+        pub no_map_files: bool,
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -39,9 +39,9 @@ fn format_build_id(build_id: Option<&[u8]>) -> String {
     }
 }
 
-fn normalize(normalize: args::Normalize) -> Result<()> {
+fn normalize(normalize: args::normalize::Normalize) -> Result<()> {
     match normalize {
-        args::Normalize::User(args::User {
+        args::normalize::Normalize::User(args::normalize::User {
             pid,
             addrs,
             no_build_ids,
@@ -114,16 +114,16 @@ fn print_frame(
 }
 
 /// The handler for the 'symbolize' command.
-fn symbolize(symbolize: args::Symbolize) -> Result<()> {
+fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
     let symbolizer = Symbolizer::new();
     let (src, input, addrs) = match symbolize {
-        args::Symbolize::Breakpad(args::Breakpad { path, ref addrs }) => {
+        args::symbolize::Symbolize::Breakpad(args::symbolize::Breakpad { path, ref addrs }) => {
             let src = symbolize::Source::from(symbolize::Breakpad::new(path));
             let addrs = addrs.as_slice();
             let input = symbolize::Input::FileOffset(addrs);
             (src, input, addrs)
         }
-        args::Symbolize::Elf(args::Elf {
+        args::symbolize::Symbolize::Elf(args::symbolize::Elf {
             path,
             no_debug_syms,
             ref addrs,
@@ -135,13 +135,13 @@ fn symbolize(symbolize: args::Symbolize) -> Result<()> {
             let input = symbolize::Input::VirtOffset(addrs);
             (src, input, addrs)
         }
-        args::Symbolize::Gsym(args::Gsym { path, ref addrs }) => {
+        args::symbolize::Symbolize::Gsym(args::symbolize::Gsym { path, ref addrs }) => {
             let src = symbolize::Source::from(symbolize::GsymFile::new(path));
             let addrs = addrs.as_slice();
             let input = symbolize::Input::VirtOffset(addrs);
             (src, input, addrs)
         }
-        args::Symbolize::Process(args::Process {
+        args::symbolize::Symbolize::Process(args::symbolize::Process {
             pid,
             ref addrs,
             no_map_files,

--- a/data/test-stable-addresses-cu2.c
+++ b/data/test-stable-addresses-cu2.c
@@ -1,4 +1,9 @@
 extern unsigned int factorial(unsigned int n);
+extern volatile char a_variable[8];
+
+__attribute__((noinline)) static void i_exist_twice(void) {
+  a_variable[0] = '\0';
+}
 
 __attribute__((noinline)) static void
 factorial_wrapper() {

--- a/data/test-stable-addresses.c
+++ b/data/test-stable-addresses.c
@@ -43,6 +43,10 @@ static void (*resolve_indirect_func(void))(void) {
 
 void indirect_func(void) __attribute__ ((ifunc ("resolve_indirect_func")));
 
+__attribute__((noinline)) static void i_exist_twice(void) {
+  a_variable[1] = '\0';
+}
+
 // A dummy function that should not actually be called. It just contains a bunch
 // of signature bytes that we use for offset verification later on.
 asm(
@@ -63,6 +67,7 @@ main(int argc, const char *argv[]) {
   factorial_inline_test();
   foo();
   dummy();
+  i_exist_twice();
 
   a_variable[0] = 42;
   return 0;

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -383,7 +383,7 @@ mod tests {
         // `main` resides at address 0x2000000, and it's located at the given
         // line.
         let info = resolver.find_code_info(0x2000000, true).unwrap().unwrap();
-        assert_eq!(info.direct.1.line, Some(61));
+        assert_eq!(info.direct.1.line, Some(65));
         assert_eq!(info.direct.1.file, OsStr::new("test-stable-addresses.c"));
         assert_eq!(info.inlined, Vec::new());
 


### PR DESCRIPTION
Introduce the 'inspect' command to the program. It in turn is comprised
of the 'lookup' and 'dump' sub-commands. Right now only inspection of
ELF files is supported.
```
  $ cargo run --package blazecli -- inspect dump elf --path ../data/test-stable-addresses.bin
  > main:                  0x00000002000000+59   [FUNC]
  > i_exist_twice:         0x0000000200003b+14   [FUNC]
  > factorial_wrapper:     0x00000002000049+17   [FUNC]
  > foo:                   0x0000000200005a+17   [FUNC]
  > i_exist_twice:         0x0000000200006b+14   [FUNC]
  > factorial_wrapper:     0x00000002000079+17   [FUNC]
  > my_indirect_func:      0x0000000200008a+7    [FUNC]
  > indirect_func:         0x00000002000091+11   [FUNC]
  > resolve_indirect_func: 0x00000002000091+11   [FUNC]
  > dummy:                 0x0000000200009c+0    [FUNC]
  > factorial:             0x00000002000100+43   [FUNC]
  > factorial_inline_test: 0x00000002000200+19   [FUNC]
  > a_variable:            0x00000002001100+8    [VAR]
```
```
  $ cargo run --package blazecli -- inspect lookup elf --path ../data/test-stable-addresses.bin main i_exist_twice
  > main:                  0x00000002000000+59   [FUNC]
  > i_exist_twice:         0x0000000200003b+14   [FUNC]
  > i_exist_twice:         0x0000000200006b+14   [FUNC]
```