### PR TITLE
Simplify source code location reporting logic

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -175,6 +175,7 @@ impl SymResolver for ElfResolver {
                     // ELF doesn't carry source code location
                     // information.
                     code_info: None,
+                    inlined: Box::new([]),
                 }
             });
 

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -43,6 +43,7 @@ impl<'ksym> From<&'ksym Ksym> for IntSym<'ksym> {
             lang: SrcLang::Unknown,
             // kallsyms doesn't have source code location information.
             code_info: None,
+            inlined: Box::new([]),
         }
     }
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -214,20 +214,6 @@ where
 }
 
 
-#[derive(Debug, PartialEq)]
-pub(crate) struct AddrCodeInfo<'src> {
-    /// Source information about the top-level frame belonging to an
-    /// address.
-    ///
-    /// It also contains an optional name, which is necessary for
-    /// formats where inline information can "correct" (overwrite) the
-    /// name of the symbol.
-    pub direct: (Option<&'src str>, CodeInfo<'src>),
-    /// Source information about inlined functions, along with their names.
-    pub inlined: Vec<(&'src str, Option<CodeInfo<'src>>)>,
-}
-
-
 /// Source code location information for a symbol or inlined function.
 #[derive(Clone, Debug, PartialEq)]
 pub struct CodeInfo<'src> {
@@ -315,7 +301,9 @@ pub(crate) struct IntSym<'src> {
     /// The source code language from which the symbol originates.
     pub lang: SrcLang,
     /// Source code location information.
-    pub code_info: Option<AddrCodeInfo<'src>>,
+    pub code_info: Option<CodeInfo<'src>>,
+    /// Inlined function information.
+    pub inlined: Box<[InlinedFn<'src>]>,
 }
 
 
@@ -491,12 +479,6 @@ mod tests {
 
         let symbolized = Symbolized::Sym(sym);
         assert_ne!(format!("{symbolized:?}"), "");
-
-        let addr_code_info = AddrCodeInfo {
-            direct: (None, code_info),
-            inlined: Vec::new(),
-        };
-        assert_ne!(format!("{addr_code_info:?}"), "");
     }
 
     /// Exercise the `Display` representation of various types.

--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -191,6 +191,7 @@ impl SymResolver for PerfMap {
                             size: Some(*size),
                             lang: SrcLang::Unknown,
                             code_info: None,
+                            inlined: Box::new([]),
                         };
                         return Ok(Ok(sym))
                     }


### PR DESCRIPTION
Ever since we added Gsym inline function reporting support, we had to do this weird dance of bubbling up a AddrCodeInfo object which we then use to fix up reported symbol names conditionally. That was necessary due to...the unnecessary split between SymResolver::find_code_info() and SymResolver::find_sym().
Now that this split is no longer present, this change moves the inlined function information data directly into the IntSym type. Once we do that, we can move the symbol name fixup to exactly the place where it is needed: inside the GsymResolver. That in turn simplifies the logic in Symbolizer::symbolize_with_resolver() in a major way and just generally concentrates related bits of functionality in a single location instead of spreading them over multiple places. It also means that our IntSym is very close in nature to the public Sym type, which is a great property to have, as it makes it clear what additional data we use internally.