### PR TITLE
Fix typo: 'unsupprted' -> 'unsupported'

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -89,7 +89,7 @@ impl Reason {
         match self {
             Self::Unmapped => b"absolute address not found in virtual memory map of process\0",
             Self::MissingComponent => b"proc maps entry has no component\0",
-            Self::Unsupported => b"address belongs to unsupprted entity\0",
+            Self::Unsupported => b"address belongs to unsupported entity\0",
         }
     }
 }
@@ -122,7 +122,7 @@ mod tests {
         );
         assert_eq!(
             Reason::Unsupported.to_string(),
-            "address belongs to unsupprted entity"
+            "address belongs to unsupported entity"
         );
     }
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -397,7 +397,7 @@ impl Display for Reason {
             Self::InvalidFileOffset => "file offset does not map to a valid piece of code/data",
             Self::MissingComponent => "proc maps entry has no component",
             Self::MissingSyms => "symbolization source has no or no relevant symbols",
-            Self::Unsupported => "address belongs to unsupprted entity",
+            Self::Unsupported => "address belongs to unsupported entity",
             Self::UnknownAddr => "address not found in symbolization source",
         };
 


### PR DESCRIPTION
Fix wrong spelling of 'unsupported' in a couple of user facing strings.