### PR TITLE
Remove Default and Eq impls from OnceCell

### DIFF
--- a/src/once.rs
+++ b/src/once.rs
@@ -139,13 +139,6 @@ impl<T> OnceCell<T> {
     }
 }
 
-impl<T> Default for OnceCell<T> {
-    #[inline]
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<T: fmt::Debug> fmt::Debug for OnceCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_tuple("OnceCell");
@@ -170,15 +163,6 @@ impl<T: Clone> Clone for OnceCell<T> {
         res
     }
 }
-
-impl<T: PartialEq> PartialEq for OnceCell<T> {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.get() == other.get()
-    }
-}
-
-impl<T: Eq> Eq for OnceCell<T> {}
 
 impl<T> From<T> for OnceCell<T> {
     /// Creates a new `OnceCell<T>` which already contains the given `value`.


### PR DESCRIPTION
We don't need the Default and Eq impls on our OnceCell copy. At this point they constitute dead and untested code. Remove them. If needed in the future we should be able to easily bring them back.