### PR TITLE
Fall back to using debug link parser for DwarfResolver::find_sym()

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -498,6 +498,16 @@ fn prepare_test_files() {
         ],
     );
 
+    let elf = data_dir.join("test-stable-addrs-no-dwarf.bin");
+    objcopy(
+        &src,
+        "test-stable-addrs-stripped-with-link-to-elf-only.bin",
+        &[
+            "--strip-all",
+            &format!("--add-gnu-debuglink={}", elf.display()),
+        ],
+    );
+
     dwarf(&src, "test-stable-addrs-dwarf-only-wrong-crc.dbg");
     let dbg = data_dir.join("test-stable-addrs-dwarf-only-wrong-crc.dbg");
     objcopy(

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -124,11 +124,16 @@ fn symbolize_elf_dwarf_gsym() {
         }
     }
 
-    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
-        .join("data")
-        .join("test-stable-addrs-no-dwarf.bin");
-    let src = symbolize::Source::Elf(symbolize::Elf::new(path));
-    test(src, false);
+    for file in [
+        "test-stable-addrs-no-dwarf.bin",
+        "test-stable-addrs-stripped-with-link-to-elf-only.bin",
+    ] {
+        let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join(file);
+        let src = symbolize::Source::Elf(symbolize::Elf::new(path));
+        test(src, false);
+    }
 
     for file in [
         "test-stable-addrs-stripped-elf-with-dwarf.bin",


### PR DESCRIPTION
Similar to what we did in commit 2ed468d2ffcb ("Fall back to using debug link parser for Inspect::find_addr()"), adjust DwarfResolver::find_sym() to use the debug link ELF parser as a first fall back, if present.