### PR TITLE
Be more forgiving when attempting to calculate file offset

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -366,7 +366,11 @@ fn cc_stable_addrs(dst: impl AsRef<OsStr>, options: &[&str]) {
 fn cc_test_so(dst: impl AsRef<OsStr>, options: &[&str]) {
     let data_dir = data_dir();
     let src = data_dir.join("test-so.c");
-    let args = ["-shared", "-fPIC"]
+    let map = data_dir.join("test-so.map");
+    let wl = format!("-Wl,--version-script,{}", map.to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", map.display());
+
+    let args = ["-shared", "-fPIC", &wl]
         .into_iter()
         .chain(options.iter().map(Deref::deref))
         .collect::<Vec<_>>();

--- a/data/test-so.map
+++ b/data/test-so.map
@@ -1,0 +1,9 @@
+ADDRS_0.0.0 {
+  global:
+    the_answer;
+};
+
+ADDRS_0.0.1 {
+  global:
+    the_ignored_answer;
+};


### PR DESCRIPTION
We may not be able to determine a file offset for each symbol in an ELF file. For example, when using version scripts many linkers emit zero sized symbols such as GLIBC_2.2.5 as version markers into a binary. Those are marked as type "absolute" and have a value ("address") of zero.
Currently we bail out hard when attempting to calculate the file offset for such a symbol: the section index would be SHN_ABS (0xfff1) and such a section will not be found.
Logically, the address zero cannot be a valid file offset, because that's where the ELF header resides, so we need to build in optionality into the file offset retrieval. With this change we do just that, and bulk ignore symbols with any reserved section indices, including SHN_ABS.