### PR TITLE
Adjust DwarfResolver::find_sym() signature to mirror Symbolize::find_…

### DIFF
--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -440,6 +440,12 @@ impl<'dwarf> Units<'dwarf> {
     pub(super) fn dwarf(&self) -> &gimli::Dwarf<R<'dwarf>> {
         &self.dwarf
     }
+
+    /// Check whether no units are present at all.
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.unit_ranges.is_empty()
+    }
 }
 
 

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -153,7 +153,7 @@ impl Symbolize for ElfResolver {
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<IntSym<'_>, Reason>> {
         #[cfg(feature = "dwarf")]
         if let ElfBackend::Dwarf(dwarf) = &self.backend {
-            if let Some(sym) = dwarf.find_sym(addr, opts)? {
+            if let Ok(sym) = dwarf.find_sym(addr, opts)? {
                 return Ok(Ok(sym))
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! relevance for C).
 
 #![allow(
+    clippy::collapsible_else_if,
     clippy::collapsible_if,
     clippy::fn_to_numeric_cast,
     clippy::let_and_return,


### PR DESCRIPTION
…sym()'s

Adjust the signature of the DwarfResolver::find_sym() method to mirror that of Symbolize::find_sym(). Doing so will allow us to implement the trait for DwarfResolver down the line.