### PR TITLE
cli: Add --debug-dirs option to symbolize elf sub-command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `--debug-dirs` option to `symbolize elf` sub-command
+
+
 0.1.4
 -----
 - Added `inspect` command

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -187,13 +187,24 @@ pub mod symbolize {
     }
 
     #[derive(Debug, Arguments)]
+    #[group(multiple = false)]
+    pub struct DebugArgs {
+        /// Comma-separated list of debug directories to search when
+        /// resolving debug links.
+        #[clap(long, value_parser, value_delimiter = ',')]
+        pub debug_dirs: Option<Vec<PathBuf>>,
+        /// Disable the use of debug symbols.
+        #[clap(long)]
+        pub no_debug_syms: bool,
+    }
+
+    #[derive(Debug, Arguments)]
     pub struct Elf {
         /// The path to the ELF file.
         #[clap(short, long)]
         pub path: PathBuf,
-        /// Disable the use of debug symbols.
-        #[clap(long)]
-        pub no_debug_syms: bool,
+        #[command(flatten)]
+        pub debug_args: DebugArgs,
         /// The addresses to symbolize.
         ///
         /// Addresses are assumed to already be normalized to the file


### PR DESCRIPTION
Introduce the --debug-dirs option to the 'symbolize elf' sub-command. This option can be used to adjust the directories being used when searching for target files of debug links.

```
  $ cargo run -p blazecli -- symbolize elf --path /tmp/test-stable-addrs-stripped-with-link.bin 0x2000100
  > 2024-06-03T22:27:33.408437Z  WARN debug link references destination `test-stable-addrs-dwarf-only.dbg` which was not found in any known location
  > 0x00000002000100: <no-symbol>
  $ cargo run -p blazecli -- symbolize elf --path /tmp/test-stable-addrs-stripped-with-link.bin 0x2000100 --debug-dirs data/
  > 0x00000002000100: factorial @ 0x2000100+0x0 data/test-stable-addrs.c:10:27
```