### PR TITLE
Fix reporting of zero sized symbols in Gsym

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added support for transparently following debug links in ELF binaries
+- Fixed handling of zero sized symbols in Gsym symbolization logic
 
 
 0.2.0-alpha.12

--- a/data/test-stable-addrs.c
+++ b/data/test-stable-addrs.c
@@ -61,6 +61,16 @@ asm(
 
 extern void dummy(void);
 
+// It's possible to control section placement via `.pushsection` command,
+// which would allow for precise address control. However, gsym conversion
+// ignored the symbol in this case. Play it safe and don't specify the section.
+asm(
+  ".globl zero_size\n"
+  ".type zero_size, @function\n"
+  "zero_size:\n"
+);
+extern void zero_size(void);
+
 __attribute__((section(".text.main"))) int
 main(int argc, const char *argv[]) {
   factorial_wrapper();
@@ -68,6 +78,7 @@ main(int argc, const char *argv[]) {
   foo();
   dummy();
   i_exist_twice();
+  zero_size();
 
   a_variable[0] = 42;
   return 0;

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -178,7 +178,9 @@ impl Symbolize for GsymResolver<'_> {
                 .ctx
                 .addr_info(idx)
                 .ok_or_invalid_data(|| format!("failed to read address information entry {idx}"))?;
-            if addr >= (sym_addr + info.size as Addr) {
+            if (info.size == 0 && sym_addr != addr)
+                || (info.size > 0 && addr >= (sym_addr + info.size as Addr))
+            {
                 return Ok(Err(Reason::UnknownAddr))
             }
 
@@ -379,7 +381,7 @@ mod tests {
         assert!(sym.inlined.is_empty());
 
         let info = sym.code_info.unwrap();
-        assert_eq!(info.line, Some(65));
+        assert_eq!(info.line, Some(75));
         assert_eq!(info.file, OsStr::new("test-stable-addrs.c"));
 
         // `factorial` resides at address 0x2000100, and it's located at the


### PR DESCRIPTION
Commit c1b5affa0550 ("Reuse more data between GsymResolver::find_sym() and find_code_info()") merged parts of the
GsymResolver::find_code_info() logic into GsymResolver::find_sym(). In the process it copied the address sanity check over. As it turns out this check had been subtly broken, in that it did not correctly handle zero sized symbols.
This change fixes the issue by correcting the logic for zero sized symbols.