### PR TITLE
Add zstd decompression support for ELF sections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
           - runs-on: ubuntu-latest
             rust: stable
             profile: dev
+            args: "--lib --no-default-features --features=zstd"
+          - runs-on: ubuntu-latest
+            rust: stable
+            profile: dev
             args: "--package=blazecli"
           - runs-on: ubuntu-latest
             rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ gsym = []
 # Enable this feature to enable support for zlib decompression. This is
 # currently only used for handling compressed debug information.
 zlib = ["dep:miniz_oxide"]
+# Enable this feature to enable support for zstd decompression. This is
+# currently only used for handling compressed debug information.
+zstd = ["dep:zstd"]
 
 # Below here are dev-mostly features that should not be needed by
 # regular users.
@@ -108,12 +111,16 @@ miniz_oxide = {version = "0.7", default-features = false, features = ["simd", "w
 nom = {version = "7", optional = true}
 rustc-demangle = {version = "0.1.4", optional = true}
 tracing = {version = "0.1.27", default-features = false, features = ["attributes"], optional = true}
+zstd = {version = "0.13.1", default-features = false, optional = true}
 
 [dev-dependencies]
 # For performance comparison; pinned, because we use #[doc(hidden)]
 # APIs.
 addr2line = "=0.21.0"
 anyhow = "1.0.71"
+# TODO: Enable `zstd` feature once toolchain support for it is more
+#       widespread (enabled by default in `ld`). Remove conditionals in
+#       test code alongside.
 blazesym = {path = ".", features = ["generate-unit-test-files", "apk", "breakpad", "gsym", "tracing"]}
 # TODO: Use 0.5.2 once released.
 criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}

--- a/build.rs
+++ b/build.rs
@@ -371,6 +371,13 @@ fn prepare_test_files(crate_root: &Path) {
         "test-dwarf-v5-zlib.bin",
         &["-gstrict-dwarf", "-gdwarf-5", "-gz=zlib"],
     );
+    if cfg!(feature = "zstd") {
+        cc(
+            &src,
+            "test-dwarf-v5-zstd.bin",
+            &["-gstrict-dwarf", "-gdwarf-5", "-gz=zstd"],
+        );
+    }
 
     let src = crate_root.join("data").join("test-wait.c");
     cc(&src, "test-wait.bin", &[]);
@@ -413,6 +420,23 @@ fn prepare_test_files(crate_root: &Path) {
             src_cu2,
         ],
     );
+    if cfg!(feature = "zstd") {
+        cc(
+            &src,
+            "test-stable-addresses-compressed-debug-zstd.bin",
+            &[
+                "-gdwarf-4",
+                "-T",
+                ld_script,
+                "-Wl,--build-id=none",
+                "-O0",
+                "-nostdlib",
+                "-gz=zstd",
+                // TODO: Eventually we may want to make `cc` multi-input-file aware.
+                src_cu2,
+            ],
+        );
+    }
     cc(
         &src,
         "test-stable-addresses-no-dwarf.bin",

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -50,6 +50,8 @@ which = {version = "6.0.0", optional = true}
 
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
+# TODO: Enable `zstd` feature once we enabled it for testing in the main
+#       crate.
 blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "zlib"]}
 # TODO: Remove dependency one MSRV is 1.77.
 memoffset = "0.9"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,8 @@ grev = "0.1.3"
 
 [dependencies]
 anyhow = "1.0.68"
+# TODO: Enable `zstd` feature once we enabled it for testing in the main
+#       crate.
 blazesym = {version = "=0.2.0-alpha.11", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
 clap = {version = "4.1.7", features = ["derive"]}
 clap_complete = {version = "4.1.1", optional = true}

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -487,6 +487,8 @@ mod tests {
             "test-dwarf-v4.bin",
             "test-dwarf-v5.bin",
             "test-dwarf-v5-zlib.bin",
+            #[cfg(feature = "zstd")]
+            "test-dwarf-v5-zstd.bin",
         ];
 
         for binary in binaries {
@@ -526,6 +528,8 @@ mod tests {
             "test-dwarf-v4.bin",
             "test-dwarf-v5.bin",
             "test-dwarf-v5-zlib.bin",
+            #[cfg(feature = "zstd")]
+            "test-dwarf-v5-zstd.bin",
         ];
 
         for binary in binaries {

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -104,9 +104,16 @@ fn decompress_zlib(_data: &[u8]) -> Result<Vec<u8>> {
     ))
 }
 
+#[cfg(feature = "zstd")]
+fn decompress_zstd(data: &[u8]) -> Result<Vec<u8>> {
+    use zstd::stream::decode_all;
+    decode_all(data).context("zstd decompression failed")
+}
+
+#[cfg(not(feature = "zstd"))]
 fn decompress_zstd(_data: &[u8]) -> Result<Vec<u8>> {
     Err(Error::with_unsupported(
-        "ELF section is zstd compressed but zstd compression is currently not supported",
+        "ELF section is zstd compressed but zstd compression support is not enabled",
     ))
 }
 

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -128,6 +128,8 @@ fn symbolize_elf_dwarf_gsym() {
         "test-stable-addresses-dwarf-only.bin",
         "test-stable-addresses-lto.bin",
         "test-stable-addresses-compressed-debug-zlib.bin",
+        #[cfg(feature = "zstd")]
+        "test-stable-addresses-compressed-debug-zstd.bin",
     ] {
         let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
@@ -347,6 +349,8 @@ fn symbolize_dwarf_gsym_inlined() {
     for file in [
         "test-stable-addresses-dwarf-only.bin",
         "test-stable-addresses-compressed-debug-zlib.bin",
+        #[cfg(feature = "zstd")]
+        "test-stable-addresses-compressed-debug-zstd.bin",
     ] {
         let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")


### PR DESCRIPTION
Add support for decompressing zstd compressed ELF sections. This is a bit tricky to test by default, at the moment, because most distributions don't ship `zstd` enabled toolchains. For that reason we don't enable the feature or tests by default.