### PR TITLE
Fix clippy reported warning

### DIFF
--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -142,7 +142,7 @@ impl PerfMap {
         // We transmute the mmap's lifetime to static here as that is a
         // necessity for self-referentiality.
         // SAFETY: We never hand out any 'static references later on.
-        let data = unsafe { transmute(mmap.deref()) };
+        let data = unsafe { transmute::<&[u8], &'static [u8]>(mmap.deref()) };
         let functions = parse_perf_map(data)
             .with_context(|| format!("failed to parse perf map `{}`", path.display()))?;
 

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -15,6 +15,7 @@ use crate::SymType;
 ///
 /// This function returns the symbol information of the function along
 /// with it's absolute address in the memory mapped region.
+#[allow(clippy::missing_transmute_annotations)]
 pub(crate) fn find_the_answer_fn(mmap: &Mmap) -> (inspect::SymInfo<'static>, Addr) {
     // Look up the address of the `the_answer` function inside of the shared
     // object.


### PR DESCRIPTION
With Rust 1.79, clippy warns about a missing transmute annotation. Add it to silence the warning.