### PR TITLE
Merge SymResolver::find_code_info() into SymResolver::find_sym()

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -122,7 +122,7 @@ impl ElfResolver {
     ) -> Result<Self> {
         #[cfg(feature = "dwarf")]
         let backend = if _debug_syms {
-            let dwarf = DwarfResolver::from_parser(parser, code_info)?;
+            let dwarf = DwarfResolver::from_parser(parser)?;
             let backend = ElfBackend::Dwarf(Rc::new(dwarf));
             backend
         } else {
@@ -243,7 +243,7 @@ mod tests {
         assert!(dbg.starts_with("ELF"), "{dbg}");
         assert!(dbg.ends_with("test-stable-addresses.bin"), "{dbg}");
 
-        let dwarf = DwarfResolver::from_parser(parser, true).unwrap();
+        let dwarf = DwarfResolver::from_parser(parser).unwrap();
         let backend = ElfBackend::Dwarf(Rc::new(dwarf));
         let resolver = ElfResolver::with_backend(&path, backend).unwrap();
         let dbg = format!("{resolver:?}");

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -41,7 +41,6 @@ impl FileCache<ElfResolverData> {
         &'slf self,
         path: &Path,
         debug_syms: bool,
-        code_info: bool,
     ) -> Result<&'slf Rc<ElfResolver>> {
         let (file, cell) = self.entry(path)?;
         let resolver = if let Some(data) = cell.get() {
@@ -52,7 +51,7 @@ impl FileCache<ElfResolverData> {
                     //         initializing the `dwarf` part of it, the
                     //         `elf` part *must* be present.
                     let parser = data.elf.get().unwrap().parser().clone();
-                    let resolver = ElfResolver::from_parser(path, parser, debug_syms, code_info)?;
+                    let resolver = ElfResolver::from_parser(path, parser, debug_syms)?;
                     let resolver = Rc::new(resolver);
                     Result::<_, Error>::Ok(resolver)
                 })?
@@ -63,7 +62,7 @@ impl FileCache<ElfResolverData> {
                     //         initializing the `elf` part of it, the
                     //         `dwarf` part *must* be present.
                     let parser = data.dwarf.get().unwrap().parser().clone();
-                    let resolver = ElfResolver::from_parser(path, parser, debug_syms, code_info)?;
+                    let resolver = ElfResolver::from_parser(path, parser, debug_syms)?;
                     let resolver = Rc::new(resolver);
                     Result::<_, Error>::Ok(resolver)
                 })?
@@ -71,7 +70,7 @@ impl FileCache<ElfResolverData> {
             .clone()
         } else {
             let parser = Rc::new(ElfParser::open_file(file)?);
-            let resolver = ElfResolver::from_parser(path, parser, debug_syms, code_info)?;
+            let resolver = ElfResolver::from_parser(path, parser, debug_syms)?;
             Rc::new(resolver)
         };
 
@@ -118,7 +117,6 @@ impl ElfResolver {
         path: &Path,
         parser: Rc<ElfParser>,
         _debug_syms: bool,
-        code_info: bool,
     ) -> Result<Self> {
         #[cfg(feature = "dwarf")]
         let backend = if _debug_syms {

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -395,14 +395,26 @@ mod tests {
 
         // `main` resides at address 0x2000000, and it's located at the given
         // line.
-        let info = resolver.find_code_info(0x2000000, true).unwrap().unwrap();
+        let (sym, info) = resolver
+            .find_sym(0x2000000, &FindSymOpts::CodeInfoAndInlined)
+            .unwrap()
+            .unwrap();
+        assert_eq!(sym.name, "main");
+
+        let info = info.unwrap();
         assert_eq!(info.direct.1.line, Some(65));
         assert_eq!(info.direct.1.file, OsStr::new("test-stable-addresses.c"));
         assert_eq!(info.inlined, Vec::new());
 
         // `factorial` resides at address 0x2000100, and it's located at the
         // given line.
-        let info = resolver.find_code_info(0x2000100, true).unwrap().unwrap();
+        let (sym, info) = resolver
+            .find_sym(0x2000100, &FindSymOpts::CodeInfoAndInlined)
+            .unwrap()
+            .unwrap();
+        assert_eq!(sym.name, "factorial");
+
+        let info = info.unwrap();
         assert_eq!(info.direct.1.line, Some(10));
         assert_eq!(info.direct.1.file, OsStr::new("test-stable-addresses.c"));
         assert_eq!(info.inlined, Vec::new());
@@ -434,7 +446,13 @@ mod tests {
         assert_eq!(frame.file, OsStr::new("test-stable-addresses.c"));
         assert_eq!(frame.line, Some(23));
 
-        let info = resolver.find_code_info(addr, false).unwrap().unwrap();
+        let (_sym, info) = resolver
+            .find_sym(addr, &FindSymOpts::CodeInfo)
+            .unwrap()
+            .unwrap();
+        assert_eq!(sym.name, "factorial_inline_test");
+
+        let info = info.unwrap();
         // Note that the line number reported without inline information is
         // different to that when using inlined function information, because in
         // Gsym this additional data is used to "refine" the result.

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -99,8 +99,7 @@ impl Inspector {
                 debug_syms,
                 _non_exhaustive: (),
             }) => {
-                let code_info = true;
-                let resolver = self.elf_cache.elf_resolver(path, *debug_syms, code_info)?;
+                let resolver = self.elf_cache.elf_resolver(path, *debug_syms)?;
                 resolver.deref() as &dyn SymResolver
             }
         };
@@ -170,8 +169,7 @@ impl Inspector {
                         offset_in_file: true,
                         sym_type: SymType::Undefined,
                     };
-                    let code_info = true;
-                    let resolver = slf.elf_cache.elf_resolver(path, *debug_syms, code_info)?;
+                    let resolver = slf.elf_cache.elf_resolver(path, *debug_syms)?;
                     let parser = resolver.parser();
                     parser.for_each_sym(&opts, f)
                 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::symbolize::AddrCodeInfo;
+use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::Addr;
@@ -18,15 +19,12 @@ where
     Self: Debug,
 {
     /// Find the symbol corresponding to the given address.
-    fn find_sym(&self, addr: Addr) -> Result<Result<IntSym<'_>, Reason>>;
+    fn find_sym(
+        &self,
+        addr: Addr,
+        opts: &FindSymOpts,
+    ) -> Result<Result<(IntSym<'_>, Option<AddrCodeInfo<'_>>), Reason>>;
+
     /// Find information about a symbol given its name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'_>>>;
-    /// Finds the source code location for a given address.
-    ///
-    /// This function tries to find source code information for the given
-    /// address. If no such information was found, `None` will be returned. If
-    /// `inlined_fns` is true, information about inlined calls at the very
-    /// address will also be looked up and reported as the optional
-    /// [`AddrCodeInfo::inlined`] attribute.
-    fn find_code_info(&self, addr: Addr, inlined_fns: bool) -> Result<Option<AddrCodeInfo<'_>>>;
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -129,6 +129,38 @@ use crate::normalize;
 use crate::Addr;
 
 
+/// Options determining what "parts" of a symbol to look up.
+#[derive(Debug)]
+pub(crate) enum FindSymOpts {
+    /// Only look up the "basic" symbol data (name, address, size, ...), without
+    /// source code location and inlined function information.
+    Basic,
+    /// Look up symbol data and source code location information.
+    CodeInfo,
+    /// Look up symbol data, source code location information, and inlined
+    /// function information.
+    CodeInfoAndInlined,
+}
+
+impl FindSymOpts {
+    #[inline]
+    pub(crate) fn code_info(&self) -> bool {
+        match self {
+            Self::Basic => false,
+            Self::CodeInfo | Self::CodeInfoAndInlined => true,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn inlined_fns(&self) -> bool {
+        match self {
+            Self::Basic | Self::CodeInfo => false,
+            Self::CodeInfoAndInlined => true,
+        }
+    }
+}
+
+
 /// A enumeration of the different input types the symbolization APIs
 /// support.
 #[derive(Clone, Copy, Debug)]

--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -11,24 +11,22 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str;
 
+use crate::inspect::FindAddrOpts;
+use crate::inspect::SymInfo;
+use crate::mmap::Mmap;
+use crate::resolver::SymResolver;
+use crate::symbolize::AddrCodeInfo;
+use crate::symbolize::FindSymOpts;
+use crate::symbolize::IntSym;
+use crate::symbolize::Reason;
+use crate::symbolize::SrcLang;
+use crate::util::find_match_or_lower_bound_by_key;
 use crate::Addr;
 use crate::Error;
 use crate::ErrorExt as _;
 use crate::IntoError as _;
 use crate::Pid;
-
-use crate::inspect::FindAddrOpts;
-use crate::inspect::SymInfo;
-use crate::mmap::Mmap;
-use crate::resolver::SymResolver;
-use crate::util::find_match_or_lower_bound_by_key;
 use crate::Result;
-
-use crate::symbolize::AddrCodeInfo;
-use crate::symbolize::IntSym;
-use crate::symbolize::Reason;
-
-use super::SrcLang;
 
 
 #[derive(Debug, Eq, PartialEq)]
@@ -175,7 +173,11 @@ impl PerfMap {
 }
 
 impl SymResolver for PerfMap {
-    fn find_sym(&self, addr: Addr) -> Result<Result<IntSym<'_>, Reason>> {
+    fn find_sym(
+        &self,
+        addr: Addr,
+        _opts: &FindSymOpts,
+    ) -> Result<Result<(IntSym<'_>, Option<AddrCodeInfo<'_>>), Reason>> {
         let result = find_match_or_lower_bound_by_key(&self.functions, addr, |l| l.addr);
         match result {
             Some(idx) => {
@@ -194,7 +196,7 @@ impl SymResolver for PerfMap {
                             size: Some(*size),
                             lang: SrcLang::Unknown,
                         };
-                        return Ok(Ok(sym))
+                        return Ok(Ok((sym, None)))
                     }
                 }
                 Ok(Err(Reason::UnknownAddr))
@@ -211,11 +213,6 @@ impl SymResolver for PerfMap {
         Err(Error::with_unsupported(
             "Perf map resolver does not currently support lookup by name",
         ))
-    }
-
-    fn find_code_info(&self, _addr: Addr, _inlined_fns: bool) -> Result<Option<AddrCodeInfo<'_>>> {
-        // Perf maps don't carry any source code information.
-        Ok(None)
     }
 }
 
@@ -350,7 +347,10 @@ mod tests {
         let perf_map = PerfMap::from_file(Path::new("SAMPLE_PERF_MAP"), &file).unwrap();
 
         for offset in 0..0xb {
-            let sym = perf_map.find_sym(0x7fbf1fc2144c + offset).unwrap().unwrap();
+            let (sym, _) = perf_map
+                .find_sym(0x7fbf1fc2144c + offset, &FindSymOpts::Basic)
+                .unwrap()
+                .unwrap();
             assert_eq!(sym.name, "py::<module>:<frozen posixpath>");
             assert_eq!(sym.addr, 0x7fbf1fc2144c);
             assert_eq!(sym.size, Some(0xb));

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -59,6 +59,7 @@ use super::source::Kernel;
 use super::source::Process;
 use super::source::Source;
 use super::AddrCodeInfo;
+use super::FindSymOpts;
 use super::InlinedFn;
 use super::Input;
 use super::IntSym;
@@ -146,9 +147,6 @@ pub struct Builder {
     /// symbolization operation.
     auto_reload: bool,
     /// Whether to attempt to gather source code location information.
-    ///
-    /// This setting implies usage of debug symbols and forces the corresponding
-    /// flag to `true`.
     code_info: bool,
     /// Whether to report inlined functions as part of symbolization.
     inlined_fns: bool,
@@ -176,6 +174,8 @@ impl Builder {
     }
 
     /// Enable/disable inlined function reporting.
+    ///
+    /// This option only has an effect if `code_info` is `true`.
     pub fn enable_inlined_fns(mut self, enable: bool) -> Self {
         self.inlined_fns = enable;
         self
@@ -308,40 +308,23 @@ impl Symbolizer {
         addr: Addr,
         resolver: &Resolver<'_, 'slf>,
     ) -> Result<Symbolized<'slf>> {
-        let (sym_name, sym_addr, sym_size, lang) = match resolver {
-            Resolver::Uncached(resolver) => match resolver.find_sym(addr)? {
-                Ok(sym) => {
-                    let IntSym {
-                        name: sym_name,
-                        addr: sym_addr,
-                        size: sym_size,
-                        lang,
-                    } = sym;
-
-                    (Cow::Owned(sym_name.to_string()), sym_addr, sym_size, lang)
-                }
-                Err(reason) => return Ok(Symbolized::Unknown(reason)),
-            },
-            Resolver::Cached(resolver) => match resolver.find_sym(addr)? {
-                Ok(sym) => {
-                    let IntSym {
-                        name: sym_name,
-                        addr: sym_addr,
-                        size: sym_size,
-                        lang,
-                    } = sym;
-
-                    (Cow::Borrowed(sym_name), sym_addr, sym_size, lang)
-                }
-                Err(reason) => return Ok(Symbolized::Unknown(reason)),
-            },
+        let opts = match (self.code_info, self.inlined_fns) {
+            (false, _) => FindSymOpts::Basic,
+            (true, false) => FindSymOpts::CodeInfo,
+            (true, true) => FindSymOpts::CodeInfoAndInlined,
         };
 
-        let (name, code_info, inlined) = if self.code_info {
-            match resolver {
-                Resolver::Uncached(resolver) => {
-                    let addr_code_info = resolver.find_code_info(addr, self.inlined_fns)?;
-                    if let Some(AddrCodeInfo {
+        let (sym_name, sym_addr, sym_size, lang, name, code_info, inlined) = match resolver {
+            Resolver::Uncached(resolver) => match resolver.find_sym(addr, &opts)? {
+                Ok((sym, addr_code_info)) => {
+                    let IntSym {
+                        name: sym_name,
+                        addr: sym_addr,
+                        size: sym_size,
+                        lang,
+                    } = sym;
+
+                    let (name, code_info, inlined) = if let Some(AddrCodeInfo {
                         direct: (direct_name, direct_code_info),
                         inlined,
                     }) = addr_code_info
@@ -362,11 +345,30 @@ impl Symbolizer {
                         (direct_name, Some(direct_code_info), inlined)
                     } else {
                         (None, None, Vec::new())
-                    }
+                    };
+
+                    (
+                        Cow::Owned(sym_name.to_string()),
+                        sym_addr,
+                        sym_size,
+                        lang,
+                        name,
+                        code_info,
+                        inlined,
+                    )
                 }
-                Resolver::Cached(resolver) => {
-                    let addr_code_info = resolver.find_code_info(addr, self.inlined_fns)?;
-                    if let Some(AddrCodeInfo {
+                Err(reason) => return Ok(Symbolized::Unknown(reason)),
+            },
+            Resolver::Cached(resolver) => match resolver.find_sym(addr, &opts)? {
+                Ok((sym, addr_code_info)) => {
+                    let IntSym {
+                        name: sym_name,
+                        addr: sym_addr,
+                        size: sym_size,
+                        lang,
+                    } = sym;
+
+                    let (name, code_info, inlined) = if let Some(AddrCodeInfo {
                         direct: (direct_name, direct_code_info),
                         inlined,
                     }) = addr_code_info
@@ -386,11 +388,20 @@ impl Symbolizer {
                         (direct_name, Some(direct_code_info), inlined)
                     } else {
                         (None, None, Vec::new())
-                    }
+                    };
+
+                    (
+                        Cow::Borrowed(sym_name),
+                        sym_addr,
+                        sym_size,
+                        lang,
+                        name,
+                        code_info,
+                        inlined,
+                    )
                 }
-            }
-        } else {
-            (None, None, Vec::new())
+                Err(reason) => return Ok(Symbolized::Unknown(reason)),
+            },
         };
 
         let sym = Sym {


### PR DESCRIPTION
The SymResolver trait contains two methods used to fulfill symbolization requests: find_sym() unearths basic information about the symbol such as its name, address, and size, and find_code_info() reports additional source code level information, if present.
This split is rather arbitrary and it can be the cause of inefficiencies. Specifically, source code information may be co-located with symbol information and by having this two-way split we may need to perform the same lookup twice. This is obviously the case already in the Breakpad resolver, but it is actually also happening in a more convoluted way in the DWARF logic.
The only conceivable reason why such a split may have been desired in the past in the first place, is to "refine" symbol information from one source with that of another. For example, for kernel symbols one may use kallsyms to report the symbol name, but then look at a potential DWARF file for reporting source code information. While a valid use case, it is niche and generally not all that necessary: if one were to fall back to using *only* DWARF, there should be no issue in practice. This arbitrary split also means that we need to stitch together the final Sym object based on some IntSym and an optional AddrCodeInfo, which requires the existence of those internal types in the first place.

This change merges these two methods into one. It does so in the dumbest way possible: just adjusting the signature of find_sym() and then reusing find_code_info() internally. This is making for some complex logic, but this will get simplified down the line.

Note that, while conceptually a refactoring, this change introduces a slight semantic change to the kernel resolver: where previously it may consult two "resolvers" and stitch the result together, it now only ever consults a single resolver.
