### PR TITLE
Bump version to 0.2.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Unreleased
+0.2.0-rc.0
 ----------
 - Added support for transparently following debug links in ELF binaries
   - Added `symbolize::Builder::set_debug_dirs` for configuring directories

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
-version = "0.2.0-alpha.12"
+version = "0.2.0-rc.0"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "=0.2.0-alpha.12"
+blazesym = "=0.2.0-rc.0"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -21,7 +21,7 @@ Unreleased
 - Added support for transparently working with input data not in accordance with
   Rust's alignment requirements
 - Removed `BLAZE_INPUT` macro
-- Bumped `blazesym` dependency to `0.2.0-alpha.12`
+- Bumped `blazesym` dependency to `0.2.0-rc.0`
 
 
 0.1.0-alpha.1

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -52,7 +52,7 @@ which = {version = "6.0.0", optional = true}
 # Pinned, because we use #[doc(hidden)] APIs.
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-alpha.12", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "zlib"]}
+blazesym = {version = "=0.2.0-rc.0", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "zlib"]}
 # TODO: Remove dependency one MSRV is 1.77.
 memoffset = "0.9"
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added `--debug-dirs` option to `symbolize elf` sub-command
+- Bumped `blazesym` dependency to `0.2.0-rc.0`
 
 
 0.1.4

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,7 +38,7 @@ grev = "0.1.3"
 anyhow = "1.0.68"
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-alpha.12", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
+blazesym = {version = "=0.2.0-rc.0", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
 clap = {version = "4.1.7", features = ["derive"]}
 clap_complete = {version = "4.1.1", optional = true}
 tracing = "0.1"

--- a/cli/README.md
+++ b/cli/README.md
@@ -63,5 +63,5 @@ the list of supported shells.
 
 [blazecli-bins]: https://github.com/libbpf/blazesym/actions/workflows/build.yml
 [blazesym]: https://crates.io/crates/blazesym
-[blazesym-sym]: https://docs.rs/blazesym/0.2.0-alpha.12/blazesym/symbolize/struct.Symbolizer.html
-[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-alpha.12/blazesym/symbolize/enum.Source.html#variant.Elf
+[blazesym-sym]: https://docs.rs/blazesym/0.2.0-rc.0/blazesym/symbolize/struct.Symbolizer.html
+[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-rc.0/blazesym/symbolize/enum.Source.html#variant.Elf

--- a/examples/gsym-in-apk/Cargo.toml
+++ b/examples/gsym-in-apk/Cargo.toml
@@ -11,7 +11,7 @@ name = "gsym-in-apk"
 path = "main.rs"
 
 [dependencies]
-blazesym = {version = "=0.2.0-alpha.12", path = "../..", default-features = false, features = [
+blazesym = {version = "=0.2.0-rc.0", path = "../..", default-features = false, features = [
   "apk",
   "gsym",
   "generate-unit-test-files",

--- a/examples/sym-debuginfod/Cargo.toml
+++ b/examples/sym-debuginfod/Cargo.toml
@@ -12,7 +12,7 @@ path = "main.rs"
 
 [dependencies]
 anyhow = "1.0"
-blazesym = {version = "=0.2.0-alpha.12", path = "../..", features = ["tracing"]}
+blazesym = {version = "=0.2.0-rc.0", path = "../..", features = ["tracing"]}
 clap = {version = "4.4", features = ["derive", "string"]}
 debuginfod = {version = "0.1", features = ["fs-cache", "tracing"]}
 dirs = "5.0.1"


### PR DESCRIPTION
This change bumps the version of the crate to 0.2.0-rc.0. We should already have stopped using the "alpha" version suffix a while back, as the library has been running in production in several services for some time now. But be that as it may, at this point we are getting ready for the 0.2 release and right now we do not foresee any more breaking changes to the API surface before that. So it seems reasonable to start tagging release candidates.