### PR TITLE
Refactor {Dwarf,Gsym}Resolver::find_code_info() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
   - Adjusted normalization logic to return references to cached build
     IDs if `cache_build_ids` is `true`
 - Added support for compressed debug information
-  - Added `zlib` (default enabled) and `zstd` (default disabled)
+  - Added `zlib` (default enabled) and `zstd` (default disabled) features
 - Adjusted `Inspector::for_each` signature to no longer carry explicit state
   around
 - Introduced `normalize::Reason` enum to provide best guess at why normalization


### PR DESCRIPTION
Refactor the {Dwarf,Gsym}Resolver::find_code_info() methods slightly, by passing in the FindSymOpts object directly.