### PR TITLE
Add AddrCodeInfo member to IntSym

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -8,7 +8,6 @@ use crate::elf::ElfResolver;
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
 use crate::ksym::KSymResolver;
-use crate::symbolize::AddrCodeInfo;
 use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
@@ -42,11 +41,7 @@ impl KernelResolver {
 }
 
 impl SymResolver for KernelResolver {
-    fn find_sym(
-        &self,
-        addr: Addr,
-        opts: &FindSymOpts,
-    ) -> Result<Result<(IntSym<'_>, Option<AddrCodeInfo<'_>>), Reason>> {
+    fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>> {
         // TODO: If an `ElfResolver` is available we probably should give
         //       preference to it, if for no other reason than the fact that it
         //       may report source code location information.

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use crate::inspect::FindAddrOpts;
 use crate::inspect::SymInfo;
-use crate::symbolize::AddrCodeInfo;
 use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
@@ -19,11 +18,7 @@ where
     Self: Debug,
 {
     /// Find the symbol corresponding to the given address.
-    fn find_sym(
-        &self,
-        addr: Addr,
-        opts: &FindSymOpts,
-    ) -> Result<Result<(IntSym<'_>, Option<AddrCodeInfo<'_>>), Reason>>;
+    fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>>;
 
     /// Find information about a symbol given its name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'_>>>;

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -314,6 +314,8 @@ pub(crate) struct IntSym<'src> {
     pub size: Option<usize>,
     /// The source code language from which the symbol originates.
     pub lang: SrcLang,
+    /// Source code location information.
+    pub code_info: Option<AddrCodeInfo<'src>>,
 }
 
 

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -321,12 +321,13 @@ impl Symbolizer {
     ) -> Result<Symbolized<'slf>> {
         let (sym_name, sym_addr, sym_size, lang, name, code_info, inlined) = match resolver {
             Resolver::Uncached(resolver) => match resolver.find_sym(addr, &self.find_sym_opts)? {
-                Ok((sym, addr_code_info)) => {
+                Ok(sym) => {
                     let IntSym {
                         name: sym_name,
                         addr: sym_addr,
                         size: sym_size,
                         lang,
+                        code_info: addr_code_info,
                     } = sym;
 
                     let (name, code_info, inlined) = if let Some(AddrCodeInfo {
@@ -365,12 +366,13 @@ impl Symbolizer {
                 Err(reason) => return Ok(Symbolized::Unknown(reason)),
             },
             Resolver::Cached(resolver) => match resolver.find_sym(addr, &self.find_sym_opts)? {
-                Ok((sym, addr_code_info)) => {
+                Ok(sym) => {
                     let IntSym {
                         name: sym_name,
                         addr: sym_addr,
                         size: sym_size,
                         lang,
+                        code_info: addr_code_info,
                     } = sym;
 
                     let (name, code_info, inlined) = if let Some(AddrCodeInfo {


### PR DESCRIPTION
With recent refactorings, the signature of the `SymResolver::find_sym()` method has become rather...convoluted. Now that `SymResolver::find_code_info()` is no more, the need for keeping source code location information separate from the symbol data has vanished. This change adds a `AddrCodeInfo` member to the `IntSym` type to reflect that fact and simplify the signature of `SymResolver::find_sym()`.