### PR TITLE
Start running examples in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,6 +218,15 @@ jobs:
       run: rm .cargo/config.toml
     - name: Run tests
       run: cargo miri test --workspace --features=dont-generate-unit-test-files -- "insert_map::" "util::" "::elf_src_validity"
+  test-examples:
+    name: Test examples
+    runs-on: ubuntu-22.04
+    env:
+      LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo run --example backtrace
   c-header:
     name: Check generated C header
     runs-on: ubuntu-latest

--- a/examples/backtrace.rs
+++ b/examples/backtrace.rs
@@ -71,7 +71,7 @@ fn symbolize_current_bt() {
     let src = Source::Process(Process::new(Pid::Slf));
     let symbolizer = Symbolizer::new();
 
-    let syms = symbolizer.symbolize(&src, Input::VirtOffset(bt)).unwrap();
+    let syms = symbolizer.symbolize(&src, Input::AbsAddr(bt)).unwrap();
     let addrs = bt;
 
     for (input_addr, sym) in addrs.iter().copied().zip(syms) {


### PR DESCRIPTION
Start exercising examples that don't need user input in CI, to make sure that they still work as expected. While at it, fix up the backtrace example, which somehow was using the wrong input address type.