### PR TITLE
capi: Bump version to 0.1.0-rc.0

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,4 +1,4 @@
-Unreleased
+0.1.0-rc.0
 ----------
 - Added `debug_dirs` attribute to `blaze_symbolizer_opts`
 - Added `cache_maps` attribute to `blaze_normalizer_opts`

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym-c"
 description = "C bindings for blazesym"
-version = "0.1.0-alpha.1"
+version = "0.1.0-rc.0"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Daniel Müller <deso@posteo.net>"]

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1,7 +1,7 @@
 /*
  * Please refer to the documentation hosted at
  *
- *   https://docs.rs/blazesym-c/0.1.0-alpha.1
+ *   https://docs.rs/blazesym-c/0.1.0-rc.0
  */
 
 


### PR DESCRIPTION
This change bumps the blazesym-c's version to 0.1.0-rc.0. The following notable changes have been made since 0.1.0-alpha.1:
- Added debug_dirs attribute to blaze_symbolizer_opts
- Added cache_maps attribute to blaze_normalizer_opts
- Introduced blaze_err enum and adjusted all fallible functions to set a thread local error
  - Introduced blaze_err_last to retrieve the last error
  - Introduced blaze_err_str function to convert errors to textual representation
- Introduced blaze_normalize_opts and added blaze_normalize_user_addrs_opts to use it
  - Removed blaze_normalize_user_addrs_sorted function
- Introduced blaze_normalize_reason type
  - Added reason attribute to blaze_user_meta_unknown
  - Added blaze_normalize_reason_str to retrieve textual representation
- Introduced blaze_symbolize_reason type
  - Added reason attribute to blaze_sym
  - Added blaze_symbolize_reason_str to retrieve textual representation
- Added blaze_symbolize_elf_file_offsets function for symbolization of file offsets
- Added support for transparently working with input data not in accordance with Rust's alignment requirements
- Removed BLAZE_INPUT macro
- Bumped blazesym dependency to 0.2.0-rc.0