### PR TITLE
Optimize LEB128 data reading

### DIFF
--- a/src/gsym/inline.rs
+++ b/src/gsym/inline.rs
@@ -25,8 +25,7 @@ impl InlineInfo {
     ) -> Result<Option<InlineInfo>> {
         let range_cnt = data
             .read_u64_leb128()
-            .ok_or_invalid_data(|| "failed to read range count from inline information")?
-            .0;
+            .ok_or_invalid_data(|| "failed to read range count from inline information")?;
         let range_cnt = usize::try_from(range_cnt)
             .ok()
             .ok_or_invalid_data(|| "range count ({}) is too big")?;
@@ -41,12 +40,10 @@ impl InlineInfo {
             for i in 0..range_cnt {
                 let offset = data
                     .read_u64_leb128()
-                    .ok_or_invalid_data(|| "failed to read offset from inline information")?
-                    .0;
+                    .ok_or_invalid_data(|| "failed to read offset from inline information")?;
                 let size = data
                     .read_u64_leb128()
-                    .ok_or_invalid_data(|| "failed to read size from inline information")?
-                    .0;
+                    .ok_or_invalid_data(|| "failed to read size from inline information")?;
 
                 let start = base_addr
                     .checked_add(offset)
@@ -91,15 +88,13 @@ impl InlineInfo {
         let (call_file, call_line) = if lookup_addr.is_some() {
             let call_file = data
                 .read_u64_leb128()
-                .ok_or_invalid_data(|| "failed to read call file from inline information")?
-                .0;
+                .ok_or_invalid_data(|| "failed to read call file from inline information")?;
             let call_file = u32::try_from(call_file)
                 .ok()
                 .ok_or_invalid_data(|| "call file index ({}) is too big")?;
             let call_line = data
                 .read_u64_leb128()
-                .ok_or_invalid_data(|| "failed to read call line from inline information")?
-                .0;
+                .ok_or_invalid_data(|| "failed to read call line from inline information")?;
             let call_line = u32::try_from(call_line).unwrap_or(u32::MAX);
             (Some(call_file), Some(call_line))
         } else {

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -48,9 +48,9 @@ impl LineTableHeader {
     ///
     /// * `data` - is what [`AddrData::data`] is.
     pub(super) fn parse(data: &mut &[u8]) -> Option<Self> {
-        let (min_delta, _bytes) = data.read_i64_leb128()?;
-        let (max_delta, _bytes) = data.read_i64_leb128()?;
-        let (first_line, _bytes) = data.read_u64_leb128()?;
+        let min_delta = data.read_i64_leb128()?;
+        let max_delta = data.read_i64_leb128()?;
+        let first_line = data.read_u64_leb128()?;
 
         let header = Self {
             min_delta,
@@ -108,17 +108,17 @@ pub(crate) fn run_op(
     match op {
         END_SEQUENCE => Some(RunResult::End),
         SET_FILE => {
-            let (f, _bytes) = ops.read_u64_leb128()?;
+            let f = ops.read_u64_leb128()?;
             row.file_idx = f as u32;
             Some(RunResult::Ok)
         }
         ADVANCE_PC => {
-            let (adv, _bytes) = ops.read_u64_leb128()?;
+            let adv = ops.read_u64_leb128()?;
             row.addr += adv as Addr;
             Some(RunResult::NewRow)
         }
         ADVANCE_LINE => {
-            let (adv, _bytes) = ops.read_i64_leb128()?;
+            let adv = ops.read_i64_leb128()?;
             row.file_line = (row.file_line as i64 + adv) as u32;
             Some(RunResult::Ok)
         }


### PR DESCRIPTION
As it turns out, the Rust compiler uses variable length LEB128 encoded integers internally. It so happens that they spent a fair amount of effort micro-optimizing the decoding functionality [0] [1], as it's in the hot path.
With this change we replace our decoding routines with these optimized ones. To make that happen more easily (and to gain some base line speed up), also remove the "shift" return from the respective methods. As a result of these changes, we see a repsectable speed up:

Before:
```
  test util::tests::bench_u64_leb128_reading  ... bench:  128 ns/iter (+/- 10)
```

After:
```
  test util::tests::bench_u64_leb128_reading  ... bench:  103 ns/iter (+/- 5)
```

Gsym decoding, which uses these routines, improved as follows:
```
  main/symbolize_gsym_multi_no_setup
    time:   [146.26 µs 146.69 µs 147.18 µs]
    change: [−7.2075% −5.7106% −4.4870%] (p = 0.00 < 0.02)
    Performance has improved.
```

[0] https://github.com/rust-lang/rust/pull/69050
[1] https://github.com/rust-lang/rust/pull/69157