### PR TITLE
Report Gsym symbols with size = 0 even if addresses don't match

### DIFF
--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -178,9 +178,12 @@ impl Symbolize for GsymResolver<'_> {
                 .ctx
                 .addr_info(idx)
                 .ok_or_invalid_data(|| format!("failed to read address information entry {idx}"))?;
-            if (info.size == 0 && sym_addr != addr)
-                || (info.size > 0 && addr >= (sym_addr + info.size as Addr))
-            {
+            // NB: Never bail out for zero sized symbols. We have seen cases
+            //     where the reported `sym_addr` was (way) before `addr` for
+            //     zero sized symbols, but the majority of tools report the
+            //     result irrespectively and the behavior was deemed the right
+            //     call.
+            if info.size > 0 && addr >= (sym_addr + info.size as Addr) {
                 return Ok(Err(Reason::UnknownAddr))
             }
 


### PR DESCRIPTION
Commit 7140f5816775 ("Fix reporting of zero sized symbols in Gsym") fixed the reporting of zero sized symbols in Gsym. However, since then have seen cases where certain zero sized symbols stopped being reported that the LLVM Gsym implementation *does* report and that also common tools such as llvm-addr2line and llvm-symbolizer report. E.g.,

```
  $ llvm-gsymutil --address 0x99820 libstdc++.so.6.0.29.gsym --verbose
  > Looking up addresses in "libstdc++.so.6.0.29.gsym":
  > FunctionInfo for 0x0000000000099820:
  > [0x0000000000099000 - 0x0000000000099000) "_init"
  >
  > LookupResult for 0x0000000000099820:
  > 0x0000000000099820: _init + 2080
```

We have confirmed that this behavior is indeed intentional and with this change we relax our checks accordingly, to follow this behavior and be more liberal when it comes to reporting zero sized symbols.