### PR TITLE
Fix typo normalizing -> symbolizing

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -552,10 +552,10 @@ typedef struct blaze_sym {
    * The byte offset of the address that got symbolized from the
    * start of the symbol (i.e., from `addr`).
    *
-   * E.g., when normalizing address 0x1337 of a function that starts at
+   * E.g., when symbolizing address 0x1337 of a function that starts at
    * 0x1330, the offset will be set to 0x07 (and `addr` will be 0x1330). This
    * member is especially useful in contexts when input addresses are not
-   * already normalized, such as when normalizing an address in a process
+   * already normalized, such as when symbolizing an address in a process
    * context (which may have been relocated and/or have layout randomizations
    * applied).
    */

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -371,10 +371,10 @@ pub struct blaze_sym {
     /// The byte offset of the address that got symbolized from the
     /// start of the symbol (i.e., from `addr`).
     ///
-    /// E.g., when normalizing address 0x1337 of a function that starts at
+    /// E.g., when symbolizing address 0x1337 of a function that starts at
     /// 0x1330, the offset will be set to 0x07 (and `addr` will be 0x1330). This
     /// member is especially useful in contexts when input addresses are not
-    /// already normalized, such as when normalizing an address in a process
+    /// already normalized, such as when symbolizing an address in a process
     /// context (which may have been relocated and/or have layout randomizations
     /// applied).
     pub offset: usize,

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -354,10 +354,10 @@ pub struct Sym<'src> {
     /// The byte offset of the address that got symbolized from the
     /// start of the symbol (i.e., from `addr`).
     ///
-    /// E.g., when normalizing address 0x1337 of a function that starts at
+    /// E.g., when symbolizing address 0x1337 of a function that starts at
     /// 0x1330, the offset will be set to 0x07 (and `addr` will be 0x1330). This
     /// member is especially useful in contexts when input addresses are not
-    /// already normalized, such as when normalizing an address in a process
+    /// already normalized, such as when symbolizing an address in a process
     /// context (which may have been relocated and/or have layout randomizations
     /// applied).
     pub offset: usize,


### PR DESCRIPTION
The Sym/blaze_sym types are used in symbolization contexts, not normalization. Adjust the documentation comment accordingly.