### PR TITLE
Enable clippy::clone_on_ref_ptr lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! relevance for C).
 
 #![allow(
+    clippy::clone_on_ref_ptr,
     clippy::collapsible_else_if,
     clippy::collapsible_if,
     clippy::fn_to_numeric_cast,


### PR DESCRIPTION
Enable the 'clone_on_ref_ptr' Clippy lint, which flags the usage of .clone() syntax on reference counted pointers. The more explicit Rc::clone() syntax is preferable in many cases, because it will invalidate the code should the Rc be removed, instead of unintentionally causing creation of a potentially expensive deep clone.