### PR TITLE
Highlight required features in documentation better

### DIFF
--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -25,8 +25,9 @@ use crate::Addr;
 use crate::SymType;
 
 pub use inspector::Inspector;
-#[cfg(feature = "breakpad")]
-pub use source::Breakpad;
+cfg_breakpad! {
+  pub use source::Breakpad;
+}
 pub use source::Elf;
 pub use source::Source;
 

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -107,17 +107,18 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::path::Path;
 
-#[cfg(feature = "apk")]
-pub use source::Apk;
-#[cfg(feature = "breakpad")]
-pub use source::Breakpad;
+cfg_apk! {
+  pub use source::Apk;
+}
+cfg_breakpad! {
+  pub use source::Breakpad;
+}
 pub use source::Elf;
-#[cfg(feature = "gsym")]
-pub use source::Gsym;
-#[cfg(feature = "gsym")]
-pub use source::GsymData;
-#[cfg(feature = "gsym")]
-pub use source::GsymFile;
+cfg_gsym! {
+  pub use source::Gsym;
+  pub use source::GsymData;
+  pub use source::GsymFile;
+}
 pub use source::Kernel;
 pub use source::Process;
 pub use source::Source;


### PR DESCRIPTION
As it turns out, even re-exports of public items need to add the `cfg_attr(docsrs, ...)` attribute, or the generated documentation will not show the necessary features to include said item. Adjust our re-exports accordingly.