### PR TITLE
Make for_each functionality part of Inspect trait

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -201,6 +201,13 @@ impl Inspect for DwarfResolver {
 
         Ok(syms)
     }
+
+    fn for_each(&self, _opts: &FindAddrOpts, _f: &mut dyn FnMut(&SymInfo<'_>)) -> Result<()> {
+        // TODO: Implement this functionality.
+        Err(Error::with_unsupported(
+            "DWARF logic does not currently support symbol iteration",
+        ))
+    }
 }
 
 impl Debug for DwarfResolver {
@@ -384,7 +391,7 @@ mod tests {
 
     /// Check that we fail to look up variables.
     #[test]
-    fn lookup_symbol_wrong_type() {
+    fn unsupported_ops() {
         let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
             .join("test-stable-addresses-dwarf-only.bin");
@@ -395,6 +402,9 @@ mod tests {
         let resolver = DwarfResolver::open(test_dwarf.as_ref()).unwrap();
 
         let err = resolver.find_addr("factorial", &opts).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
+
+        let err = resolver.for_each(&opts, &mut |_| ()).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::Unsupported);
     }
 }

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -811,10 +811,11 @@ impl ElfParser {
     }
 
     /// Perform an operation on each symbol.
-    pub(crate) fn for_each_sym<F>(&self, opts: &FindAddrOpts, mut f: F) -> Result<()>
-    where
-        F: FnMut(&SymInfo<'_>),
-    {
+    pub(crate) fn for_each(
+        &self,
+        opts: &FindAddrOpts,
+        mut f: &mut dyn FnMut(&SymInfo<'_>),
+    ) -> Result<()> {
         let symtab = self.cache.ensure_symtab()?;
         let str2symtab = self.cache.ensure_str2symtab()?;
         let () = self.for_each_sym_impl(opts, symtab, str2symtab, &mut f)?;
@@ -1126,7 +1127,7 @@ mod tests {
         };
         let parser = ElfParser::open(bin_name.as_ref()).unwrap();
         let () = parser
-            .for_each_sym(&opts, |sym| {
+            .for_each(&opts, &mut |sym| {
                 let file_offset = parser.find_file_offset(sym.addr).unwrap();
                 assert_eq!(file_offset, sym.file_offset);
             })

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
+use std::ops::Deref as _;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -169,6 +170,11 @@ impl Inspect for ElfResolver {
         let parser = self.parser();
         let syms = parser.find_addr(name, opts)?;
         Ok(syms)
+    }
+
+    fn for_each(&self, opts: &FindAddrOpts, f: &mut dyn FnMut(&SymInfo<'_>)) -> Result<()> {
+        let parser = self.parser();
+        parser.deref().for_each(opts, f)
     }
 }
 

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -93,4 +93,7 @@ where
 {
     /// Find information about a symbol given its name.
     fn find_addr(&self, name: &str, opts: &FindAddrOpts) -> Result<Vec<SymInfo<'_>>>;
+
+    /// Perform an operation on each symbol.
+    fn for_each(&self, opts: &FindAddrOpts, f: &mut dyn FnMut(&SymInfo<'_>)) -> Result<()>;
 }


### PR DESCRIPTION
The for_each() symbol iteration functionality is currently pretty ad-hoc, with each type having their own variant. Let's unify everything and move it into the Inspect trait, so that we have a bit more structure.