### PR TITLE
Mention zstd decompression support in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
   - Adjusted normalization logic to return references to cached build
     IDs if `cache_build_ids` is `true`
 - Added support for compressed debug information
-  - Added default enabled `zlib` feature
+  - Added `zlib` (default enabled) and `zstd` (default disabled)
 - Adjusted `Inspector::for_each` signature to no longer carry explicit state
   around
 - Introduced `normalize::Reason` enum to provide best guess at why normalization


### PR DESCRIPTION
Make sure to mention the recently added zstd decompression support for ELF sections in the CHANGELOG.