### PR TITLE
Use gimli::UnitRef

### DIFF
--- a/src/dwarf/location.rs
+++ b/src/dwarf/location.rs
@@ -64,7 +64,8 @@ impl<'unit, 'dwarf> LocationRangeUnitIter<'unit, 'dwarf> {
         probe_low: u64,
         probe_high: u64,
     ) -> Result<Option<Self>, gimli::Error> {
-        let lines = unit.parse_lines(units)?;
+        let unit_ref = units.unit_ref(unit.dw_unit());
+        let lines = unit.parse_lines(unit_ref)?;
 
         if let Some(lines) = lines {
             // Find index for probe_low.

--- a/src/dwarf/range.rs
+++ b/src/dwarf/range.rs
@@ -47,8 +47,7 @@ impl<R: gimli::Reader> Default for RangeAttributes<R> {
 impl<R: gimli::Reader> RangeAttributes<R> {
     pub(crate) fn for_each_range<F: FnMut(gimli::Range)>(
         &self,
-        sections: &gimli::Dwarf<R>,
-        unit: &gimli::Unit<R>,
+        unit: gimli::UnitRef<'_, R>,
         mut f: F,
     ) -> Result<bool, gimli::Error> {
         let mut added_any = false;
@@ -59,7 +58,7 @@ impl<R: gimli::Reader> RangeAttributes<R> {
             }
         };
         if let Some(ranges_offset) = self.ranges_offset {
-            let mut range_list = sections.ranges(unit, ranges_offset)?;
+            let mut range_list = unit.ranges(ranges_offset)?;
             while let Some(range) = range_list.next()? {
                 add_range(range);
             }


### PR DESCRIPTION
Switch over to using gimli::UnitRef as a replacement for the various gimli::Unit & Units tuples that we pass around. We still need Units in some places, but we can now remove its dwarf() method, which exposed a gimli::Dwarf object, which may be problematic in the context of split DWARF support.