### PR TITLE
Declare various methods as pub(crate)

### DIFF
--- a/src/breakpad/parser.rs
+++ b/src/breakpad/parser.rs
@@ -556,12 +556,12 @@ pub struct SymbolParser {
 
 impl SymbolParser {
     /// Creates a new [`SymbolParser`].
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
     /// Parses and then returns how many bytes of the input was used.
-    pub fn parse(&mut self, mut input: &[u8]) -> Result<usize> {
+    pub(crate) fn parse(&mut self, mut input: &[u8]) -> Result<usize> {
         // We parse the input line-by-line, so trim away any part of the input
         // that comes after the last newline (this is necessary for streaming
         // parsing, as it can otherwise be impossible to tell if a line is
@@ -728,7 +728,7 @@ impl SymbolParser {
     /// Finish the parse and create the final [`SymbolFile`].
     ///
     /// Call this when the parser has consumed all the input.
-    pub fn finish(mut self) -> SymbolFile {
+    pub(crate) fn finish(mut self) -> SymbolFile {
         // If there's a pending multiline item, finish it now.
         if let Some(item) = self.cur_item.take() {
             self.finish_item(item);

--- a/src/breakpad/types.rs
+++ b/src/breakpad/types.rs
@@ -146,7 +146,7 @@ impl Function {
     /// have been inlined all the way into A (A being the "outer function"),
     /// then the call A -> B is at level zero, and the call B -> C is at
     /// level one.
-    pub fn find_inlinee_at_depth(&self, depth: u32, addr: u64) -> Option<&Inlinee> {
+    pub(crate) fn find_inlinee_at_depth(&self, depth: u32, addr: u64) -> Option<&Inlinee> {
         let inlinee = match self
             .inlinees
             .binary_search_by_key(&(depth, addr), |inlinee| (inlinee.depth, inlinee.addr))
@@ -170,7 +170,7 @@ impl Function {
         }
     }
 
-    pub fn find_inlinees(&self, addr: u64) -> Vec<&Inlinee> {
+    pub(crate) fn find_inlinees(&self, addr: u64) -> Vec<&Inlinee> {
         let mut inlinees = Vec::new();
         while let Some(inlinee) = self.find_inlinee_at_depth(inlinees.len() as _, addr) {
             let () = inlinees.push(inlinee);
@@ -194,7 +194,7 @@ pub(crate) struct SymbolFile {
 }
 
 impl SymbolFile {
-    pub fn find_function(&self, addr: u64) -> Option<&Function> {
+    pub(crate) fn find_function(&self, addr: u64) -> Option<&Function> {
         let idx = find_match_or_lower_bound_by_key(&self.functions, addr, |f| f.addr)?;
         for func in &self.functions[idx..] {
             if func.addr > addr {
@@ -224,7 +224,7 @@ impl SymbolFile {
     }
 
     /// Find a function symbol based on its name.
-    pub fn find_addr<'s, 'slf: 's>(
+    pub(crate) fn find_addr<'s, 'slf: 's>(
         &'slf self,
         name: &'s str,
     ) -> impl Iterator<Item = &'slf Function> + 's {

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -153,11 +153,11 @@ pub(crate) struct DwarfResolver {
 
 impl DwarfResolver {
     /// Retrieve the resolver's underlying `ElfParser`.
-    pub fn parser(&self) -> &Rc<ElfParser> {
+    pub(crate) fn parser(&self) -> &Rc<ElfParser> {
         &self.parser
     }
 
-    pub fn from_parser(parser: Rc<ElfParser>) -> Result<Self, Error> {
+    pub(crate) fn from_parser(parser: Rc<ElfParser>) -> Result<Self, Error> {
         let linkee_parser = try_deref_debug_link(&parser)?;
 
         // SAFETY: We own the `ElfParser` and make sure that it stays
@@ -191,7 +191,7 @@ impl DwarfResolver {
     /// `filename` is the name of an ELF binary/or shared object that
     /// has .debug_line section.
     #[cfg(test)]
-    pub fn open(filename: &Path) -> Result<Self> {
+    pub(crate) fn open(filename: &Path) -> Result<Self> {
         let parser = ElfParser::open(filename)?;
         Self::from_parser(Rc::new(parser))
     }

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -386,7 +386,7 @@ impl<'dwarf> Units<'dwarf> {
 
     /// Find the source file and line corresponding to the given virtual memory
     /// address.
-    pub fn find_location(&self, probe: u64) -> Result<Option<Location<'_>>, gimli::Error> {
+    pub(crate) fn find_location(&self, probe: u64) -> Result<Option<Location<'_>>, gimli::Error> {
         for unit in self.find_units(probe) {
             if let Some(location) = unit.find_location(probe, self)? {
                 return Ok(Some(location))
@@ -395,7 +395,7 @@ impl<'dwarf> Units<'dwarf> {
         Ok(None)
     }
 
-    pub fn find_name<'s, 'slf: 's>(
+    pub(crate) fn find_name<'s, 'slf: 's>(
         &'slf self,
         name: &'s str,
     ) -> impl Iterator<Item = Result<&Function<'dwarf>, gimli::Error>> + 's {

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -582,7 +582,7 @@ pub(crate) struct ElfParser {
 
 impl ElfParser {
     /// Create an `ElfParser` from an open file.
-    pub fn open_file<P>(file: &File, path: P) -> Result<Self>
+    pub(crate) fn open_file<P>(file: &File, path: P) -> Result<Self>
     where
         P: Into<PathBuf>,
     {
@@ -591,7 +591,7 @@ impl ElfParser {
     }
 
     /// Create an `ElfParser` from mmap'ed data.
-    pub fn from_mmap(mmap: Mmap, path: Option<PathBuf>) -> Self {
+    pub(crate) fn from_mmap(mmap: Mmap, path: Option<PathBuf>) -> Self {
         // We transmute the mmap's lifetime to static here as that is a
         // necessity for self-referentiality.
         // SAFETY: We never hand out any 'static references to cache
@@ -608,7 +608,7 @@ impl ElfParser {
     }
 
     /// Create an `ElfParser` for a path.
-    pub fn open(path: &Path) -> Result<ElfParser> {
+    pub(crate) fn open(path: &Path) -> Result<ElfParser> {
         let file =
             File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
         Self::open_file(&file, path)
@@ -619,7 +619,7 @@ impl ElfParser {
     ///
     /// If the section is compressed the resulting decompressed data
     /// will be cached for the life time of this object.
-    pub fn section_data(&self, idx: usize) -> Result<&[u8]> {
+    pub(crate) fn section_data(&self, idx: usize) -> Result<&[u8]> {
         let (shdr, mut data) = self.cache.section_data_raw(idx)?;
 
         if shdr.sh_flags & SHF_COMPRESSED != 0 {
@@ -654,12 +654,12 @@ impl ElfParser {
     /// Find the section of a given name.
     ///
     /// This function return the index of the section if found.
-    pub fn find_section(&self, name: &str) -> Result<Option<usize>> {
+    pub(crate) fn find_section(&self, name: &str) -> Result<Option<usize>> {
         let index = self.cache.find_section(name)?;
         Ok(index)
     }
 
-    pub fn find_sym(
+    pub(crate) fn find_sym(
         &self,
         addr: Addr,
         opts: &FindSymOpts,
@@ -905,7 +905,7 @@ impl ElfParser {
 
     /// Retrieve the path to the file this object operates on.
     #[inline]
-    pub fn path(&self) -> Option<&Path> {
+    pub(crate) fn path(&self) -> Option<&Path> {
         self.path.as_deref()
     }
 }

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -87,13 +87,13 @@ pub(crate) struct Builder<T> {
 
 impl<T> Builder<T> {
     /// Enable/disable auto reloading of files when stale.
-    pub fn enable_auto_reload(mut self, enable: bool) -> Self {
+    pub(crate) fn enable_auto_reload(mut self, enable: bool) -> Self {
         self.auto_reload = enable;
         self
     }
 
     /// Create the [`FileCache`] object.
-    pub fn build(self) -> FileCache<T> {
+    pub(crate) fn build(self) -> FileCache<T> {
         let Builder {
             auto_reload,
             _phantom: _,
@@ -135,12 +135,12 @@ pub(crate) struct FileCache<T> {
 impl<T> FileCache<T> {
     /// Retrieve a [`Builder`] object for configurable construction of a
     /// [`FileCache`].
-    pub fn builder() -> Builder<T> {
+    pub(crate) fn builder() -> Builder<T> {
         Builder::<T>::default()
     }
 
     /// Retrieve an entry for the file at the given `path`.
-    pub fn entry(&self, path: &Path) -> Result<(&File, &OnceCell<T>)> {
+    pub(crate) fn entry(&self, path: &Path) -> Result<(&File, &OnceCell<T>)> {
         let stat = if self.auto_reload {
             let stat = stat(path).with_context(|| format!("failed to stat {}", path.display()))?;
             Some(stat)

--- a/src/gsym/inline.rs
+++ b/src/gsym/inline.rs
@@ -18,7 +18,7 @@ pub(super) struct InlineInfo {
 
 impl InlineInfo {
     /// Parse Gsym `InlineInfo` from raw bytes.
-    pub fn parse(
+    pub(crate) fn parse(
         data: &mut &[u8],
         base_addr: u64,
         lookup_addr: Option<u64>,
@@ -155,7 +155,7 @@ impl InlineInfo {
         false
     }
 
-    pub fn inline_stack(&self, addr: u64) -> Vec<&Self> {
+    pub(crate) fn inline_stack(&self, addr: u64) -> Vec<&Self> {
         let mut inlined = Vec::new();
         let _done = self.inline_stack_impl(addr, &mut inlined);
         inlined

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -79,7 +79,7 @@ impl LineTableRow {
     /// * `header` - is a [`LineTableHeader`] returned by
     ///   [`parse_line_table_header()`].
     /// * `symaddr` - the address of the symbol that `header` belongs to.
-    pub fn from_header(header: &LineTableHeader, symaddr: Addr) -> Self {
+    pub(crate) fn from_header(header: &LineTableHeader, symaddr: Addr) -> Self {
         Self {
             addr: symaddr,
             file_idx: 1,
@@ -99,7 +99,7 @@ impl LineTableRow {
 /// * `header` - is a `LineTableHeader`.
 /// * `ops` - is the buffer of the operators following the `LineTableHeader` in
 ///   a GSYM file.
-pub fn run_op(
+pub(crate) fn run_op(
     row: &mut LineTableRow,
     header: &LineTableHeader,
     ops: &mut &[u8],

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -21,7 +21,7 @@ pub(crate) struct KernelResolver {
 }
 
 impl KernelResolver {
-    pub fn new(
+    pub(crate) fn new(
         ksym_resolver: Option<Rc<KSymResolver>>,
         elf_resolver: Option<Rc<ElfResolver>>,
     ) -> Result<KernelResolver> {

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -76,7 +76,7 @@ pub struct KSymResolver {
 }
 
 impl KSymResolver {
-    pub fn load_file_name(filename: PathBuf) -> Result<Self> {
+    pub(crate) fn load_file_name(filename: PathBuf) -> Result<Self> {
         let f = File::open(&filename)?;
         let mut reader = BufReader::new(f);
         let mut line = String::new();

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -28,13 +28,13 @@ impl Builder {
 
     /// Configure the mapping to be executable.
     #[cfg(test)]
-    pub fn exec(mut self) -> Self {
+    pub(crate) fn exec(mut self) -> Self {
         self.protection |= libc::PROT_EXEC;
         self
     }
 
     /// Memory map the file at the provided `path`.
-    pub fn open<P>(self, path: P) -> Result<Mmap>
+    pub(crate) fn open<P>(self, path: P) -> Result<Mmap>
     where
         P: AsRef<Path>,
     {
@@ -43,7 +43,7 @@ impl Builder {
     }
 
     /// Map the provided file into memory, in its entirety.
-    pub fn map(self, file: &File) -> Result<Mmap> {
+    pub(crate) fn map(self, file: &File) -> Result<Mmap> {
         let len = libc::size_t::try_from(file.metadata()?.len())
             .map_err(Error::with_invalid_data)
             .context("file is too large to mmap")?;

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -136,7 +136,7 @@ pub(super) struct NormalizationHandler<'reader, 'src> {
 
 impl<'reader, 'src> NormalizationHandler<'reader, 'src> {
     /// Instantiate a new `NormalizationHandler` object.
-    pub fn new(reader: &'reader dyn BuildIdReader<'src>, addr_cnt: usize) -> Self {
+    pub(crate) fn new(reader: &'reader dyn BuildIdReader<'src>, addr_cnt: usize) -> Self {
         Self {
             normalized: UserOutput {
                 outputs: Vec::with_capacity(addr_cnt),

--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -127,7 +127,7 @@ pub(crate) struct PerfMap {
 impl PerfMap {
     /// Retrieve the path to a perf map file representing the process with the
     /// given `pid`.
-    pub fn path(pid: Pid) -> PathBuf {
+    pub(crate) fn path(pid: Pid) -> PathBuf {
         let pid = pid.resolve();
         // The documentation mentions /tmp by name specifically, ignoring
         // `TMPDIR` et al, so that is what we work with as well.
@@ -136,7 +136,7 @@ impl PerfMap {
     }
 
     /// Load the [`PerfMap`] for the process with the given `pid`, if any.
-    pub fn from_file(path: &Path, file: &File) -> Result<Self> {
+    pub(crate) fn from_file(path: &Path, file: &File) -> Result<Self> {
         let mmap = Mmap::map(file)
             .with_context(|| format!("failed to mmap perf map `{}`", path.display()))?;
         // We transmute the mmap's lifetime to static here as that is a

--- a/src/util.rs
+++ b/src/util.rs
@@ -115,7 +115,7 @@ pub(crate) fn trim_ascii(bytes: &[u8]) -> &[u8] {
 //       stabilized, we should remove this functionality in favor of the std
 //       version.
 #[inline]
-pub fn split_once<F>(bytes: &[u8], pred: F) -> Option<(&[u8], &[u8])>
+pub(crate) fn split_once<F>(bytes: &[u8], pred: F) -> Option<(&[u8], &[u8])>
 where
     F: FnMut(&u8) -> bool,
 {
@@ -534,7 +534,7 @@ mod tests {
 
     /// Check whether an iterator represents a sorted sequence.
     // Copy of iterator::is_sorted_by used while it is still unstable.
-    pub fn is_sorted_by<I, F>(mut iter: I, compare: F) -> bool
+    fn is_sorted_by<I, F>(mut iter: I, compare: F) -> bool
     where
         I: Iterator,
         F: FnMut(&I::Item, &I::Item) -> Option<Ordering>,

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -264,7 +264,7 @@ pub(crate) struct Archive {
 impl Archive {
     /// Open a zip archive at the provided `path`.
     #[cfg(test)]
-    pub fn open<P>(path: P) -> Result<Self>
+    pub(crate) fn open<P>(path: P) -> Result<Self>
     where
         P: AsRef<Path>,
     {
@@ -273,7 +273,7 @@ impl Archive {
     }
 
     /// Create an `Archive` instance using the provided `Mmap`.
-    pub fn with_mmap(mmap: Mmap) -> Result<Self> {
+    pub(crate) fn with_mmap(mmap: Mmap) -> Result<Self> {
         // Check that a central directory is present as at least some form
         // of validation that we are in fact dealing with a valid zip file.
         let (cd_offset, cd_records) = Archive::find_cd(&mmap)?;
@@ -344,7 +344,7 @@ impl Archive {
     }
 
     /// Create an iterator over the entries of the archive.
-    pub fn entries(&self) -> EntryIter<'_> {
+    pub(crate) fn entries(&self) -> EntryIter<'_> {
         let archive_data = &self.mmap;
         // SANITY: The offset has been validated during construction.
         let cd_record_data = self.mmap.get(self.cd_offset as usize..).unwrap();
@@ -360,7 +360,7 @@ impl Archive {
 
     /// Retrieve the [`Mmap`] object used by this `Archive`.
     #[inline]
-    pub fn mmap(&self) -> &Mmap {
+    pub(crate) fn mmap(&self) -> &Mmap {
         &self.mmap
     }
 }


### PR DESCRIPTION
Switch various methods from having 'pub' visibility to 'pub(crate)' in order to prevent accidental leakage but also to reduce the amount of confusion.