### PR TITLE
Add Display impl for ErrorKind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
 - Introduced `normalize::Reason` enum to provide best guess at why normalization
   was not successful as part of the `normalize::UserMeta::Unknown` variant
 - Added `From<Box<dyn std::error::Error>>` conversion to `Error`
+- Added `Display` impl to `ErrorKind`
 - Added `read_elf_build_id_from_mmap` function to `helper` module
 - Reduced number of allocations performed on address normalization and
   process symbolization paths

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ use std::fmt::Result as FmtResult;
 use std::io;
 use std::mem::transmute;
 use std::ops::Deref;
+use std::str;
 
 
 mod private {
@@ -343,6 +344,15 @@ impl ErrorKind {
             Self::WriteZero => b"write zero\0",
             Self::InvalidDwarf => b"DWARF data invalid\0",
         }
+    }
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let cstr = self.as_bytes();
+        // SAFETY: `as_bytes` always returns a valid string.
+        let s = unsafe { str::from_utf8_unchecked(&cstr[..cstr.len() - 1]) };
+        f.write_str(s)
     }
 }
 
@@ -709,6 +719,17 @@ mod tests {
 
     use test_log::test;
 
+
+    /// Exercise the `Display` representation of various types.
+    #[test]
+    fn display_repr() {
+        assert_eq!(ErrorKind::NotFound.to_string(), "entity not found");
+        assert_eq!(ErrorKind::OutOfMemory.to_string(), "out of memory");
+        assert_eq!(
+            ErrorKind::UnexpectedEof.to_string(),
+            "unexpected end of file"
+        );
+    }
 
     /// Check various features of our `Str` wrapper type.
     #[test]


### PR DESCRIPTION
Add a Display impl for the ErrorKind enum. We already have Display impls for all Reason types provided by the crate, and ErrorKind is very similar in nature. Also, std::io::ErrorKind has a Display impl and it makes sense for us to behave similarly.