### PR TITLE
capi: Add `blaze_symbolization_reason` enum

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -10,9 +10,12 @@ Unreleased
 - Introduced `blaze_normalize_opts` and added
   `blaze_normalize_user_addrs_opts` to use it
   - Removed `blaze_normalize_user_addrs_sorted` function
-- Introduced `blaze_normalize_reason` type and extended
+- Introduced `blaze_normalize_reason` type
   - Added `reason` attribute to `blaze_user_meta_unknown`
   - Added `blaze_normalize_reason_str` to retrieve textual representation
+- Introduced `blaze_symbolize_reason` type
+  - Added `reason` attribute to `blaze_sym`
+  - Added `blaze_symbolize_reason_str` to retrieve textual representation
 - Added `blaze_symbolize_elf_file_offsets` function for symbolization of
   file offsets
 - Added support for transparently working with input data not in accordance with

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -144,6 +144,54 @@ typedef uint8_t blaze_sym_type;
 #endif // __cplusplus
 
 /**
+ * The reason why symbolization failed.
+ *
+ * The reason is generally only meant as a hint. Reasons reported may
+ * change over time and, hence, should not be relied upon for the
+ * correctness of the application.
+ */
+enum blaze_symbolize_reason
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  /**
+   * Symbolization was successful.
+   */
+  BLAZE_SYMBOLIZE_REASON_SUCCESS = 0,
+  /**
+   * The absolute address was not found in the corresponding process'
+   * virtual memory map.
+   */
+  BLAZE_SYMBOLIZE_REASON_UNMAPPED,
+  /**
+   * The file offset does not map to a valid piece of code/data.
+   */
+  BLAZE_SYMBOLIZE_REASON_INVALID_FILE_OFFSET,
+  /**
+   * The `/proc/<pid>/maps` entry corresponding to the address does
+   * not have a component (file system path, object, ...) associated
+   * with it.
+   */
+  BLAZE_SYMBOLIZE_REASON_MISSING_COMPONENT,
+  /**
+   * The symbolization source has no or no relevant symbols.
+   */
+  BLAZE_SYMBOLIZE_REASON_MISSING_SYMS,
+  /**
+   * The address could not be found in the symbolization source.
+   */
+  BLAZE_SYMBOLIZE_REASON_UNKNOWN_ADDR,
+  /**
+   * The address belonged to an entity that is currently unsupported.
+   */
+  BLAZE_SYMBOLIZE_REASON_UNSUPPORTED,
+};
+#ifndef __cplusplus
+typedef uint8_t blaze_symbolize_reason;
+#endif // __cplusplus
+
+/**
  * The valid variant kind in [`blaze_user_meta`].
  */
 typedef enum blaze_user_meta_kind {
@@ -602,9 +650,14 @@ typedef struct blaze_sym {
    */
   const struct blaze_symbolize_inlined_fn *inlined;
   /**
+   * On error (i.e., if `name` is NULL), a reason trying to explain
+   * why symbolization failed.
+   */
+  blaze_symbolize_reason reason;
+  /**
    * Unused member available for future expansion.
    */
-  uint8_t reserved[8];
+  uint8_t reserved[7];
 } blaze_sym;
 
 /**
@@ -977,6 +1030,12 @@ struct blaze_normalized_user_output *blaze_normalize_user_addrs_opts(const blaze
  * [`blaze_normalize_user_addrs_opts`].
  */
 void blaze_user_output_free(struct blaze_normalized_user_output *output);
+
+/**
+ * Retrieve a textual representation of the reason of a symbolization
+ * failure.
+ */
+const char *blaze_symbolize_reason_str(blaze_symbolize_reason err);
 
 /**
  * Create an instance of a symbolizer.


### PR DESCRIPTION
This change introduces the blaze_symbolization_reason enumeration to blazesym-c and adjusts the blaze_sym type to carry such a reason. We also introduce the blaze_symbolization_reason_str() helper function that can be used to retrieve a textual representation of a reason for a symbolization failure.