### PR TITLE
Run more tests in Miri

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -717,9 +717,11 @@ mod tests {
     use std::mem::size_of;
 
     use test_log::test;
+    use test_tag::tag;
 
 
     /// Exercise the `Display` representation of various types.
+    #[tag(miri)]
     #[test]
     fn display_repr() {
         assert_eq!(ErrorKind::NotFound.to_string(), "entity not found");
@@ -731,6 +733,7 @@ mod tests {
     }
 
     /// Check various features of our `Str` wrapper type.
+    #[tag(miri)]
     #[test]
     fn str_wrapper() {
         let b = "test string".to_string().into_boxed_str();
@@ -748,6 +751,7 @@ mod tests {
     }
 
     /// Check that we can convert a `dyn std::error::Error` into our `Error`.
+    #[tag(miri)]
     #[test]
     fn std_error_conversion() {
         let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");
@@ -760,6 +764,7 @@ mod tests {
     }
 
     /// Check that we can format errors as expected.
+    #[tag(miri)]
     #[test]
     fn error_formatting() {
         let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");

--- a/src/ksym.rs
+++ b/src/ksym.rs
@@ -205,11 +205,13 @@ mod tests {
     use super::*;
 
     use test_log::test;
+    use test_tag::tag;
 
     use crate::ErrorKind;
 
 
     /// Exercise the `Debug` representation of various types.
+    #[tag(miri)]
     #[test]
     fn debug_repr() {
         let resolver = KSymResolver {
@@ -284,6 +286,7 @@ mod tests {
         ensure_addr_for_name(found.name, addr);
     }
 
+    #[tag(miri)]
     #[test]
     fn find_ksym() {
         let resolver = KSymResolver {
@@ -344,6 +347,7 @@ mod tests {
     }
 
     /// Check that we can correctly iterate over all symbols.
+    #[tag(miri)]
     #[test]
     fn symbol_iteration() {
         let resolver = KSymResolver {
@@ -381,6 +385,7 @@ mod tests {
     /// Check that [`KSymResolver::find_addr`] and
     /// [`KSymResolver::for_each`] behave as expected for variable
     /// inquiries.
+    #[tag(miri)]
     #[test]
     fn variable_operations() {
         let resolver = KSymResolver {

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -313,6 +313,7 @@ mod tests {
     use std::path::Path;
 
     use test_log::test;
+    use test_tag::tag;
 
     #[cfg(feature = "nightly")]
     use test::Bencher;
@@ -334,6 +335,7 @@ mod tests {
     }
 
     /// Make sure that we can parse proc maps lines correctly.
+    #[tag(miri)]
     #[test]
     fn map_line_parsing() {
         let lines = r#"00400000-00401000 r--p 00000000 00:29 47459                              /tmp/test/test
@@ -443,6 +445,7 @@ ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0                  [vsysca
     }
 
     /// Check that we error out as expected on malformed proc maps lines.
+    #[tag(miri)]
     #[test]
     fn malformed_proc_maps_lines() {
         let lines = [

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,7 +1,0 @@
-use std::fmt::Debug;
-
-use crate::symbolize::FindSymOpts;
-use crate::symbolize::IntSym;
-use crate::symbolize::Reason;
-use crate::Addr;
-use crate::Result;


### PR DESCRIPTION
Now that we are tagging tests eligible for running under Miri it is much easier to onboard new ones. Add a bunch.