### PR TITLE
cli: Omit "target" from tracing output

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,7 @@ use clap::Parser as _;
 
 use tracing::subscriber::set_global_default as set_global_subscriber;
 use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::fmt::time::SystemTime;
 use tracing_subscriber::FmtSubscriber;
@@ -283,7 +284,9 @@ fn main() -> Result<()> {
         _ => LevelFilter::TRACE,
     };
 
+    let format = fmt::format().with_target(false).compact();
     let subscriber = FmtSubscriber::builder()
+        .event_format(format)
         .with_max_level(level)
         .with_span_events(FmtSpan::FULL)
         .with_timer(SystemTime)


### PR DESCRIPTION
Our span output can get somewhat lengthy. Omit the "target" from said output to shorten it slightly.