### PR TITLE
capi: Introduce blaze_normalize_reason_str() helper function

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
     representation
 - Introduced `blaze_normalize_reason` type and extended
   - Added `reason` attribute to `blaze_user_meta_unknown`
+  - Added `blaze_normalize_reason_str` to retrieve textual representation
 - Added `blaze_symbolize_elf_file_offsets` function for symbolization of
   file offsets
 - Removed `BLAZE_INPUT` macro

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -747,7 +747,7 @@ extern "C" {
 enum blaze_err blaze_err_last(void);
 
 /**
- * Retrieve a textual representation of the error code, if any.
+ * Retrieve a textual representation of the error code.
  */
 const char *blaze_err_str(enum blaze_err err);
 
@@ -855,6 +855,11 @@ blaze_normalizer *blaze_normalizer_new_opts(const struct blaze_normalizer_opts *
  * [`blaze_normalizer_new`].
  */
 void blaze_normalizer_free(blaze_normalizer *normalizer);
+
+/**
+ * Retrieve a textual representation of the reason of a normalization failure.
+ */
+const char *blaze_normalize_reason_str(blaze_normalize_reason err);
 
 /**
  * Normalize a list of user space addresses.

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -182,7 +182,7 @@ fn set_last_err(err: blaze_err) {
 }
 
 
-/// Retrieve a textual representation of the error code, if any.
+/// Retrieve a textual representation of the error code.
 #[no_mangle]
 pub extern "C" fn blaze_err_str(err: blaze_err) -> *const c_char {
     match err as i32 {


### PR DESCRIPTION
This change introduces the `blaze_normalize_reason_str()` helper function that can be used to retrieve a textual representation of a reason for a normalization failure.