### PR TITLE
Simplify ElfResolver::find_sym()

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -152,16 +152,11 @@ impl ElfResolver {
 impl Symbolize for ElfResolver {
     #[cfg_attr(feature = "tracing", crate::log::instrument(fields(addr = format_args!("{addr:#x}"))))]
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<ResolvedSym<'_>, Reason>> {
-        #[cfg(feature = "dwarf")]
-        if let ElfBackend::Dwarf(dwarf) = &self.backend {
-            if let Ok(sym) = dwarf.find_sym(addr, opts)? {
-                return Ok(Ok(sym))
-            }
+        match &self.backend {
+            #[cfg(feature = "dwarf")]
+            ElfBackend::Dwarf(dwarf) => dwarf.find_sym(addr, opts),
+            ElfBackend::Elf(parser) => parser.find_sym(addr, opts),
         }
-
-        let parser = self.parser();
-        let result = parser.find_sym(addr, opts)?;
-        Ok(result)
     }
 }
 


### PR DESCRIPTION
Similar to what we did in commit 2ed468d2ffcb ("Fall back to using debug link parser for Inspect::find_addr()"), adjust ElfResolver::find_sym() to directly dispatch to DwarfResolver or ElfParser, but not to have some weird conditional logic in there. This is now possible, because the DwarfResolver will automatically fall back to its internal ELF parser. Without this change we may end up consulting the ELF parser twice for the same input address, which is unnecessary.