### PR TITLE
Remove Clone impl from symbolize::Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
   was not successful as part of the `normalize::UserMeta::Unknown` variant
 - Reduced number of allocations performed on address normalization and
   process symbolization paths
+- Removed `Clone` impl of `symbolize::Builder` type
 
 
 0.2.0-alpha.11

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -125,7 +125,7 @@ fn maybe_demangle(name: Cow<'_, str>, _language: SrcLang) -> Cow<'_, str> {
 /// A builder for configurable construction of [`Symbolizer`] objects.
 ///
 /// By default all features are enabled.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Builder {
     /// Whether or not to automatically reload file system based
     /// symbolization sources that were updated since the last


### PR DESCRIPTION
There isn't really a convincing case for having a Clone impl for the symbolize::Builder type. Remove it.