### PR TITLE
Move file name from ElfResolver into ElfParser

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -190,7 +190,7 @@ impl Inspect for DwarfResolver {
                                 .then(|| self.parser.find_file_offset(addr))
                                 .transpose()?
                                 .flatten(),
-                            obj_file_name: None,
+                            obj_file_name: Some(Cow::Borrowed(self.parser.path())),
                         };
                         Ok(info)
                     }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -63,7 +63,7 @@ impl Debug for KernelResolver {
                 .display(),
             self.elf_resolver
                 .as_ref()
-                .map(|resolver| resolver.file_name())
+                .map(|resolver| resolver.path())
                 .unwrap_or_else(|| Path::new(""))
                 .display(),
         )

--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -134,7 +134,7 @@ impl<'src> BuildIdReader<'src> for CachingBuildIdReader<'src> {
         let (file, cell) = self.cache.entry(path)?;
         let build_id = cell
             .get_or_try_init(|| {
-                let parser = ElfParser::open_file(file)?;
+                let parser = ElfParser::open_file(file, path)?;
                 let buildid =
                     read_build_id_impl(&parser)?.map(|buildid| Cow::Owned(buildid.to_vec()));
                 Result::<_, Error>::Ok(buildid)

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -376,10 +376,10 @@ mod tests {
             .join("data")
             .join("libtest-so.so");
 
-        let mmap = Mmap::builder().exec().open(test_so).unwrap();
+        let mmap = Mmap::builder().exec().open(&test_so).unwrap();
         // Look up the address of the `the_answer` function inside of the shared
         // object.
-        let elf_parser = ElfParser::from_mmap(mmap.clone());
+        let elf_parser = ElfParser::from_mmap(mmap.clone(), test_so);
         let opts = FindAddrOpts {
             sym_type: SymType::Function,
             ..Default::default()
@@ -445,7 +445,7 @@ mod tests {
 
             // Look up the address of the `the_answer` function inside of the shared
             // object.
-            let elf_parser = ElfParser::from_mmap(elf_mmap.clone());
+            let elf_parser = ElfParser::from_mmap(elf_mmap.clone(), &test_zip);
             let opts = FindAddrOpts {
                 sym_type: SymType::Function,
                 offset_in_file: true,

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -442,8 +442,8 @@ impl Symbolizer {
                     // Create an Android-style binary-in-APK path for
                     // reporting purposes.
                     let apk_elf_path = create_apk_elf_path(apk_path, apk_entry.path)?;
-                    let parser = Rc::new(ElfParser::from_mmap(mmap));
-                    let resolver = ElfResolver::from_parser(&apk_elf_path, parser, debug_syms)?;
+                    let parser = Rc::new(ElfParser::from_mmap(mmap, apk_elf_path));
+                    let resolver = ElfResolver::from_parser(parser, debug_syms)?;
                     let resolver = Rc::new(resolver);
                     Ok(resolver)
                 })?;
@@ -1161,7 +1161,7 @@ mod tests {
             .join("data")
             .join("test-stable-addresses.bin");
         let parser = Rc::new(ElfParser::open(&test_elf).unwrap());
-        let resolver = ElfResolver::from_parser(&test_elf, parser, false).unwrap();
+        let resolver = ElfResolver::from_parser(parser, false).unwrap();
         let resolver = Resolver::Cached(&resolver);
         assert_ne!(format!("{resolver:?}"), "");
     }
@@ -1303,7 +1303,7 @@ mod tests {
 
         // Look up the address of the `the_answer` function inside of the shared
         // object.
-        let elf_parser = ElfParser::from_mmap(elf_mmap.clone());
+        let elf_parser = ElfParser::from_mmap(elf_mmap.clone(), Path::new("libtest-so.so"));
         let opts = FindAddrOpts {
             sym_type: SymType::Function,
             ..Default::default()

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -374,7 +374,6 @@ mod tests {
     use std::io::Write as _;
     use std::ops::Deref as _;
 
-    use tempfile::tempfile;
     use tempfile::NamedTempFile;
 
     use test_log::test;
@@ -461,10 +460,10 @@ mod tests {
 
         // Sanity check that the entry actually references a valid ELF binary,
         // which is what we expect.
-        let mut file = tempfile().unwrap();
+        let mut file = NamedTempFile::new().unwrap();
         let () = file.write_all(entry.data).unwrap();
 
-        let elf = ElfParser::open_file(&file).unwrap();
+        let elf = ElfParser::open_file(file.as_file(), file.path()).unwrap();
         assert!(elf.find_section(".text").is_ok());
     }
 


### PR DESCRIPTION
Move the file name (or rather: path) of the ELF object operated on from the ElfResolver type into ElfParser. Right now this is the most appropriate location to store it.