### PR TITLE
capi: Reword documentation of blaze_symbolize_*()

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1023,9 +1023,10 @@ void blaze_symbolizer_free(blaze_symbolizer *symbolizer);
 /**
  * Symbolize a list of process absolute addresses.
  *
- * On success, the function returns an array of [`blaze_result`] with
- * `abs_addr_cnt` elements. The returned object should be released using
- * [`blaze_result_free`] once it is no longer needed.
+ * On success, the function returns a [`blaze_result`] containing an
+ * array of `abs_addr_cnt` [`blaze_sym`] objects. The returned object
+ * should be released using [`blaze_result_free`] once it is no longer
+ * needed.
  *
  * On error, the function returns `NULL` and sets the thread's last error to
  * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -1044,9 +1045,10 @@ const struct blaze_result *blaze_symbolize_process_abs_addrs(blaze_symbolizer *s
 /**
  * Symbolize a list of kernel absolute addresses.
  *
- * On success, the function returns an array of [`blaze_result`] with
- * `abs_addr_cnt` elements. The returned object should be released using
- * [`blaze_result_free`] once it is no longer needed.
+ * On success, the function returns a [`blaze_result`] containing an
+ * array of `abs_addr_cnt` [`blaze_sym`] objects. The returned object
+ * should be released using [`blaze_result_free`] once it is no longer
+ * needed.
  *
  * On error, the function returns `NULL` and sets the thread's last error to
  * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -1065,9 +1067,10 @@ const struct blaze_result *blaze_symbolize_kernel_abs_addrs(blaze_symbolizer *sy
 /**
  * Symbolize virtual offsets in an ELF file.
  *
- * On success, the function returns an array of [`blaze_result`] with
- * `virt_offset_cnt` elements. The returned object should be released using
- * [`blaze_result_free`] once it is no longer needed.
+ * On success, the function returns a [`blaze_result`] containing an
+ * array of `virt_offset_cnt` [`blaze_sym`] objects. The returned
+ * object should be released using [`blaze_result_free`] once it is no
+ * longer needed.
  *
  * On error, the function returns `NULL` and sets the thread's last error to
  * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -1086,9 +1089,10 @@ const struct blaze_result *blaze_symbolize_elf_virt_offsets(blaze_symbolizer *sy
 /**
  * Symbolize file offsets in an ELF file.
  *
- * On success, the function returns an array of [`blaze_result`] with
- * `file_offset_cnt` elements. The returned object should be released using
- * [`blaze_result_free`] once it is no longer needed.
+ * On success, the function returns a [`blaze_result`] containing an
+ * array of `file_offset_cnt` [`blaze_sym`] objects. The returned
+ * object should be released using [`blaze_result_free`] once it is no
+ * longer needed.
  *
  * On error, the function returns `NULL` and sets the thread's last error to
  * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -1107,9 +1111,10 @@ const struct blaze_result *blaze_symbolize_elf_file_offsets(blaze_symbolizer *sy
 /**
  * Symbolize virtual offsets using "raw" Gsym data.
  *
- * On success, the function returns an array of [`blaze_result`] with
- * `virt_offset_cnt` elements. The returned object should be released using
- * [`blaze_result_free`] once it is no longer needed.
+ * On success, the function returns a [`blaze_result`] containing an
+ * array of `virt_offset_cnt` [`blaze_sym`] objects. The returned
+ * object should be released using [`blaze_result_free`] once it is no
+ * longer needed.
  *
  * On error, the function returns `NULL` and sets the thread's last error to
  * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -1128,9 +1133,10 @@ const struct blaze_result *blaze_symbolize_gsym_data_virt_offsets(blaze_symboliz
 /**
  * Symbolize virtual offsets in a Gsym file.
  *
- * On success, the function returns an array of [`blaze_result`] with
- * `virt_offset_cnt` elements. The returned object should be released using
- * [`blaze_result_free`] once it is no longer needed.
+ * On success, the function returns a [`blaze_result`] containing an
+ * array of `virt_offset_cnt` [`blaze_sym`] objects. The returned
+ * object should be released using [`blaze_result_free`] once it is no
+ * longer needed.
  *
  * On error, the function returns `NULL` and sets the thread's last error to
  * indicate the problem encountered. Use [`blaze_err_last`] to retrieve this

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -752,9 +752,10 @@ unsafe fn blaze_symbolize_impl(
 
 /// Symbolize a list of process absolute addresses.
 ///
-/// On success, the function returns an array of [`blaze_result`] with
-/// `abs_addr_cnt` elements. The returned object should be released using
-/// [`blaze_result_free`] once it is no longer needed.
+/// On success, the function returns a [`blaze_result`] containing an
+/// array of `abs_addr_cnt` [`blaze_sym`] objects. The returned object
+/// should be released using [`blaze_result_free`] once it is no longer
+/// needed.
 ///
 /// On error, the function returns `NULL` and sets the thread's last error to
 /// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -784,9 +785,10 @@ pub unsafe extern "C" fn blaze_symbolize_process_abs_addrs(
 
 /// Symbolize a list of kernel absolute addresses.
 ///
-/// On success, the function returns an array of [`blaze_result`] with
-/// `abs_addr_cnt` elements. The returned object should be released using
-/// [`blaze_result_free`] once it is no longer needed.
+/// On success, the function returns a [`blaze_result`] containing an
+/// array of `abs_addr_cnt` [`blaze_sym`] objects. The returned object
+/// should be released using [`blaze_result_free`] once it is no longer
+/// needed.
 ///
 /// On error, the function returns `NULL` and sets the thread's last error to
 /// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -816,9 +818,10 @@ pub unsafe extern "C" fn blaze_symbolize_kernel_abs_addrs(
 
 /// Symbolize virtual offsets in an ELF file.
 ///
-/// On success, the function returns an array of [`blaze_result`] with
-/// `virt_offset_cnt` elements. The returned object should be released using
-/// [`blaze_result_free`] once it is no longer needed.
+/// On success, the function returns a [`blaze_result`] containing an
+/// array of `virt_offset_cnt` [`blaze_sym`] objects. The returned
+/// object should be released using [`blaze_result_free`] once it is no
+/// longer needed.
 ///
 /// On error, the function returns `NULL` and sets the thread's last error to
 /// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -854,9 +857,10 @@ pub unsafe extern "C" fn blaze_symbolize_elf_virt_offsets(
 
 /// Symbolize file offsets in an ELF file.
 ///
-/// On success, the function returns an array of [`blaze_result`] with
-/// `file_offset_cnt` elements. The returned object should be released using
-/// [`blaze_result_free`] once it is no longer needed.
+/// On success, the function returns a [`blaze_result`] containing an
+/// array of `file_offset_cnt` [`blaze_sym`] objects. The returned
+/// object should be released using [`blaze_result_free`] once it is no
+/// longer needed.
 ///
 /// On error, the function returns `NULL` and sets the thread's last error to
 /// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -893,9 +897,10 @@ pub unsafe extern "C" fn blaze_symbolize_elf_file_offsets(
 
 /// Symbolize virtual offsets using "raw" Gsym data.
 ///
-/// On success, the function returns an array of [`blaze_result`] with
-/// `virt_offset_cnt` elements. The returned object should be released using
-/// [`blaze_result_free`] once it is no longer needed.
+/// On success, the function returns a [`blaze_result`] containing an
+/// array of `virt_offset_cnt` [`blaze_sym`] objects. The returned
+/// object should be released using [`blaze_result_free`] once it is no
+/// longer needed.
 ///
 /// On error, the function returns `NULL` and sets the thread's last error to
 /// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this
@@ -931,9 +936,10 @@ pub unsafe extern "C" fn blaze_symbolize_gsym_data_virt_offsets(
 
 /// Symbolize virtual offsets in a Gsym file.
 ///
-/// On success, the function returns an array of [`blaze_result`] with
-/// `virt_offset_cnt` elements. The returned object should be released using
-/// [`blaze_result_free`] once it is no longer needed.
+/// On success, the function returns a [`blaze_result`] containing an
+/// array of `virt_offset_cnt` [`blaze_sym`] objects. The returned
+/// object should be released using [`blaze_result_free`] once it is no
+/// longer needed.
 ///
 /// On error, the function returns `NULL` and sets the thread's last error to
 /// indicate the problem encountered. Use [`blaze_err_last`] to retrieve this


### PR DESCRIPTION
The blaze_symbolize_*() functions don't really return an array of blaze_result objects. Reword the documentation accordingly.