### PR TITLE
Factor out test_helper module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ pub mod normalize;
 mod once;
 mod pid;
 pub mod symbolize;
+#[cfg(test)]
+mod test_helper;
 mod util;
 #[cfg(feature = "apk")]
 mod zip;

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1374,13 +1374,9 @@ impl Default for Symbolizer {
 mod tests {
     use super::*;
 
-    use std::mem::transmute;
-
-    use crate::inspect;
-    use crate::inspect::FindAddrOpts;
     use crate::symbolize;
     use crate::symbolize::CodeInfo;
-    use crate::SymType;
+    use crate::test_helper::find_the_answer_fn;
 
     use test_log::test;
 
@@ -1516,44 +1512,6 @@ mod tests {
                 assert_eq!(err.kind(), ErrorKind::Unsupported);
             }
         }
-    }
-
-    fn find_the_answer_fn(mmap: &Mmap) -> (inspect::SymInfo<'_>, Addr) {
-        let archive = zip::Archive::with_mmap(mmap.clone()).unwrap();
-        let so = archive
-            .entries()
-            .find_map(|entry| {
-                let entry = entry.unwrap();
-                (entry.path == Path::new("libtest-so.so")).then_some(entry)
-            })
-            .unwrap();
-
-        let elf_mmap = mmap
-            .constrain(so.data_offset..so.data_offset + so.data.len() as u64)
-            .unwrap();
-
-        // Look up the address of the `the_answer` function inside of the shared
-        // object.
-        let elf_parser =
-            ElfParser::from_mmap(elf_mmap.clone(), Some(PathBuf::from("libtest-so.so")));
-        let opts = FindAddrOpts {
-            sym_type: SymType::Function,
-            ..Default::default()
-        };
-        let syms = elf_parser.find_addr("the_answer", &opts).unwrap();
-        // There is only one symbol with this address in there.
-        assert_eq!(syms.len(), 1);
-        let sym = syms.first().unwrap();
-
-        let the_answer_addr = unsafe { elf_mmap.as_ptr().add(sym.addr as usize) };
-        // Now just double check that everything worked out and the function
-        // is actually where it was meant to be.
-        let the_answer_fn =
-            unsafe { transmute::<_, extern "C" fn() -> libc::c_int>(the_answer_addr) };
-        let answer = the_answer_fn();
-        assert_eq!(answer, 42);
-
-        (sym.to_owned(), the_answer_addr as Addr)
     }
 
     /// Check that we can symbolize an address residing in a zip archive.

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -1,0 +1,47 @@
+use std::mem::transmute;
+use std::path::Path;
+use std::path::PathBuf;
+
+use crate::elf::ElfParser;
+use crate::inspect;
+use crate::zip;
+use crate::Addr;
+use crate::Mmap;
+use crate::SymType;
+
+
+pub(crate) fn find_the_answer_fn(mmap: &Mmap) -> (inspect::SymInfo<'_>, Addr) {
+    let archive = zip::Archive::with_mmap(mmap.clone()).unwrap();
+    let so = archive
+        .entries()
+        .find_map(|entry| {
+            let entry = entry.unwrap();
+            (entry.path == Path::new("libtest-so.so")).then_some(entry)
+        })
+        .unwrap();
+
+    let elf_mmap = mmap
+        .constrain(so.data_offset..so.data_offset + so.data.len() as u64)
+        .unwrap();
+
+    // Look up the address of the `the_answer` function inside of the shared
+    // object.
+    let elf_parser = ElfParser::from_mmap(elf_mmap.clone(), Some(PathBuf::from("libtest-so.so")));
+    let opts = inspect::FindAddrOpts {
+        sym_type: SymType::Function,
+        ..Default::default()
+    };
+    let syms = elf_parser.find_addr("the_answer", &opts).unwrap();
+    // There is only one symbol with this address in there.
+    assert_eq!(syms.len(), 1);
+    let sym = syms.first().unwrap();
+
+    let the_answer_addr = unsafe { elf_mmap.as_ptr().add(sym.addr as usize) };
+    // Now just double check that everything worked out and the function
+    // is actually where it was meant to be.
+    let the_answer_fn = unsafe { transmute::<_, extern "C" fn() -> libc::c_int>(the_answer_addr) };
+    let answer = the_answer_fn();
+    assert_eq!(answer, 42);
+
+    (sym.to_owned(), the_answer_addr as Addr)
+}


### PR DESCRIPTION
Factor out a new test-only module containing helper functionality, test_helper, and move the find_the_answer_fn() function into it. This way, we will be able to reuse it from various tests instead of duplicating the logic all over the place.