### PR TITLE
Use read_pod() for reading compression header

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -617,7 +617,7 @@ impl ElfParser {
                 // Compression header is contained in the actual section
                 // data.
                 let chdr = data
-                    .read_pod_ref::<Elf64_Chdr>()
+                    .read_pod::<Elf64_Chdr>()
                     .ok_or_invalid_data(|| "failed to read Elf64_Chdr")?;
 
                 let decompressed = match chdr.ch_type {


### PR DESCRIPTION
The ELF compression header resides inside an ELF section's actual data. As such, it may not be aligned correctly. Switch over to reading it using read_pod() to make sure that we are able to read it even if unaligned.