### PR TITLE
Remove 'R' generic argument from Inspector::for_each() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Unreleased
     IDs if `cache_build_ids` is `true`
 - Added support for compressed debug information
   - Added default enabled `zlib` feature
+- Adjusted `Inspector::for_each` signature to no longer carry explicit state
+  around
 - Introduced `normalize::Reason` enum to provide best guess at why normalization
   was not successful as part of the `normalize::UserMeta::Unknown` variant
 - Reduced number of allocations performed on address normalization and

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -109,9 +109,9 @@ fn inspect(inspect: args::inspect::Inspect) -> Result<()> {
                     inspect::Source::from(inspect::Elf::new(path))
                 }
             };
-            let mut sym_infos = inspector.for_each(&src, Vec::new(), |mut vec, sym| {
-                let () = vec.push(sym.to_owned());
-                vec
+            let mut sym_infos = Vec::new();
+            let () = inspector.for_each(&src, |sym| {
+                let () = sym_infos.push(sym.to_owned());
             })?;
             let () = sym_infos.sort_by_key(|sym| sym.addr);
             let () = print_sym_infos(&sym_infos);

--- a/src/breakpad/resolver.rs
+++ b/src/breakpad/resolver.rs
@@ -98,9 +98,9 @@ impl BreakpadResolver {
     }
 
     /// Perform an operation on each symbol.
-    pub(crate) fn for_each_sym<F, R>(&self, opts: &FindAddrOpts, mut r: R, mut f: F) -> Result<R>
+    pub(crate) fn for_each_sym<F>(&self, opts: &FindAddrOpts, mut f: F) -> Result<()>
     where
-        F: FnMut(R, &SymInfo<'_>) -> R,
+        F: FnMut(&SymInfo<'_>),
     {
         if let SymType::Variable = opts.sym_type {
             return Err(Error::with_unsupported(
@@ -110,9 +110,9 @@ impl BreakpadResolver {
 
         for func in &self.symbol_file.functions {
             let sym = SymInfo::from(func);
-            r = f(r, &sym);
+            let () = f(&sym);
         }
-        Ok(r)
+        Ok(())
     }
 }
 
@@ -257,7 +257,7 @@ mod tests {
         let err = resolver.find_addr("a_variable", &opts).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::Unsupported);
 
-        let err = resolver.for_each_sym(&opts, (), |(), _| ()).unwrap_err();
+        let err = resolver.for_each_sym(&opts, |_| ()).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::Unsupported);
     }
 }

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -138,9 +138,9 @@ impl Inspector {
     ///   - no variable support is present
     ///   - file offsets won't be reported
     ///   - addresses are reported as they appear in the symbol source
-    pub fn for_each<F, R>(&self, src: &Source, r: R, f: F) -> Result<R>
+    pub fn for_each<F>(&self, src: &Source, f: F) -> Result<()>
     where
-        F: FnMut(R, &SymInfo<'_>) -> R,
+        F: FnMut(&SymInfo<'_>),
     {
         match src {
             #[cfg(feature = "breakpad")]
@@ -154,7 +154,7 @@ impl Inspector {
                     sym_type: SymType::Undefined,
                 };
                 let resolver = self.breakpad_resolver(path)?;
-                resolver.for_each_sym(&opts, r, f)
+                resolver.for_each_sym(&opts, f)
             }
             Source::Elf(Elf {
                 path,
@@ -168,7 +168,7 @@ impl Inspector {
                 let code_info = true;
                 let resolver = self.elf_cache.elf_resolver(path, *debug_syms, code_info)?;
                 let parser = resolver.parser();
-                parser.for_each_sym(&opts, r, f)
+                parser.for_each_sym(&opts, f)
             }
         }
     }

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -901,15 +901,11 @@ fn inspect_elf_breakpad_all_symbols() {
     fn test(src: &inspect::Source) {
         let breakpad = matches!(src, inspect::Source::Breakpad(..));
         let inspector = Inspector::new();
-        let syms = inspector
-            .for_each(
-                src,
-                HashMap::<String, inspect::SymInfo>::new(),
-                |mut syms, sym| {
-                    let _inserted = syms.insert(sym.name.to_string(), sym.to_owned());
-                    syms
-                },
-            )
+        let mut syms = HashMap::<String, inspect::SymInfo>::new();
+        let () = inspector
+            .for_each(src, |sym| {
+                let _inserted = syms.insert(sym.name.to_string(), sym.to_owned());
+            })
             .unwrap();
 
         // Breakpad doesn't contain any or any reasonable information for
@@ -972,10 +968,10 @@ fn inspect_elf_all_symbols_without_duplicates() {
     let src = inspect::Source::Elf(elf);
 
     let inspector = Inspector::new();
-    let syms = inspector
-        .for_each(&src, Vec::<String>::new(), |mut syms, sym| {
+    let mut syms = Vec::<String>::new();
+    let () = inspector
+        .for_each(&src, |sym| {
             let () = syms.push(sym.name.to_string());
-            syms
         })
         .unwrap();
 


### PR DESCRIPTION
The Inspector::for_each() method currently carries a "result" around for each symbols visited. There isn't really any point to having a result like this be passed around, given that we are not constraining its type and so we effectively can't do anything with it.
Remove it from the signature. Users can just close mutably over the state that previously was passed around. By removing it we bring the method signature in line with that of [`Iterator::for_each()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.for_each).