### PR TITLE
Factor out Inspect trait

### DIFF
--- a/src/breakpad/resolver.rs
+++ b/src/breakpad/resolver.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::inspect::FindAddrOpts;
+use crate::inspect::Inspect;
 use crate::inspect::SymInfo;
 use crate::mmap::Mmap;
 use crate::symbolize::CodeInfo;
@@ -207,7 +208,9 @@ impl SymResolver for BreakpadResolver {
 
         Ok(Ok(sym))
     }
+}
 
+impl Inspect for BreakpadResolver {
     fn find_addr<'slf>(&'slf self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'slf>>> {
         if let SymType::Variable = opts.sym_type {
             return Err(Error::with_unsupported(

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 use crate::dwarf::DwarfResolver;
 use crate::file_cache::FileCache;
 use crate::inspect::FindAddrOpts;
+use crate::inspect::Inspect;
 use crate::inspect::SymInfo;
 use crate::once::OnceCell;
 use crate::symbolize::FindSymOpts;
@@ -181,7 +182,9 @@ impl SymResolver for ElfResolver {
 
         Ok(result)
     }
+}
 
+impl Inspect for ElfResolver {
     fn find_addr<'slf>(&'slf self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'slf>>> {
         fn find_addr_impl<'slf>(
             slf: &'slf ElfResolver,

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -9,8 +9,6 @@ use std::mem::swap;
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::inspect::FindAddrOpts;
-use crate::inspect::SymInfo;
 use crate::mmap::Mmap;
 use crate::symbolize::CodeInfo;
 use crate::symbolize::FindSymOpts;
@@ -19,7 +17,6 @@ use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::symbolize::SrcLang;
 use crate::Addr;
-use crate::Error;
 use crate::IntoError as _;
 use crate::Result;
 use crate::SymResolver;
@@ -206,18 +203,6 @@ impl SymResolver for GsymResolver<'_> {
             Ok(Err(Reason::UnknownAddr))
         }
     }
-
-    fn find_addr<'slf>(
-        &'slf self,
-        _name: &str,
-        _opts: &FindAddrOpts,
-    ) -> Result<Vec<SymInfo<'slf>>> {
-        // It is inefficient to find the address of a symbol with
-        // Gsym. We may support it in the future if needed.
-        Err(Error::with_unsupported(
-            "Gsym resolver does not currently support lookup by name",
-        ))
-    }
 }
 
 impl GsymResolver<'_> {
@@ -346,8 +331,6 @@ mod tests {
 
     use test_log::test;
 
-    use crate::ErrorKind;
-
 
     /// Exercise the `Debug` representation of various types.
     #[test]
@@ -449,18 +432,5 @@ mod tests {
         // Gsym this additional data is used to "refine" the result.
         assert_eq!(info.line, Some(23));
         assert_eq!(info.file, OsStr::new("test-stable-addresses.c"));
-    }
-
-    /// Check that [`GsymResolver::find_addr`] behaves as expected.
-    #[test]
-    fn unsupported_find_addr() {
-        let test_gsym = Path::new(&env!("CARGO_MANIFEST_DIR"))
-            .join("data")
-            .join("test-stable-addresses.gsym");
-        let resolver = GsymResolver::new(test_gsym).unwrap();
-        let err = resolver
-            .find_addr("factorial", &FindAddrOpts::default())
-            .unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::Unsupported);
     }
 }

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -11,13 +11,13 @@ use crate::breakpad::BreakpadResolver;
 use crate::elf::ElfResolverData;
 use crate::file_cache::FileCache;
 use crate::Result;
-use crate::SymResolver;
 
 #[cfg(feature = "breakpad")]
 use super::source::Breakpad;
 use super::source::Elf;
 use super::source::Source;
 use super::FindAddrOpts;
+use super::Inspect;
 use super::SymInfo;
 use super::SymType;
 
@@ -92,7 +92,7 @@ impl Inspector {
                 _non_exhaustive: (),
             }) => {
                 let resolver = self.breakpad_resolver(path)?;
-                resolver.deref() as &dyn SymResolver
+                resolver.deref() as &dyn Inspect
             }
             Source::Elf(Elf {
                 path,
@@ -100,7 +100,7 @@ impl Inspector {
                 _non_exhaustive: (),
             }) => {
                 let resolver = self.elf_cache.elf_resolver(path, *debug_syms)?;
-                resolver.deref() as &dyn SymResolver
+                resolver.deref() as &dyn Inspect
             }
         };
 

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -19,9 +19,11 @@ mod inspector;
 mod source;
 
 use std::borrow::Cow;
+use std::fmt::Debug;
 use std::path::Path;
 
 use crate::Addr;
+use crate::Result;
 use crate::SymType;
 
 pub use inspector::Inspector;
@@ -81,4 +83,14 @@ pub(crate) struct FindAddrOpts {
     /// [`Undefined`][SymType::Undefined] indicates that all supported
     /// symbols are of interest.
     pub sym_type: SymType,
+}
+
+
+/// The trait providing inspection functionality.
+pub(crate) trait Inspect
+where
+    Self: Debug,
+{
+    /// Find information about a symbol given its name.
+    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'_>>>;
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -5,8 +5,6 @@ use std::path::Path;
 use std::rc::Rc;
 
 use crate::elf::ElfResolver;
-use crate::inspect::FindAddrOpts;
-use crate::inspect::SymInfo;
 use crate::ksym::KSymResolver;
 use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
@@ -50,14 +48,6 @@ impl SymResolver for KernelResolver {
         } else {
             self.elf_resolver.as_ref().unwrap().find_sym(addr, opts)
         }
-    }
-
-    fn find_addr<'slf>(
-        &'slf self,
-        _name: &str,
-        _opts: &FindAddrOpts,
-    ) -> Result<Vec<SymInfo<'slf>>> {
-        Ok(Vec::new())
     }
 }
 

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::inspect::FindAddrOpts;
+use crate::inspect::Inspect;
 use crate::inspect::SymInfo;
 use crate::once::OnceCell;
 use crate::symbolize::FindSymOpts;
@@ -127,7 +128,9 @@ impl SymResolver for KSymResolver {
         let sym = self.find_ksym(addr).map(IntSym::from);
         Ok(sym)
     }
+}
 
+impl Inspect for KSymResolver {
     fn find_addr<'slf>(&'slf self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'slf>>> {
         if let SymType::Variable = opts.sym_type {
             return Ok(Vec::new())

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,7 +1,5 @@
 use std::fmt::Debug;
 
-use crate::inspect::FindAddrOpts;
-use crate::inspect::SymInfo;
 use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
@@ -19,7 +17,4 @@ where
 {
     /// Find the symbol corresponding to the given address.
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>>;
-
-    /// Find information about a symbol given its name.
-    fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'_>>>;
 }


### PR DESCRIPTION
Ever since the beginning of time, most internals have evolved around the SymResolver trait. As we double down on providing inspection functionality (such as iteration over all symbols), this trait felt more a more like the wrong abstraction. The reason being that some symbol sources basically by design don't support such inspection. That led to shenanigans such as methods being effectively unimplemented, but returned an error, which then meant that we needed tests for this unimplemented functionality, to not have abysmal code coverage numbers. Long story short, the SymResolver trait as-is, is not quite the right abstraction.
This change takes a first step towards mitigating this issue. Specifically, we factor out the Inspect trait, which encapsulates the already present inspection functionality. We only implement it for "resolver" that actually provide means for inspection, eliminating a bunch of clutter in the process. Long term we may want to extend this trait with symbol iteration functionality (for_each logic) or remove it all together. It's not clear whether it's a terribly useful abstraction, but for now we want to preserve the "grouping" that any such trait provides.