### PR TITLE
Make path an optional member of ElfParser

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -205,7 +205,7 @@ impl Inspect for DwarfResolver {
                                 .then(|| self.parser.find_file_offset(addr))
                                 .transpose()?
                                 .flatten(),
-                            obj_file_name: Some(Cow::Borrowed(self.parser.path())),
+                            obj_file_name: self.parser.path().map(Cow::Borrowed),
                         };
                         Ok(info)
                     }

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -144,7 +144,7 @@ impl ElfResolver {
     }
 
     /// Retrieve the path to the ELF file represented by this resolver.
-    pub(crate) fn path(&self) -> &Path {
+    pub(crate) fn path(&self) -> Option<&Path> {
         match &self.backend {
             #[cfg(feature = "dwarf")]
             ElfBackend::Dwarf(dwarf) => dwarf.parser().path(),
@@ -201,8 +201,16 @@ impl Debug for ElfResolver {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.backend {
             #[cfg(feature = "dwarf")]
-            ElfBackend::Dwarf(_) => write!(f, "DWARF {}", self.path().display()),
-            ElfBackend::Elf(_) => write!(f, "ELF {}", self.path().display()),
+            ElfBackend::Dwarf(_) => write!(
+                f,
+                "DWARF {}",
+                self.path().unwrap_or_else(|| Path::new("")).display()
+            ),
+            ElfBackend::Elf(_) => write!(
+                f,
+                "ELF {}",
+                self.path().unwrap_or_else(|| Path::new("")).display()
+            ),
         }
     }
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -63,7 +63,7 @@ impl Debug for KernelResolver {
                 .display(),
             self.elf_resolver
                 .as_ref()
-                .map(|resolver| resolver.path())
+                .and_then(|resolver| resolver.path())
                 .unwrap_or_else(|| Path::new(""))
                 .display(),
         )

--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -212,10 +212,7 @@ where
 //       feasible at this point.
 #[inline]
 pub fn read_elf_build_id_from_mmap(mmap: &Mmap) -> Result<Option<BuildId<'static>>> {
-    // TODO: The provided path is only relevant for tracing purposes, but
-    //       eventually we may want to decide whether the `ElfParser` path is
-    //       optional or not.
-    let parser = ElfParser::from_mmap(mmap.clone(), Path::new("<anonymous>"));
+    let parser = ElfParser::from_mmap(mmap.clone(), None);
     let buildid = read_build_id_impl(&parser)?.map(|buildid| Cow::Owned(buildid.to_vec()));
     Ok(buildid)
 }

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -381,7 +381,7 @@ mod tests {
         let mmap = Mmap::builder().exec().open(&test_so).unwrap();
         // Look up the address of the `the_answer` function inside of the shared
         // object.
-        let elf_parser = ElfParser::from_mmap(mmap.clone(), test_so);
+        let elf_parser = ElfParser::from_mmap(mmap.clone(), Some(test_so));
         let opts = FindAddrOpts {
             sym_type: SymType::Function,
             ..Default::default()
@@ -445,7 +445,7 @@ mod tests {
 
             // Look up the address of the `the_answer` function inside of the shared
             // object.
-            let elf_parser = ElfParser::from_mmap(elf_mmap.clone(), &test_zip);
+            let elf_parser = ElfParser::from_mmap(elf_mmap.clone(), Some(test_zip.clone()));
             let opts = FindAddrOpts {
                 sym_type: SymType::Function,
                 offset_in_file: true,

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -177,7 +177,7 @@ fn default_apk_dispatcher(info: ApkMemberInfo<'_>, debug_syms: bool) -> Result<B
     // Create an Android-style binary-in-APK path for
     // reporting purposes.
     let apk_elf_path = create_apk_elf_path(info.apk_path, info.member_path)?;
-    let parser = Rc::new(ElfParser::from_mmap(info.member_mmap, apk_elf_path));
+    let parser = Rc::new(ElfParser::from_mmap(info.member_mmap, Some(apk_elf_path)));
     let resolver = ElfResolver::from_parser(parser, debug_syms)?;
     let resolver = Box::new(resolver);
     Ok(resolver)
@@ -1460,7 +1460,8 @@ mod tests {
 
         // Look up the address of the `the_answer` function inside of the shared
         // object.
-        let elf_parser = ElfParser::from_mmap(elf_mmap.clone(), Path::new("libtest-so.so"));
+        let elf_parser =
+            ElfParser::from_mmap(elf_mmap.clone(), Some(PathBuf::from("libtest-so.so")));
         let opts = FindAddrOpts {
             sym_type: SymType::Function,
             ..Default::default()


### PR DESCRIPTION
So far we have treated ElfParser objects to always have a path to the ELF file. However, with commit 3451927a0fe9 ("Introduce read_elf_build_id_from_mmap() helper function") that is no longer a guarantee: all we have available may be a Mmap object, without knowledge of the path it represents.
With upcoming changes we expect to perform additional logic with an ElfParser's path (i.e., more than just using it for reporting purposes), in which case it makes sense to do away with hacks such as '<anonymous>' paths. To that end, this change makes the path property optional.