### PR TITLE
Fix blazesym-c publish workflow

### DIFF
--- a/.github/workflows/publish-capi.yml
+++ b/.github/workflows/publish-capi.yml
@@ -14,7 +14,7 @@ jobs:
     - id: version
       shell: bash
       run: |
-        cd cli
+        cd capi
         cargo generate-lockfile
         version="$(cargo pkgid | cut -d '#' -f2 | cut -d '@' -f2 | grep -o '[^:]*$')"
 


### PR DESCRIPTION
The publish workflow for the blazesym-c crate was changing to the wrong directory when attempting to retrieve the crate version. Fix up the path to make tag creation work as it should.