### PR TITLE
cli: Change the way symbol size is conveyed

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -62,7 +62,10 @@ fn print_sym_infos(sym_infos: &[inspect::SymInfo]) {
             SymType::Variable => " [VAR]",
             _ => " [UNDEF]",
         };
-        println!("{name:<name_width$} {addr:#0ADDR_WIDTH$x}+{size:<4}{type_}");
+        println!(
+            "{name:<name_width$} {addr:#0ADDR_WIDTH$x} {size:<11}{type_}",
+            size = format!("(size={size})")
+        );
     }
 }
 


### PR DESCRIPTION
Using a plus sign ('+') followed by the size of the function/variable when looking up/dumping symbols, it is not easy to infer the meaning. Switch to using a more expressive output where we just print the size labeled as such:

```
$ cargo run --package blazecli -- inspect dump breakpad --path data/test-stable-addresses.sym
> factorial_wrapper:     0x00000000000040 (size=17)   [FUNC]
> i_exist_twice:         0x00000000000051 (size=14)   [FUNC]
> foo:                   0x0000000000005f (size=22)   [FUNC]
> factorial_wrapper:     0x00000000000075 (size=17)   [FUNC]
> my_indirect_func:      0x00000000000086 (size=7)    [FUNC]
> resolve_indirect_func: 0x0000000000008d (size=11)   [FUNC]
> i_exist_twice:         0x00000000000098 (size=14)   [FUNC]
> factorial:             0x00000000000100 (size=43)   [FUNC]
> factorial_inline_test: 0x00000000000200 (size=19)   [FUNC]
```