### PR TITLE
Use test-tag crate for tagging Miri tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
     - name: Remove .cargo/config.toml
       run: rm .cargo/config.toml
     - name: Run tests
-      run: cargo miri test --workspace --features=dont-generate-unit-test-files -- "insert_map::" "util::" "::elf_src_validity"
+      run: cargo miri test --workspace --features=dont-generate-unit-test-files -- ":miri:"
   test-examples:
     name: Test examples
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ scopeguard = "1.2"
 stats_alloc = {version = "0.1.1", features = ["nightly"]}
 tempfile = "3.4"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
+test-tag = "0.1"
 
 # A set of unused dependencies that we require to force correct minimum versions
 # of transitive dependencies, for cases where our dependencies have incorrect

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -63,3 +63,4 @@ criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e2
 libc = "0.2.137"
 tempfile = "3.4"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
+test-tag = "0.1"

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -388,6 +388,7 @@ mod tests {
     use std::slice;
 
     use test_log::test;
+    use test_tag::tag;
 
 
     /// Check that various types have expected sizes.
@@ -429,7 +430,7 @@ mod tests {
 
     /// Test that we can correctly validate zeroed "extensions" of a
     /// struct.
-    // NB: If renamed, please adjust Miri CI workflow accordingly.
+    #[tag(miri)]
     #[test]
     fn elf_src_validity() {
         #[repr(C)]

--- a/capi/src/util.rs
+++ b/capi/src/util.rs
@@ -79,8 +79,11 @@ mod tests {
     use std::ops::Deref as _;
     use std::ptr;
 
+    use test_tag::tag;
+
 
     /// Check that `is_mem_zero` works as it should.
+    #[tag(miri)]
     #[test]
     fn mem_zeroed_checking() {
         let mut bytes = [0u8; 64];
@@ -94,6 +97,7 @@ mod tests {
 
     /// Test the `slice_from_aligned_user_array` helper in the presence of
     /// various inputs.
+    #[tag(miri)]
     #[test]
     fn slice_creation() {
         let slice = unsafe { slice_from_aligned_user_array::<u64>(ptr::null(), 0) };
@@ -112,6 +116,7 @@ mod tests {
 
     /// Make sure that we can create a slice from a potentially unaligned C
     /// array of values.
+    #[tag(miri)]
     #[test]
     fn unaligned_slice_creation() {
         let slice = unsafe { slice_from_user_array(ptr::null::<u64>(), 0) };

--- a/src/insert_map.rs
+++ b/src/insert_map.rs
@@ -70,11 +70,14 @@ impl<K, V> Default for InsertMap<K, V> {
 mod tests {
     use super::*;
 
+    use test_tag::tag;
+
     use crate::Error;
     use crate::ErrorKind;
 
 
     /// Check that value insertion works as it should.
+    #[tag(miri)]
     #[test]
     fn insertion() {
         let map = InsertMap::<usize, &'static str>::new();
@@ -99,6 +102,7 @@ mod tests {
 
     /// Make sure that `InsertMap` does not allow for recursive
     /// access as part of initialization.
+    #[tag(miri)]
     #[test]
     #[should_panic = "already borrowed"]
     fn recursive_access() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -545,11 +545,14 @@ mod tests {
 
     use tempfile::NamedTempFile;
 
+    use test_tag::tag;
+
     #[cfg(feature = "nightly")]
     use test::Bencher;
 
 
     /// Exercise the `Debug` representation of various types.
+    #[tag(miri)]
     #[test]
     fn debug_repr() {
         let addrs = [0x42, 0x1337];
@@ -598,6 +601,7 @@ mod tests {
 
 
     /// Make sure that we can detect sorted slices.
+    #[tag(miri)]
     #[test]
     fn sorted_check() {
         assert!(is_sorted([1, 5, 6].iter()));
@@ -605,6 +609,7 @@ mod tests {
     }
 
     /// Check that our [`Dbg`] type does what it says on the tin.
+    #[tag(miri)]
     #[test]
     fn debug_non_debug() {
         #[repr(transparent)]
@@ -618,6 +623,7 @@ mod tests {
     }
 
     /// Check that we can reorder elements in an array as expected.
+    #[tag(miri)]
     #[test]
     fn array_reordering() {
         let mut array = vec![];
@@ -636,6 +642,7 @@ mod tests {
     }
 
     /// Check that `with_ordered_elems` works as it should.
+    #[tag(miri)]
     #[test]
     fn with_element_ordering() {
         let vec = vec![5u8, 0, 1, 99, 6, 2];
@@ -655,7 +662,6 @@ mod tests {
     /// Check that we can retrieve meta-data about a file using `stat`
     /// and `fstat`.
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn file_stating() {
         let tmpfile = NamedTempFile::new().unwrap();
         let stat1 = stat(tmpfile.path()).unwrap();
@@ -669,6 +675,7 @@ mod tests {
     }
 
     /// Make sure that `[u8]::ensure` works as expected.
+    #[tag(miri)]
     #[test]
     fn u8_slice_len_ensurance() {
         let slice = [0u8; 0].as_slice();
@@ -682,6 +689,7 @@ mod tests {
     }
 
     /// Check that we can align the read pointer on a `[u8]`.
+    #[tag(miri)]
     #[test]
     fn u8_slice_align() {
         let mut buffer = [0u8; 64];
@@ -723,6 +731,7 @@ mod tests {
     }
 
     /// Check that we can read various integers from a slice.
+    #[tag(miri)]
     #[test]
     fn pod_reading() {
         macro_rules! test {
@@ -757,6 +766,7 @@ mod tests {
     }
 
     /// Check that we can read references to `Pod`s.
+    #[tag(miri)]
     #[test]
     fn pod_ref_reading() {
         // This test assumes that `u64`'s required alignment is greater
@@ -792,6 +802,7 @@ mod tests {
 
     /// Test reading of signed and unsigned 16 and 32 bit values against known
     /// results.
+    #[tag(miri)]
     #[test]
     fn word_reading() {
         let data = 0xf936857fu32.to_ne_bytes();
@@ -800,6 +811,7 @@ mod tests {
     }
 
     /// Make sure that we can read leb128 encoded values.
+    #[tag(miri)]
     #[test]
     fn leb128_reading() {
         let data = [0xf4, 0xf3, 0x75];
@@ -813,6 +825,7 @@ mod tests {
     }
 
     /// Check that we can read a NUL terminated string from a slice.
+    #[tag(miri)]
     #[test]
     fn cstr_reading() {
         let mut slice = b"abc\x001234".as_slice();
@@ -826,6 +839,7 @@ mod tests {
     }
 
     /// Test that we correctly binary search for a lowest match.
+    #[tag(miri)]
     #[test]
     fn search_lowest_match() {
         fn test(f: impl Fn(&[u16], &u16) -> Option<usize>) {
@@ -868,6 +882,7 @@ mod tests {
     }
 
     /// Test that we correctly binary search for a match or a lower bound.
+    #[tag(miri)]
     #[test]
     fn search_match_or_lower_bound() {
         let data = [];


### PR DESCRIPTION
The way we specify the tests to run under Miri is error-prone at best. Basically, we roughly group eligible tests into modules or hard code function names of suitable functions inside the CI configuration. This is prone to result in missed tests (if somebody renames a test and forgets to adjust the CI script). It is also non-obvious from the code what is happening and that makes it much less likely that new tests are onboarded to run there. Lastly, because we establish a grouping by module (to minimize maintenance burden of naming dozens of tests in the CI configuration), we end up with attributes such as `#[cfg_attr(miri, ignore)]` for opting out.
With this change we switch over to using the test-tag crate for tagging Miri tests as such, which will make it much easier to onboard new tests and reduces the maintenance burden down the line, because the source of truth is a single declarative attribute on the eligible tests.