### PR TITLE
capi: Make debug directories to search configurable

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added `debug_dirs` attribute to `blaze_symbolizer_opts`
 - Added `cache_maps` attribute to `blaze_normalizer_opts`
 - Introduced `blaze_err` enum and adjusted all fallible functions to
   set a thread local error

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -61,4 +61,5 @@ blazesym-c = {path = ".", features = ["check-doc-snippets"]}
 # TODO: Use 0.5.2 once released.
 criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}
 libc = "0.2.137"
+tempfile = "3.4"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -459,6 +459,23 @@ typedef struct blaze_symbolizer_opts {
    */
   size_t type_size;
   /**
+   * Array of debug directories to search for split debug information.
+   *
+   * These directories will be consulted (in given order) when resolving
+   * debug links in binaries. By default and when this member is NULL,
+   * `/usr/lib/debug` and `/lib/debug/` will be searched. Setting an array
+   * here will overwrite these defaults, so make sure to include these
+   * directories as desired.
+   *
+   * Note that the directory containing a symbolization source is always an
+   * implicit candidate target directory of the highest precedence.
+   */
+  const char *const *debug_dirs;
+  /**
+   * The number of array elements in `debug_dirs`.
+   */
+  size_t debug_dirs_len;
+  /**
    * Whether or not to automatically reload file system based
    * symbolization sources that were updated since the last
    * symbolization operation.


### PR DESCRIPTION
Make the list of debug directories configurable, similar to what commit e62caa983763 ("Make debug directories to search configurable") did for the Rust crate.