### PR TITLE
Rename test-stable-addresses-dwarf-only.bin binary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -449,7 +449,7 @@ fn prepare_test_files() {
 
     let src = data_dir.join("test-stable-addresses.bin");
     gsym(&src, "test-stable-addresses.gsym");
-    dwarf(&src, "test-stable-addresses-dwarf-only.bin");
+    dwarf(&src, "test-stable-addresses-stripped-elf-with-dwarf.bin");
     strip(&src, "test-stable-addresses-stripped.bin", &[]);
     if cfg!(feature = "dump_syms") {
         syms(&src, "test-stable-addresses.sym");
@@ -475,7 +475,7 @@ fn prepare_test_files() {
     .unwrap();
 
     let files = [
-        data_dir.join("test-stable-addresses-dwarf-only.bin"),
+        data_dir.join("test-stable-addresses-stripped-elf-with-dwarf.bin"),
         data_dir.join("zip-dir").join("test-no-debug.bin"),
         data_dir.join("libtest-so.so"),
         data_dir.join("libtest-so-no-separate-code.so"),

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -619,7 +619,7 @@ mod tests {
         let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("..")
             .join("data")
-            .join("test-stable-addresses-dwarf-only.bin");
+            .join("test-stable-addresses-stripped-elf-with-dwarf.bin");
 
         let src = blaze_inspect_elf_src::from(Elf::new(test_dwarf));
         let factorial = CString::new("factorial").unwrap();

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -1320,7 +1320,7 @@ mod tests {
         let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("..")
             .join("data")
-            .join("test-stable-addresses-dwarf-only.bin");
+            .join("test-stable-addresses-stripped-elf-with-dwarf.bin");
         let path_c = CString::new(path.to_str().unwrap()).unwrap();
         let elf_src = blaze_symbolize_src_elf {
             path: path_c.as_ptr(),

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -392,7 +392,7 @@ mod tests {
     fn lookup_symbol() {
         let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test-stable-addresses-dwarf-only.bin");
+            .join("test-stable-addresses-stripped-elf-with-dwarf.bin");
         let opts = FindAddrOpts {
             offset_in_file: false,
             sym_type: SymType::Function,
@@ -412,7 +412,7 @@ mod tests {
     fn unsupported_ops() {
         let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
-            .join("test-stable-addresses-dwarf-only.bin");
+            .join("test-stable-addresses-stripped-elf-with-dwarf.bin");
         let opts = FindAddrOpts {
             offset_in_file: false,
             sym_type: SymType::Variable,

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -131,7 +131,7 @@ fn symbolize_elf_dwarf_gsym() {
     test(src, false);
 
     for file in [
-        "test-stable-addresses-dwarf-only.bin",
+        "test-stable-addresses-stripped-elf-with-dwarf.bin",
         "test-stable-addresses-lto.bin",
         "test-stable-addresses-compressed-debug-zlib.bin",
         #[cfg(feature = "zstd")]
@@ -353,7 +353,7 @@ fn symbolize_dwarf_gsym_inlined() {
     test(src, false);
 
     for file in [
-        "test-stable-addresses-dwarf-only.bin",
+        "test-stable-addresses-stripped-elf-with-dwarf.bin",
         "test-stable-addresses-compressed-debug-zlib.bin",
         #[cfg(feature = "zstd")]
         "test-stable-addresses-compressed-debug-zstd.bin",
@@ -797,7 +797,7 @@ fn inspect_elf() {
 
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("test-stable-addresses-dwarf-only.bin");
+        .join("test-stable-addresses-stripped-elf-with-dwarf.bin");
     let src = inspect::Source::Elf(inspect::Elf::new(test_dwarf));
     // Our `DwarfResolver` type does not currently support look up of
     // variables.


### PR DESCRIPTION
The name of the `test-stable-addresses-dwarf-only.bin` binary is a bit confusing and will actively cause conflicts in the future. The binary does contain ELF and DWARF bits, but the ELF symbols tables have been stripped.
Make that a bit more obvious by renaming it to `test-stable-addresses-stripped-elf-with-dwarf.bin`.