### PR TITLE
Adjust dwarf::Units::find_function() to return a Unit

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -199,8 +199,7 @@ impl DwarfResolver {
 
     /// Lookup the symbol at an address.
     pub(crate) fn find_sym(&self, addr: Addr) -> Result<Option<IntSym<'_>>, Error> {
-        let result = self.units.find_function(addr)?;
-        if let Some((function, language)) = result {
+        if let Some((function, unit)) = self.units.find_function(addr)? {
             let name = function
                 .name
                 .map(|name| name.to_string())
@@ -214,7 +213,7 @@ impl DwarfResolver {
                 name,
                 addr,
                 size,
-                lang: language.into(),
+                lang: unit.language().into(),
             };
             Ok(Some(sym))
         } else {

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -323,13 +323,13 @@ impl<'dwarf> Units<'dwarf> {
             })
     }
 
-    pub fn find_function(
+    pub(super) fn find_function(
         &self,
         probe: u64,
-    ) -> Result<Option<(&Function<'dwarf>, Option<gimli::DwLang>)>, gimli::Error> {
+    ) -> Result<Option<(&Function<'dwarf>, &Unit<'dwarf>)>, gimli::Error> {
         for unit in self.find_units(probe) {
             if let Some(function) = unit.find_function(probe, self)? {
-                return Ok(Some((function, unit.language())))
+                return Ok(Some((function, unit)))
             }
         }
         Ok(None)


### PR DESCRIPTION
In addition to the `Function` reference, return a `Unit` reference from `dwarf::Units::find_function()` instead of the `Language` previously returned. Doing so will allow for better reuse of data down the line.