### PR TITLE
cli: Bump version to 0.1.4

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.4
+-----
 - Added `inspect` command
 - Bumped `blazesym` dependency to `0.2.0-alpha.12`
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazecli"
 description = "A command line utility for the blazesym library."
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.65"
 default-run = "blazecli"


### PR DESCRIPTION
This change bumps blazecli's version to 0.1.4. The following notable changes have been made since 0.1.3:
- Added 'inspect' command
- Bumped blazesym dependency to 0.2.0-alpha.12