### PR TITLE
cli: Add support for reading ELF build IDs

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -70,6 +70,8 @@ pub mod inspect {
         Dump(Dump),
         #[command(subcommand)]
         Lookup(Lookup),
+        #[command(subcommand, name = "buildid")]
+        BuildId(BuildId),
     }
 
     /// A type representing the `inspect lookup` sub-command.
@@ -81,7 +83,6 @@ pub mod inspect {
         Elf(ElfLookup),
     }
 
-
     /// A type representing the `inspect dump` sub-command.
     #[derive(Debug, Subcommand)]
     pub enum Dump {
@@ -89,6 +90,13 @@ pub mod inspect {
         Breakpad(BreakpadDump),
         /// Dump all symbols in an ELF file.
         Elf(ElfDump),
+    }
+
+    /// A type representing the `inspect buildid` sub-command.
+    #[derive(Debug, Subcommand)]
+    pub enum BuildId {
+        /// Read the build ID of an ELF file.
+        Elf { path: PathBuf },
     }
 
     #[derive(Debug, Arguments)]


### PR DESCRIPTION
Add support for reading ELF build IDs to the program. Perhaps a bit counter to the direct mirroring of blazesym's structure we adhere to for other functionality, we add this functionality below the 'inspect' command. At least right now that seems the most appropriate.

```
$ cargo run --package blazecli -- inspect buildid elf data/libtest-so.so
> df0178b961f7ffb9f956d96781970219674b75e2
$ cargo run --package blazecli -- inspect buildid elf data/test-stable-addresses.bin
> N/A
```

Refs: #304