### PR TITLE
capi: Don't create features for various dependencies

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -37,7 +37,7 @@ check-doc-snippets = []
 # up-to-date version of this header should already be available in the
 # include/ directory, so this feature is only necessary when APIs are
 # changed.
-generate-c-header = ["cbindgen", "which"]
+generate-c-header = ["dep:cbindgen", "dep:which"]
 
 [[bench]]
 name = "capi"


### PR DESCRIPTION
Similar to what we did for the main crate with commit a5c4ef57a36b ("Don't create features for various dependencies"), use the 'dep:' syntax for specifying dependencies that we do not need to expose as features.