### PR TITLE
Add test for symbolization of additional "entry" types

### DIFF
--- a/src/normalize/meta.rs
+++ b/src/normalize/meta.rs
@@ -112,6 +112,7 @@ pub enum UserMeta<'src> {
 
 impl<'src> UserMeta<'src> {
     /// Retrieve the [`Apk`] of this enum, if this variant is active.
+    #[inline]
     pub fn apk(&self) -> Option<&Apk> {
         match self {
             Self::Apk(entry) => Some(entry),
@@ -120,6 +121,7 @@ impl<'src> UserMeta<'src> {
     }
 
     /// Retrieve the [`Elf`] of this enum, if this variant is active.
+    #[inline]
     pub fn elf(&self) -> Option<&Elf<'src>> {
         match self {
             Self::Elf(elf) => Some(elf),
@@ -128,6 +130,7 @@ impl<'src> UserMeta<'src> {
     }
 
     /// Retrieve the [`Unknown`] of this enum, if this variant is active.
+    #[inline]
     pub fn unknown(&self) -> Option<&Unknown> {
         match self {
             Self::Unknown(unknown) => Some(unknown),


### PR DESCRIPTION
Add a test covering the symbolization of maps "entries" without a path as well as with a "component" (as opposed to a file).