### PR TITLE
Use StdError import more

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -125,7 +125,6 @@ fn try_deref_debug_link(parser: &ElfParser) -> Result<Option<Rc<ElfParser>>> {
                     )))
                 }
 
-                debug!("followed debug link to: {}", path.display());
                 let dst_parser = Rc::new(ElfParser::from_mmap(mmap, Some(path)));
                 Ok(Some(dst_parser))
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,6 @@ use std::backtrace::Backtrace;
 use std::backtrace::BacktraceStatus;
 use std::borrow::Borrow;
 use std::borrow::Cow;
-use std::error;
 use std::error::Error as StdError;
 use std::fmt::Debug;
 use std::fmt::Display;
@@ -269,8 +268,8 @@ impl Display for ErrorImpl {
     }
 }
 
-impl error::Error for ErrorImpl {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+impl StdError for ErrorImpl {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             #[cfg(feature = "dwarf")]
             Self::Dwarf { error, .. } => error.source(),
@@ -516,9 +515,9 @@ impl Display for Error {
     }
 }
 
-impl error::Error for Error {
+impl StdError for Error {
     #[inline]
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         self.error.source()
     }
 }


### PR DESCRIPTION
It's confusing to reference the std::error::Error trait via the StdError import as well as via error::Error. Switch to using StdError throughout the file.