### PR TITLE
Adjust symbolize::Builder::set_debug_dirs() to accept Option

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -294,17 +294,26 @@ impl Builder {
     ///
     /// Note that the directory containing a symbolization source is always an
     /// implicit candidate target directory of the highest precedence.
+    ///
+    /// A value of `None` reverts to using the default set of directories.
     #[cfg(feature = "dwarf")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dwarf")))]
-    pub fn set_debug_dirs<D, P>(mut self, debug_dirs: D) -> Self
+    pub fn set_debug_dirs<D, P>(mut self, debug_dirs: Option<D>) -> Self
     where
         D: IntoIterator<Item = P>,
         P: AsRef<Path>,
     {
-        self.debug_dirs = debug_dirs
-            .into_iter()
-            .map(|p| p.as_ref().to_path_buf())
-            .collect();
+        if let Some(debug_dirs) = debug_dirs {
+            self.debug_dirs = debug_dirs
+                .into_iter()
+                .map(|p| p.as_ref().to_path_buf())
+                .collect();
+        } else {
+            self.debug_dirs = DEFAULT_DEBUG_DIRS
+                .iter()
+                .map(PathBuf::from)
+                .collect::<Vec<_>>();
+        }
         self
     }
 

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -456,7 +456,8 @@ fn symbolize_configurable_debug_dirs() {
 
     let src = symbolize::Source::from(symbolize::Elf::new(dst));
     let symbolizer = Symbolizer::builder()
-        .set_debug_dirs([] as [&Path; 0])
+        .set_debug_dirs(Option::<[&Path; 0]>::None)
+        .set_debug_dirs(Option::<[&Path; 0]>::Some([]))
         .build();
     let result = symbolizer
         .symbolize_single(&src, symbolize::Input::VirtOffset(0x2000100))
@@ -476,7 +477,7 @@ fn symbolize_configurable_debug_dirs() {
 
     let src = symbolize::Source::from(symbolize::Elf::new(path));
     let symbolizer = Symbolizer::builder()
-        .set_debug_dirs([debug_dir1, debug_dir2])
+        .set_debug_dirs(Some([debug_dir1, debug_dir2]))
         .build();
     let sym = symbolizer
         .symbolize_single(&src, symbolize::Input::VirtOffset(0x2000100))


### PR DESCRIPTION
All our `Builder` methods allow for resetting a previously set value, but the recently introduced `set_debug_dirs()` does not currently. Adjust the method's signature to accept an `Option` to make such resetting possible.