### PR TITLE
Introduce explicit 'tracing' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ demangle = ["dep:cpp_demangle", "dep:rustc-demangle"]
 dwarf = ["dep:gimli"]
 # Enable this feature to enable Gsym support.
 gsym = []
+# Emit `tracing` traces and configure spans. User code is responsible for
+# subscribing.
+tracing = ["dep:tracing"]
 # Enable this feature to enable support for zlib decompression. This is
 # currently only used for handling compressed debug information.
 zlib = ["dep:miniz_oxide"]


### PR DESCRIPTION
So far the tracing dependency created an implicit feature. Switch over to declaring it explicitly instead, to make it more obvious what is going on and to document it better.