### PR TITLE
capi: Support working with potentially unaligned input arrays

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased
   - Added `blaze_normalize_reason_str` to retrieve textual representation
 - Added `blaze_symbolize_elf_file_offsets` function for symbolization of
   file offsets
+- Added support for transparently working with input data not in accordance with
+  Rust's alignment requirements
 - Removed `BLAZE_INPUT` macro
 - Bumped `blazesym` dependency to `0.2.0-alpha.12`
 

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -89,8 +89,10 @@ mod normalize;
 #[allow(non_camel_case_types)]
 mod symbolize;
 
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::ffi::c_char;
+use std::mem::align_of;
 use std::ptr::NonNull;
 use std::slice;
 
@@ -244,9 +246,11 @@ pub(crate) unsafe fn is_mem_zero(mut mem: *const u8, mut len: usize) -> bool {
     true
 }
 
-
-/// "Safely" create a slice from a user provided array.
-pub(crate) unsafe fn slice_from_user_array<'t, T>(items: *const T, num_items: usize) -> &'t [T] {
+/// "Safely" create a slice from an aligned user provided array.
+pub(crate) unsafe fn slice_from_aligned_user_array<'t, T>(
+    items: *const T,
+    num_items: usize,
+) -> &'t [T] {
     let items = if items.is_null() {
         // `slice::from_raw_parts` requires a properly aligned non-NULL pointer.
         // Craft one.
@@ -257,12 +261,49 @@ pub(crate) unsafe fn slice_from_user_array<'t, T>(items: *const T, num_items: us
     unsafe { slice::from_raw_parts(items, num_items) }
 }
 
+/// "Safely" create a slice from a user provided array.
+pub(crate) unsafe fn slice_from_user_array<'t, T>(items: *const T, num_items: usize) -> Cow<'t, [T]>
+where
+    T: Clone,
+{
+    #[cold]
+    fn safely_copy_to_allocated_slow<T>(items: *const T, num_items: usize) -> Vec<T>
+    where
+        T: Clone,
+    {
+        if items.is_null() {
+            Vec::new()
+        } else {
+            let mut src = items;
+            let mut buffer = Vec::<T>::with_capacity(num_items);
+            let mut dst = buffer.as_mut_ptr();
+
+            for _ in 0..num_items {
+                let () = unsafe { dst.write(src.read_unaligned()) };
+                src = unsafe { src.add(1) };
+                dst = unsafe { dst.add(1) };
+            }
+            let () = unsafe { buffer.set_len(num_items) };
+            buffer
+        }
+    }
+
+    if items.align_offset(align_of::<T>()) == 0 {
+        let slice = unsafe { slice_from_aligned_user_array(items, num_items) };
+        Cow::Borrowed(slice)
+    } else {
+        let vec = safely_copy_to_allocated_slow(items, num_items);
+        Cow::Owned(vec)
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use std::ffi::CStr;
+    use std::ops::Deref as _;
     use std::ptr;
 
 
@@ -282,20 +323,41 @@ mod tests {
         );
     }
 
-    /// Test the `slice_from_user_array` helper in the presence of various
-    /// inputs.
+    /// Test the `slice_from_aligned_user_array` helper in the presence of
+    /// various inputs.
     #[test]
     fn slice_creation() {
-        let slice = unsafe { slice_from_user_array::<u64>(ptr::null(), 0) };
+        let slice = unsafe { slice_from_aligned_user_array::<u64>(ptr::null(), 0) };
         assert_eq!(slice, &[]);
 
         let array = [];
-        let slice = unsafe { slice_from_user_array::<u64>(&array as *const _, array.len()) };
+        let slice =
+            unsafe { slice_from_aligned_user_array::<u64>(&array as *const _, array.len()) };
         assert_eq!(slice, &[]);
 
         let array = [42u64, 1337];
-        let slice = unsafe { slice_from_user_array::<u64>(&array as *const _, array.len()) };
+        let slice =
+            unsafe { slice_from_aligned_user_array::<u64>(&array as *const _, array.len()) };
         assert_eq!(slice, &[42, 1337]);
+    }
+
+    /// Make sure that we can create a slice from a potentially unaligned C
+    /// array of values.
+    #[test]
+    fn unaligned_slice_creation() {
+        let slice = unsafe { slice_from_user_array(ptr::null::<u64>(), 0) };
+        assert_eq!(slice.deref(), &[]);
+
+        let mut buffer = [0u64; 8];
+        let ptr = unsafe { buffer.as_mut_ptr().byte_add(3) };
+
+        let slice = unsafe { slice_from_user_array(ptr, buffer.len() - 1) };
+        assert!(matches!(slice, Cow::Owned(..)), "{slice:?}");
+        assert_eq!(slice.len(), buffer.len() - 1);
+
+        let slice = unsafe { slice_from_user_array(buffer.as_ptr(), buffer.len()) };
+        assert!(matches!(slice, Cow::Borrowed(..)), "{slice:?}");
+        assert_eq!(slice.len(), buffer.len());
     }
 
     /// Check that we can convert `ErrorKind` instances into `blaze_err`.

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -545,7 +545,7 @@ pub unsafe extern "C" fn blaze_normalize_user_addrs(
     // SAFETY: The caller needs to ensure that `addrs` is a valid pointer and
     //         that it points to `addr_cnt` elements.
     let addrs = unsafe { slice_from_user_array(addrs, addr_cnt) };
-    let result = normalizer.normalize_user_addrs(pid.into(), addrs);
+    let result = normalizer.normalize_user_addrs(pid.into(), &addrs);
     match result {
         Ok(addrs) => {
             let output_box = Box::new(ManuallyDrop::into_inner(
@@ -597,7 +597,7 @@ pub unsafe extern "C" fn blaze_normalize_user_addrs_sorted(
     // SAFETY: The caller needs to ensure that `addrs` is a valid pointer and
     //         that it points to `addr_cnt` elements.
     let addrs = unsafe { slice_from_user_array(addrs, addr_cnt) };
-    let result = normalizer.normalize_user_addrs_sorted(pid.into(), addrs);
+    let result = normalizer.normalize_user_addrs_sorted(pid.into(), &addrs);
     match result {
         Ok(addrs) => {
             let output_box = Box::new(ManuallyDrop::into_inner(

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -205,6 +205,14 @@ impl<T> Input<T> {
         }
     }
 
+    /// Retrieve a reference to the inner payload.
+    #[inline]
+    pub fn as_inner_ref(&self) -> &T {
+        match self {
+            Self::AbsAddr(x) | Self::VirtOffset(x) | Self::FileOffset(x) => x,
+        }
+    }
+
     /// Extract the inner payload.
     ///
     /// ```rust


### PR DESCRIPTION
As it turns out, C does not necessarily require natural alignment for primitive data types [0]. It is certainly more relaxed than Rust [1] in this respect, and that can be a source of problem when it comes to interoperability.
With this change we add support for working with potentially unaligned input addresses. We do so by taking necessary steps to read unaligned data into a temporary buffer and working on said temporary buffer.

[0] https://en.wikipedia.org/w/index.php?title=Data_structure_alignment&oldid=1209741102#Typical_alignment_of_C_structs_on_x86
[1] https://doc.rust-lang.org/reference/type-layout.html#primitive-data-layout

Closes: #678