### PR TITLE
Populate and use abbreviation cache when parsing DWARF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
   was not successful as part of the `normalize::UserMeta::Unknown` variant
 - Reduced number of allocations performed on address normalization and
   process symbolization paths
+- Improved symbolization performance on certain unoptimized DWARF data
 - Removed `Clone` impl of `symbolize::Builder` type
 
 


### PR DESCRIPTION
We have seen cases where symbolization performance with especially large (10+ GiB) DWARF binaries lacks behind that of llvm-symbolizer. The profile has shown excessive effort being exerted handling abbreviations. What likely is happening on those binaries is that the debug information is not particularly optimized and so abbreviations may end up being duplicated among compilation units, causing them to be reevaluated anew frequently [0].
This is a more or less common problem and to that end gimli even provides the means for managing a cache of said abbreviations. Enable it.

```
  $ ls -lh service
  > -rwxr-xr-x 1 nobody nogroup 11G XXXX-XX-XX XX:XX service

Before:
  $ time blazecli symbolize elf --path service  0x2d0bff94
  > 0x0000002d0bff94: [...]
  > ________________________________________________________
  > Executed in   12.32 secs    fish           external
  >    usr time    7.99 secs    0.00 millis    7.99 secs
  >    sys time    4.32 secs    1.01 millis    4.32 secs

After:
  $ time blazecli symbolize elf --path service  0x2d0bff94
  > 0x0000002d0bff94: [...]
  > ________________________________________________________
  > Executed in    1.36 secs      fish           external
  >    usr time  993.06 millis  216.00 micros  992.85 millis
  >    sys time  370.65 millis  741.00 micros  369.91 millis
```

[0] https://swatinem.de/blog/abbreviations/