### PR TITLE
Move Hexify type into util module

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1,8 +1,6 @@
 use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::fmt::Debug;
-use std::fmt::Formatter;
-use std::fmt::Result as FmtResult;
 use std::fs::File;
 use std::mem::take;
 use std::ops::Deref as _;
@@ -40,6 +38,8 @@ use crate::symbolize::TranslateFileOffset;
 use crate::util;
 use crate::util::uname_release;
 use crate::util::Dbg;
+#[cfg(feature = "tracing")]
+use crate::util::Hexify;
 #[cfg(feature = "apk")]
 use crate::zip;
 use crate::Addr;
@@ -73,21 +73,6 @@ use super::SrcLang;
 use super::Sym;
 use super::Symbolize;
 use super::Symbolized;
-
-
-#[cfg(feature = "tracing")]
-struct Hexify<'addrs>(&'addrs [Addr]);
-
-#[cfg(feature = "tracing")]
-impl Debug for Hexify<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let mut lst = f.debug_list();
-        for addr in self.0 {
-            let _lst = lst.entry(&format_args!("{addr:#x}"));
-        }
-        lst.finish()
-    }
-}
 
 
 #[cfg(feature = "apk")]
@@ -1394,10 +1379,6 @@ mod tests {
     /// Exercise the `Debug` representation of various types.
     #[test]
     fn debug_repr() {
-        let addrs = [0x42, 0x1337];
-        let hex = Hexify(&addrs);
-        assert_eq!(format!("{hex:?}"), "[0x42, 0x1337]");
-
         let builder = Symbolizer::builder();
         assert_ne!(format!("{builder:?}"), "");
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,6 +16,23 @@ use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::slice;
 
+use crate::Addr;
+
+
+#[cfg(feature = "tracing")]
+pub(crate) struct Hexify<'addrs>(pub &'addrs [Addr]);
+
+#[cfg(feature = "tracing")]
+impl Debug for Hexify<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let mut lst = f.debug_list();
+        for addr in self.0 {
+            let _lst = lst.entry(&format_args!("{addr:#x}"));
+        }
+        lst.finish()
+    }
+}
+
 
 /// A type providing a derive for `Debug` for types that
 /// otherwise don't.
@@ -531,6 +548,14 @@ mod tests {
     #[cfg(feature = "nightly")]
     use test::Bencher;
 
+
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let addrs = [0x42, 0x1337];
+        let hex = Hexify(&addrs);
+        assert_eq!(format!("{hex:?}"), "[0x42, 0x1337]");
+    }
 
     /// Check whether an iterator represents a sorted sequence.
     // Copy of iterator::is_sorted_by used while it is still unstable.


### PR DESCRIPTION
Move the Hexify helper type into the util module -- as less opinionated location for this reusable functionality.