### PR TITLE
capi: Partially revert a12675902d7d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ scopeguard = "1.2"
 stats_alloc = {version = "0.1.1", features = ["nightly"]}
 tempfile = "3.4"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
-test-tag = "0.1"
+test-tag = "0.1.3"
 
 # A set of unused dependencies that we require to force correct minimum versions
 # of transitive dependencies, for cases where our dependencies have incorrect

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -898,6 +898,7 @@ mod tests {
                 libc::__errno_location as Addr,
                 libc::dlopen as Addr,
                 libc::fopen as Addr,
+                elf_conversion as Addr,
                 normalize_user_addrs as Addr,
             ];
 
@@ -908,7 +909,7 @@ mod tests {
 
             let user_addrs = unsafe { &*result };
             assert_eq!(user_addrs.meta_cnt, 3);
-            assert_eq!(user_addrs.output_cnt, 5);
+            assert_eq!(user_addrs.output_cnt, 6);
 
             let meta = unsafe { user_addrs.metas.read() };
             assert_eq!(meta.kind, blaze_user_meta_kind::BLAZE_USER_META_UNKNOWN);
@@ -943,6 +944,7 @@ mod tests {
             libc::__errno_location as Addr,
             libc::dlopen as Addr,
             libc::fopen as Addr,
+            elf_conversion as Addr,
             normalize_user_addrs as Addr,
         ];
         let () = addrs.sort();
@@ -967,7 +969,7 @@ mod tests {
 
         let user_addrs = unsafe { &*result };
         assert_eq!(user_addrs.meta_cnt, 2);
-        assert_eq!(user_addrs.output_cnt, 4);
+        assert_eq!(user_addrs.output_cnt, 5);
 
         let () = unsafe { blaze_user_output_free(result) };
         let () = unsafe { blaze_normalizer_free(normalizer) };
@@ -981,6 +983,7 @@ mod tests {
             libc::__errno_location as Addr,
             libc::dlopen as Addr,
             libc::fopen as Addr,
+            elf_conversion as Addr,
             normalize_user_addrs as Addr,
         ];
         let () = addrs.sort_by(|addr1, addr2| addr1.cmp(addr2).reverse());


### PR DESCRIPTION
With commit a12675902d7d ("capi: Onboard yet more tests to Miri") we removed the usage of the elf_conversion() test function in some of the normalization tests, because the test-tag::tag attribute didn't make the function accessible under at the top level.
Version 0.1.3 of the crate rectified this short coming and with this change we update to it and revert the relevant changes of the commit.