### PR TITLE
Swallow build ID read failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Adjusted normalization logic to not fail overall operation on build ID
+  read failure
+
+
 0.2.0-rc.0
 ----------
 - Added support for transparently following debug links in ELF binaries

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -305,6 +305,9 @@ typedef struct blaze_normalizer_opts {
   /**
    * Whether to read and report build IDs as part of the normalization
    * process.
+   *
+   * Note that build ID read failures will be swallowed without
+   * failing the normalization operation.
    */
   bool build_ids;
   /**
@@ -347,7 +350,7 @@ typedef struct blaze_user_meta_elf {
    */
   size_t build_id_len;
   /**
-   * The optional build ID of the ELF file, if found.
+   * The optional build ID of the ELF file, if found and readable.
    */
   uint8_t *build_id;
   /**

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -51,6 +51,9 @@ pub struct blaze_normalizer_opts {
     pub cache_maps: bool,
     /// Whether to read and report build IDs as part of the normalization
     /// process.
+    ///
+    /// Note that build ID read failures will be swallowed without
+    /// failing the normalization operation.
     pub build_ids: bool,
     /// Whether or not to cache build IDs. This flag only has an effect
     /// if build ID reading is enabled in the first place.
@@ -292,7 +295,7 @@ pub struct blaze_user_meta_elf {
     pub path: *mut c_char,
     /// The length of the build ID, in bytes.
     pub build_id_len: usize,
-    /// The optional build ID of the ELF file, if found.
+    /// The optional build ID of the ELF file, if found and readable.
     pub build_id: *mut u8,
     /// Unused member available for future expansion.
     pub reserved: [u8; 8],

--- a/src/normalize/meta.rs
+++ b/src/normalize/meta.rs
@@ -54,7 +54,7 @@ pub struct Apk {
 pub struct Elf<'src> {
     /// The canonical absolute path to the ELF file, including its name.
     pub path: PathBuf,
-    /// The ELF file's build ID, if available.
+    /// The ELF file's build ID, if available and readable.
     pub build_id: Option<BuildId<'src>>,
     /// The struct is non-exhaustive and open to extension.
     #[doc(hidden)]

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -59,6 +59,9 @@ pub struct Builder {
     cache_maps: bool,
     /// Whether to read and report build IDs as part of the normalization
     /// process.
+    ///
+    /// Note that build ID read failures will be swallowed without
+    /// failing the normalization operation.
     build_ids: bool,
     /// Whether or not to cache build IDs. This flag only has an effect
     /// if build ID reading is enabled in the first place.
@@ -142,6 +145,9 @@ pub struct Normalizer {
     cache_maps: bool,
     /// Flag indicating whether or not to read build IDs as part of the
     /// normalization process.
+    ///
+    /// Note that build ID read failures will be swallowed without
+    /// failing the normalization operation.
     build_ids: bool,
     /// Whether or not to cache build IDs. This flag only has an effect
     /// if build ID reading is enabled in the first place.


### PR DESCRIPTION
So far any failures to read the build ID as part of an address normalization request have short-circuit the entire operation. While somewhat reasonable behavior in principle, the result will be that such a read failure for one of the files can fail normalization for others, which isn't really behavior that we are striving for. Rather, because we support batched symbolization, we should report the failure at the level of an individual address.
For build IDs specifically, we already have to work with files not containing a build ID and so the most sensible behavior is to just map read failures to a non-existent build ID.