### PR TITLE
Define rust_eh_personality symbol in data/test.rs

### DIFF
--- a/data/test.rs
+++ b/data/test.rs
@@ -3,6 +3,9 @@
 
 use core::hint::black_box;
 
+#[no_mangle]
+static rust_eh_personality: [u8; 0] = [];
+
 
 #[inline(never)]
 fn uninlined_call() -> usize {


### PR DESCRIPTION
It appears that with the switch to using rust.lld as the default linker on x86_64-unknown-linux-gnu our data/test.rs fails to link due to missing rust_eh_personality symbol. It's not 100% clear why that is, as this symbol should only have meaning when unwinding on panic (but we abort). That being said, we don't care much either way. Let's just define the symbol and move on with our lives. As long as the test binary builds we should be golden.