### PR TITLE
cli: Add support for Breakpad files to 'inspect' command

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -75,6 +75,8 @@ pub mod inspect {
     /// A type representing the `inspect lookup` sub-command.
     #[derive(Debug, Subcommand)]
     pub enum Lookup {
+        /// Lookup symbols in a Breakpad file by name.
+        Breakpad(BreakpadLookup),
         /// Lookup symbols in a ELF file by name.
         Elf(ElfLookup),
     }
@@ -83,8 +85,26 @@ pub mod inspect {
     /// A type representing the `inspect dump` sub-command.
     #[derive(Debug, Subcommand)]
     pub enum Dump {
+        /// Dump all symbols in a Breakpad file.
+        Breakpad(BreakpadDump),
         /// Dump all symbols in an ELF file.
         Elf(ElfDump),
+    }
+
+    #[derive(Debug, Arguments)]
+    pub struct BreakpadLookup {
+        /// The path to the Breakpad (*.sym) file.
+        #[clap(short, long)]
+        pub path: PathBuf,
+        /// A list of names of symbols.
+        pub names: Vec<String>,
+    }
+
+    #[derive(Debug, Arguments)]
+    pub struct BreakpadDump {
+        /// The path to the Breakpad (*.sym) file.
+        #[clap(short, long)]
+        pub path: PathBuf,
     }
 
     #[derive(Debug, Arguments)]

--- a/data/test-stable-addresses-cu2.c
+++ b/data/test-stable-addresses-cu2.c
@@ -1,15 +1,16 @@
 extern unsigned int factorial(unsigned int n);
 extern volatile char a_variable[8];
 
-__attribute__((noinline)) static void i_exist_twice(void) {
-  a_variable[0] = '\0';
-}
-
 __attribute__((noinline)) static void
 factorial_wrapper() {
 	factorial(5);
 }
 
+__attribute__((noinline)) static void i_exist_twice(void) {
+  a_variable[0] = '\0';
+}
+
 void foo(void) {
 	factorial_wrapper();
+  i_exist_twice();
 }


### PR DESCRIPTION
Add support for working with Breakpad files to the 'inspect' command.
```
$ cargo run --package blazecli -- inspect lookup breakpad --path data/test-stable-addresses.sym resolve_indirect_func main i_exist_twice
> resolve_indirect_func: 0x00000000000088+11   [FUNC]
> i_exist_twice:         0x00000000000040+14   [FUNC]
> i_exist_twice:         0x00000000000093+14   [FUNC]

$ cargo run --package blazecli -- inspect dump breakpad --path data/test-stable-addresses.sym
> i_exist_twice:         0x00000000000040+14   [FUNC]
> factorial_wrapper:     0x0000000000004e+17   [FUNC]
> foo:                   0x0000000000005f+17   [FUNC]
> factorial_wrapper:     0x00000000000070+17   [FUNC]
> my_indirect_func:      0x00000000000081+7    [FUNC]
> resolve_indirect_func: 0x00000000000088+11   [FUNC]
> i_exist_twice:         0x00000000000093+14   [FUNC]
> factorial:             0x00000000000100+43   [FUNC]
> factorial_inline_test: 0x00000000000200+19   [FUNC]
```