### PR TITLE
Use correct input slice in nom error conversion test

### DIFF
--- a/src/breakpad/parser.rs
+++ b/src/breakpad/parser.rs
@@ -796,7 +796,8 @@ foo bar baz
    ^";
         assert_eq!(s.trim(), expected);
 
-        let s = stringify_error(b"", err);
+        let empty = &input[0..0];
+        let s = stringify_error(empty, err);
         let expected = "\
 0: in context, got empty input
 


### PR DESCRIPTION
Our `stringify_error()` helper as defined in the Breakpad logic still uses nom's `Offset` logic, which assumes that all input slices are sub-slices of each other. However, one of the tests did not actually uphold this invariant. Fix it.