### PR TITLE
Declare IntSym members public

### DIFF
--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -307,13 +307,13 @@ pub(crate) enum SrcLang {
 /// Our internal representation of a symbol.
 pub(crate) struct IntSym<'src> {
     /// The name of the symbol.
-    pub(crate) name: &'src str,
+    pub name: &'src str,
     /// The symbol's normalized address.
-    pub(crate) addr: Addr,
+    pub addr: Addr,
     /// The symbol's size, if available.
-    pub(crate) size: Option<usize>,
+    pub size: Option<usize>,
     /// The source code language from which the symbol originates.
-    pub(crate) lang: SrcLang,
+    pub lang: SrcLang,
 }
 
 


### PR DESCRIPTION
It should be sufficient to restrict visibility of the overall IntSym type to prevent it from leaking outside the crate, but there is no need to restrict member visibility to the same level. Just make the members public.