### PR TITLE
Make ElfResolver::parser() private

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -135,7 +135,7 @@ impl ElfResolver {
         Ok(resolver)
     }
 
-    pub(crate) fn parser(&self) -> &Rc<ElfParser> {
+    fn parser(&self) -> &Rc<ElfParser> {
         match &self.backend {
             #[cfg(feature = "dwarf")]
             ElfBackend::Dwarf(dwarf) => dwarf.parser(),
@@ -145,11 +145,7 @@ impl ElfResolver {
 
     /// Retrieve the path to the ELF file represented by this resolver.
     pub(crate) fn path(&self) -> Option<&Path> {
-        match &self.backend {
-            #[cfg(feature = "dwarf")]
-            ElfBackend::Dwarf(dwarf) => dwarf.parser().path(),
-            ElfBackend::Elf(parser) => parser.path(),
-        }
+        self.parser().path()
     }
 }
 


### PR DESCRIPTION
As it turns out the `ElfResolver::parser()` method, by now, is used only in the `elf/resolver.rs` module itself. Make sure that it stays that way by making it private.