### PR TITLE
Make debug directories to search configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Added support for transparently following debug links in ELF binaries
+  - Added `symbolize::Builder::set_debug_dirs` for configuring directories
+    searched for targets
 - Fixed handling of zero sized symbols in Gsym symbolization logic
 - Fixed reading of ELF section contents of sections without actual data
 

--- a/src/dwarf/mod.rs
+++ b/src/dwarf/mod.rs
@@ -8,4 +8,5 @@ mod resolver;
 mod unit;
 mod units;
 
+
 pub(crate) use self::resolver::DwarfResolver;

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -4,6 +4,13 @@ mod resolver;
 #[allow(dead_code, non_camel_case_types)]
 pub(crate) mod types;
 
+// Please adjust the documentation when adjusting directories.
+// We use `str` here because `Path` is basically inconstructible in
+// const contexts :-|
+// TODO: Conceptually belongs into `dwarf` module, but with current separation
+//       of concerns that is not a workable location.
+pub(crate) static DEFAULT_DEBUG_DIRS: &[&str] = &["/usr/lib/debug", "/lib/debug/"];
+
 pub(crate) use parser::ElfParser;
 pub(crate) use resolver::ElfResolverData;
 

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -3,10 +3,12 @@ use std::fs::File;
 use std::ops::Deref as _;
 #[cfg(feature = "breakpad")]
 use std::path::Path;
+use std::path::PathBuf;
 
 #[cfg(feature = "breakpad")]
 use crate::breakpad::BreakpadResolver;
 use crate::elf::ElfResolverData;
+use crate::elf::DEFAULT_DEBUG_DIRS;
 use crate::file_cache::FileCache;
 use crate::Result;
 
@@ -98,7 +100,19 @@ impl Inspector {
                 debug_syms,
                 _non_exhaustive: (),
             }) => {
-                let resolver = self.elf_cache.elf_resolver(path, *debug_syms)?;
+                let debug_dirs;
+                let resolver = self.elf_cache.elf_resolver(
+                    path,
+                    if *debug_syms {
+                        debug_dirs = DEFAULT_DEBUG_DIRS
+                            .iter()
+                            .map(PathBuf::from)
+                            .collect::<Vec<_>>();
+                        Some(debug_dirs.as_slice())
+                    } else {
+                        None
+                    },
+                )?;
                 resolver.deref() as &dyn Inspect
             }
         };
@@ -168,7 +182,19 @@ impl Inspector {
                         offset_in_file: true,
                         sym_type: SymType::Undefined,
                     };
-                    let resolver = slf.elf_cache.elf_resolver(path, *debug_syms)?;
+                    let debug_dirs;
+                    let resolver = slf.elf_cache.elf_resolver(
+                        path,
+                        if *debug_syms {
+                            debug_dirs = DEFAULT_DEBUG_DIRS
+                                .iter()
+                                .map(PathBuf::from)
+                                .collect::<Vec<_>>();
+                            Some(debug_dirs.as_slice())
+                        } else {
+                            None
+                        },
+                    )?;
                     (resolver.deref() as &dyn Inspect, opts)
                 }
             };


### PR DESCRIPTION
When following debug links, we currently have a hard-coded list of directories that we search. Users may reasonably want to have control over this list and so with this change we make sure to expose a knob to influence the contents. This list is a property of the symbolizer instance, as opposed to a per-request one. If we were to make it a per-request thing we'd need to parametrize all our caches with it, which seems undesirable. Conceptually, the set of directories should be easy to infer and it should be static in many if not all cases.