### PR TITLE
Treat NOBITS ELF sections as containing no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Added support for transparently following debug links in ELF binaries
 - Fixed handling of zero sized symbols in Gsym symbolization logic
+- Fixed reading of ELF section contents of sections without actual data
 
 
 0.2.0-alpha.12

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -125,6 +125,7 @@ fn try_deref_debug_link(parser: &ElfParser) -> Result<Option<Rc<ElfParser>>> {
                     )))
                 }
 
+                debug!("followed debug link to: {}", path.display());
                 let dst_parser = Rc::new(ElfParser::from_mmap(mmap, Some(path)));
                 Ok(Some(dst_parser))
             }

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -81,6 +81,7 @@ pub(crate) const SHN_LORESERVE: u16 = 0xff00;
 pub(crate) const SHN_XINDEX: u16 = 0xffff;
 
 pub(crate) const SHT_NOTE: Elf64_Word = 7;
+pub(crate) const SHT_NOBITS: Elf64_Word = 8;
 
 pub(crate) const STT_OBJECT: u8 = 1;
 pub(crate) const STT_FUNC: u8 = 2;


### PR DESCRIPTION
We have seen cases where, with the debug link logic in place, we fail to read ELF section contents. The reason being in such a scenario, it is common for some ELF sections to not contain any data, despite keeping their original address and size meta data information. We just look at this meta data information to determine what data to read. What we should additionally take into consideration is the fact that the section type gets changed to NOBITS, indicating that no data is actually in the file. If this type is used, we shouldn't even attempt to read contents.