### PR TITLE
Niceify tracing output

### DIFF
--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -193,6 +193,18 @@ pub enum Input<T> {
 }
 
 impl<T> Input<T> {
+    fn map<F, U>(&self, f: F) -> Input<U>
+    where
+        T: Copy,
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            Self::AbsAddr(x) => Input::AbsAddr(f(*x)),
+            Self::VirtOffset(x) => Input::VirtOffset(f(*x)),
+            Self::FileOffset(x) => Input::FileOffset(f(*x)),
+        }
+    }
+
     /// Extract the inner payload.
     ///
     /// ```rust


### PR DESCRIPTION
Our tracing span for the Symbolizer::symbolize() method always occupy multiple lines, because we use the "pretty" formatting in order to force 0x prefixes for hexadecimal values, but that also causes arrays to be formatted across multiple lines. That is super annoying. Until Rust supports specifying formatting attributes for individual nested components (there is a Rust issue somewhere...), we have to hand roll some logic to fix this issue.