### PR TITLE
Introduce TranslateFileOffset trait

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -861,6 +861,21 @@ impl ElfParser {
         Ok(phdrs)
     }
 
+    /// Translate a file offset into a virtual offset.
+    pub(crate) fn file_offset_to_virt_offset(&self, offset: u64) -> Result<Option<Addr>> {
+        let phdrs = self.program_headers()?;
+        let addr = phdrs.iter().find_map(|phdr| {
+            if phdr.p_type == PT_LOAD {
+                if (phdr.p_offset..phdr.p_offset + phdr.p_memsz).contains(&offset) {
+                    return Some((offset - phdr.p_offset + phdr.p_vaddr) as Addr)
+                }
+            }
+            None
+        });
+
+        Ok(addr)
+    }
+
     #[cfg(test)]
     fn pick_symtab_addr(&self) -> (&str, Addr, usize) {
         let symtab = self.cache.ensure_symtab().unwrap();

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -16,6 +16,7 @@ use crate::symbolize::FindSymOpts;
 use crate::symbolize::IntSym;
 use crate::symbolize::Reason;
 use crate::symbolize::Symbolize;
+use crate::symbolize::TranslateFileOffset;
 use crate::Addr;
 use crate::Error;
 use crate::Result;
@@ -155,6 +156,13 @@ impl Symbolize for ElfResolver {
         let parser = self.parser();
         let result = parser.find_sym(addr, opts)?;
         Ok(result)
+    }
+}
+
+impl TranslateFileOffset for ElfResolver {
+    fn file_offset_to_virt_offset(&self, file_offset: u64) -> Result<Option<Addr>> {
+        let parser = self.parser();
+        parser.file_offset_to_virt_offset(file_offset)
     }
 }
 

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -454,6 +454,20 @@ where
 }
 
 
+/// A trait representing the ability to convert file offsets into virtual
+/// offsets.
+///
+/// Please refer to the [`Input`] enum for an overview of the various offset
+/// types.
+pub(crate) trait TranslateFileOffset
+where
+    Self: Debug,
+{
+    /// Convert the provided file offset into a virtual offset.
+    fn file_offset_to_virt_offset(&self, file_offset: u64) -> Result<Option<Addr>>;
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This change factors out the TranslateFileOffset trait, which provides the ability to map file offsets into virtual offsets. We use it to encapsulate the existing elf_offset_to_address() functionality in a more convenient interface (though right now this is all an implementation detail and could change at any time).