### PR TITLE
Correct APK related error messages on invalid input

### DIFF
--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -4,7 +4,7 @@
 //! Fallible functions generally return a `NULL` pointer. To provide
 //! users with a better idea of what went wrong, they additionally set a
 //! thread local last [error code][blaze_err]. This error indicates what
-//! kind of issue caused the operation to fall.
+//! kind of issue caused the operation to fail.
 //! A call to a fallible function always overwrites this error code. As
 //! such, please make sure to check the error before making an
 //! additional API call into the library.

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -810,12 +810,12 @@ impl Symbolizer {
             }) => match input {
                 Input::VirtOffset(..) => {
                     return Err(Error::with_unsupported(
-                        "ELF symbolization does not support virtual offset inputs",
+                        "APK symbolization does not support virtual offset inputs",
                     ))
                 }
                 Input::AbsAddr(..) => {
                     return Err(Error::with_unsupported(
-                        "ELF symbolization does not support absolute address inputs",
+                        "APK symbolization does not support absolute address inputs",
                     ))
                 }
                 Input::FileOffset(offsets) => offsets


### PR DESCRIPTION
When symbolizing APK addresses of unsupported types, the error messages mention "ELF symbolization". That's not entirely incorrect, given that we currently assume ELF files to reside inside, but let's refer to the process as "APK symbolization" for the sake of understanding.