### PR TITLE
Update gimli dependency to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ zip = {version = "2.0.0, <2.1.4", optional = true, default-features = false}
 
 [dependencies]
 cpp_demangle = {version = "0.4", optional = true}
-gimli = {version = "0.30", optional = true}
+gimli = {version = "0.31", optional = true}
 libc = "0.2.137"
 memmap2 = {version = "0.9", default-features = false}
 miniz_oxide = {version = "0.7", default-features = false, features = ["simd", "with-alloc"], optional = true}
@@ -132,7 +132,7 @@ zstd = {version = "0.13.1", default-features = false, optional = true}
 [dev-dependencies]
 # For performance comparison; pinned, because we use #[doc(hidden)]
 # APIs.
-addr2line = "=0.23.0"
+addr2line = "=0.24.0"
 anyhow = "1.0.71"
 # TODO: Enable `zstd` feature once toolchain support for it is more
 #       widespread (enabled by default in `ld`). Remove conditionals in


### PR DESCRIPTION
Update the gimli dependency to version 0.31 to get the latest and greatest. Bump addr2line alongside, as the two have to be updated in tandem.