### PR TITLE
capi: only set_debug_dirs when dwarf feature enabled

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -31,8 +31,13 @@ autobenches = false
 crate-type = ["cdylib", "staticlib", "lib"]
 
 [features]
+default = [
+  "dwarf",
+]
 # Check C code documentation snippets.
 check-doc-snippets = []
+# Enable this feature to enable blazesym's DWARF support.
+dwarf = ["blazesym/dwarf"]
 # Enable this feature to re-generate the library's C header file. An
 # up-to-date version of this header should already be available in the
 # include/ directory, so this feature is only necessary when APIs are
@@ -52,7 +57,7 @@ which = {version = "6.0.0", optional = true}
 # Pinned, because we use #[doc(hidden)] APIs.
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-rc.0", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "zlib"]}
+blazesym = {version = "=0.2.0-rc.0", path = "../", features = ["apk", "demangle", "gsym", "zlib"]}
 # TODO: Remove dependency one MSRV is 1.77.
 memoffset = "0.9"
 


### PR DESCRIPTION
set_debug_dirs is gated by feature "dwarf" in symbolize::Builder. I got below error if the "dwarf" feature is not enabled.

```
error[E0599]: no method named `set_debug_dirs` found for struct
`blazesym::symbolize::Builder` in the current scope
   --> capi/src/symbolize.rs:632:21
    |
632 |             builder.set_debug_dirs(Some(iter))
    |                     ^^^^^^^^^^^^^^ method not found in `Builder`
```