### PR TITLE
Rename SymResolver to Symbolize and move it into symbolize module

### DIFF
--- a/src/breakpad/resolver.rs
+++ b/src/breakpad/resolver.rs
@@ -18,12 +18,12 @@ use crate::symbolize::InlinedFn;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::symbolize::SrcLang;
+use crate::symbolize::Symbolize;
 use crate::Addr;
 use crate::Error;
 use crate::ErrorExt as _;
 use crate::IntoError as _;
 use crate::Result;
-use crate::SymResolver;
 use crate::SymType;
 
 use super::types::Function;
@@ -182,7 +182,7 @@ impl BreakpadResolver {
     }
 }
 
-impl SymResolver for BreakpadResolver {
+impl Symbolize for BreakpadResolver {
     #[cfg_attr(feature = "tracing", crate::log::instrument(fields(addr = format_args!("{addr:#x}"))))]
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>> {
         let func = if let Some(func) = self.symbol_file.find_function(addr) {

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -17,10 +17,10 @@ use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::symbolize::SrcLang;
+use crate::symbolize::Symbolize;
 use crate::Addr;
 use crate::Error;
 use crate::Result;
-use crate::SymResolver;
 use crate::SymType;
 
 use super::ElfBackend;
@@ -148,7 +148,7 @@ impl ElfResolver {
     }
 }
 
-impl SymResolver for ElfResolver {
+impl Symbolize for ElfResolver {
     #[cfg_attr(feature = "tracing", crate::log::instrument(fields(addr = format_args!("{addr:#x}"))))]
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>> {
         #[cfg(feature = "dwarf")]

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -16,10 +16,10 @@ use crate::symbolize::InlinedFn;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::symbolize::SrcLang;
+use crate::symbolize::Symbolize;
 use crate::Addr;
 use crate::IntoError as _;
 use crate::Result;
-use crate::SymResolver;
 
 use super::inline::InlineInfo;
 use super::linetab::run_op;
@@ -160,7 +160,7 @@ impl<'dat> GsymResolver<'dat> {
     }
 }
 
-impl SymResolver for GsymResolver<'_> {
+impl Symbolize for GsymResolver<'_> {
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>> {
         if let Some(idx) = self.ctx.find_addr(addr) {
             let sym_addr = self

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -9,10 +9,10 @@ use crate::ksym::KSymResolver;
 use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
+use crate::symbolize::Symbolize;
 use crate::Addr;
 use crate::Error;
 use crate::Result;
-use crate::SymResolver;
 
 
 pub(crate) struct KernelResolver {
@@ -38,7 +38,7 @@ impl KernelResolver {
     }
 }
 
-impl SymResolver for KernelResolver {
+impl Symbolize for KernelResolver {
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>> {
         // TODO: If an `ElfResolver` is available we probably should give
         //       preference to it, if for no other reason than the fact that it

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -16,10 +16,10 @@ use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::symbolize::SrcLang;
+use crate::symbolize::Symbolize;
 use crate::util::find_match_or_lower_bound_by_key;
 use crate::Addr;
 use crate::Result;
-use crate::SymResolver;
 use crate::SymType;
 
 pub const KALLSYMS: &str = "/proc/kallsyms";
@@ -123,7 +123,7 @@ impl KSymResolver {
     }
 }
 
-impl SymResolver for KSymResolver {
+impl Symbolize for KSymResolver {
     fn find_sym(&self, addr: Addr, _opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>> {
         let sym = self.find_ksym(addr).map(IntSym::from);
         Ok(sym)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,15 +70,12 @@ mod mmap;
 pub mod normalize;
 mod once;
 mod pid;
-mod resolver;
 pub mod symbolize;
 mod util;
 #[cfg(feature = "apk")]
 mod zip;
 
 use std::result;
-
-use resolver::SymResolver;
 
 
 pub use crate::error::Error;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -5,16 +5,3 @@ use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::Addr;
 use crate::Result;
-
-
-/// The trait of symbol resolvers.
-///
-/// An symbol resolver usually provides information from one symbol
-/// source; e.g., a symbol file.
-pub(crate) trait SymResolver
-where
-    Self: Debug,
-{
-    /// Find the symbol corresponding to the given address.
-    fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>>;
-}

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -102,6 +102,7 @@ mod symbolizer;
 
 use std::borrow::Cow;
 use std::ffi::OsStr;
+use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
@@ -127,6 +128,7 @@ pub use symbolizer::Symbolizer;
 
 use crate::normalize;
 use crate::Addr;
+use crate::Result;
 
 
 /// Options determining what "parts" of a symbol to look up.
@@ -439,6 +441,17 @@ impl<'src> Symbolized<'src> {
         }
     }
 }
+
+
+/// The trait for types providing address symbolization services.
+pub(crate) trait Symbolize
+where
+    Self: Debug,
+{
+    /// Find the symbol corresponding to the given address.
+    fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>>;
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -12,11 +12,11 @@ use std::path::PathBuf;
 use std::str;
 
 use crate::mmap::Mmap;
-use crate::resolver::SymResolver;
 use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::symbolize::SrcLang;
+use crate::symbolize::Symbolize;
 use crate::util::find_match_or_lower_bound_by_key;
 use crate::Addr;
 use crate::Error;
@@ -169,7 +169,7 @@ impl PerfMap {
     }
 }
 
-impl SymResolver for PerfMap {
+impl Symbolize for PerfMap {
     fn find_sym(&self, addr: Addr, _opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>> {
         let result = find_match_or_lower_bound_by_key(&self.functions, addr, |l| l.addr);
         match result {

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -43,7 +43,6 @@ use crate::ErrorKind;
 use crate::IntoError as _;
 use crate::Pid;
 use crate::Result;
-use crate::SymResolver;
 
 use super::perf_map::PerfMap;
 #[cfg(feature = "apk")]
@@ -66,6 +65,7 @@ use super::IntSym;
 use super::Reason;
 use super::SrcLang;
 use super::Sym;
+use super::Symbolize;
 use super::Symbolized;
 
 
@@ -256,8 +256,8 @@ impl Default for Builder {
 /// hand out references to mmap'ed data.
 #[derive(Debug)]
 enum Resolver<'tmp, 'slf> {
-    Uncached(&'tmp (dyn SymResolver + 'tmp)),
-    Cached(&'slf dyn SymResolver),
+    Uncached(&'tmp (dyn Symbolize + 'tmp)),
+    Cached(&'slf dyn Symbolize),
 }
 
 


### PR DESCRIPTION
The SymResolver trait now solely caters to address symbolization use cases. Rename it to Symbolize to reflect that fact better. Furthermore, move it into the symbolize module fortify this property further.