### PR TITLE
Hand out cached results for breakpad symbolization

### DIFF
--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -9,6 +9,7 @@ use std::mem::swap;
 use std::path::Path;
 use std::path::PathBuf;
 
+use crate::log::warn;
 use crate::mmap::Mmap;
 use crate::symbolize::CodeInfo;
 use crate::symbolize::FindSymOpts;
@@ -31,7 +32,6 @@ use super::parser::GsymContext;
 use super::types::AddrInfo;
 use super::types::INFO_TYPE_INLINE_INFO;
 use super::types::INFO_TYPE_LINE_TABLE_INFO;
-use crate::log::warn;
 
 
 #[allow(dead_code)]

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -825,7 +825,7 @@ impl Symbolizer {
                 };
 
                 let resolver = self.breakpad_resolver(path)?;
-                let symbols = self.symbolize_addrs(addrs, &Resolver::Uncached(resolver.deref()))?;
+                let symbols = self.symbolize_addrs(addrs, &Resolver::Cached(resolver.deref()))?;
                 Ok(symbols)
             }
             Source::Elf(Elf {


### PR DESCRIPTION
With commit e016426cfcfd ("Remove dependency on circular crate") we switched over to memory mapping breakpad source files and then parsing data directly from that mapped memory as opposed to reading everything into a buffer first using "regular" file IO.
On top of simplifying the logic tremendously, this switch turns out to have another positive side-effect: we no longer have to necessarily allocate the symbol data that we hand out, because we use zero-copy parsing and can just reference memory mapped data directly. To that end, this change switches us over to using the "cached" resolver variant on the breakpad symbolization path, which will cause elimination of unnecessary allocations.