### PR TITLE
Start running subset of tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,36 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: lcov.info
+  build-test-artifacts:
+    name: Build test artifacts for Windows
+    runs-on: ubuntu-22.04
+    env:
+      LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install required tools
+      run: sudo apt-get install -y llvm-14
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo build --features=generate-unit-test-files
+    - uses: actions/upload-artifact@v4
+      with:
+        name: test-stable-addrs
+        if-no-files-found: error
+        path: data/test-stable-addrs.bin
+  test-windows:
+    name: Test on Windows
+    runs-on: windows-latest
+    needs: [build-test-artifacts]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        name: test-stable-addrs
+        path: data/
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo test --tests --release --features=dont-generate-unit-test-files -- ':windows:'
   test-sanitizers:
     name: Test with ${{ matrix.sanitizer }} sanitizer
     strategy:

--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -16,8 +16,8 @@ where
     M: Measurement,
 {
     let mut addrs = [
-        libc::__errno_location as Addr,
-        libc::dlopen as Addr,
+        libc::atexit as Addr,
+        libc::chdir as Addr,
         libc::fopen as Addr,
         normalize_process_impl::<M> as Addr,
         Normalizer::normalize_user_addrs as Addr,

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -22,8 +22,8 @@ use criterion::BenchmarkGroup;
 fn symbolize_process() {
     let src = Source::Process(Process::new(Pid::Slf));
     let addrs = [
-        libc::__errno_location as Addr,
-        libc::dlopen as Addr,
+        libc::atexit as Addr,
+        libc::chdir as Addr,
         libc::fopen as Addr,
         symbolize_process as Addr,
         Symbolizer::symbolize_single as Addr,

--- a/capi/benches/normalize.rs
+++ b/capi/benches/normalize.rs
@@ -18,8 +18,8 @@ use criterion::BenchmarkGroup;
 
 fn normalize_process_impl(read_build_ids: bool) {
     let mut addrs = [
-        libc::__errno_location as Addr,
-        libc::dlopen as Addr,
+        libc::atexit as Addr,
+        libc::chdir as Addr,
         libc::fopen as Addr,
         blaze_normalizer_new_opts as Addr,
         blaze_normalize_user_addrs_opts as Addr,

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -898,8 +898,8 @@ mod tests {
         fn test(normalizer: *const blaze_normalizer) {
             let addrs = [
                 0x0 as Addr,
-                libc::__errno_location as Addr,
-                libc::dlopen as Addr,
+                libc::atexit as Addr,
+                libc::chdir as Addr,
                 libc::fopen as Addr,
                 elf_conversion as Addr,
                 normalize_user_addrs as Addr,
@@ -944,8 +944,8 @@ mod tests {
     #[test]
     fn normalize_user_addrs_sorted() {
         let mut addrs = [
-            libc::__errno_location as Addr,
-            libc::dlopen as Addr,
+            libc::atexit as Addr,
+            libc::chdir as Addr,
             libc::fopen as Addr,
             elf_conversion as Addr,
             normalize_user_addrs as Addr,
@@ -983,8 +983,8 @@ mod tests {
     #[test]
     fn normalize_user_addrs_unsorted_failure() {
         let mut addrs = [
-            libc::__errno_location as Addr,
-            libc::dlopen as Addr,
+            libc::atexit as Addr,
+            libc::chdir as Addr,
             libc::fopen as Addr,
             elf_conversion as Addr,
             normalize_user_addrs as Addr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
     )),
     allow(dead_code, unused_imports)
 )]
+#![cfg_attr(windows, allow(dead_code, unused_imports))]
 
 
 #[cfg(feature = "nightly")]

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -314,8 +314,8 @@ mod tests {
     #[test]
     fn user_address_normalization_unsorted() {
         let mut addrs = [
-            libc::__errno_location as Addr,
-            libc::dlopen as Addr,
+            libc::atexit as Addr,
+            libc::chdir as Addr,
             libc::fopen as Addr,
         ];
         let () = addrs.sort();
@@ -351,6 +351,7 @@ mod tests {
     }
 
     /// Check that we can normalize user addresses.
+    #[cfg(not(windows))]
     #[test]
     fn user_address_normalization() {
         fn test(normalizer: &Normalizer) {

--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -204,9 +204,6 @@ mod tests {
     use std::process::Command;
     use std::process::Stdio;
 
-    use libc::kill;
-    use libc::SIGKILL;
-
     use scopeguard::defer;
 
     use tempfile::tempfile;
@@ -314,9 +311,13 @@ mod tests {
     }
 
     /// Check that we can symbolize an address using a perf map.
+    #[cfg(not(windows))]
     #[test]
     #[ignore = "test requires python 3.12 or higher"]
     fn symbolize_perf_map() {
+        use libc::kill;
+        use libc::SIGKILL;
+
         let script = r#"
 import sys
 

--- a/tests/allocs.rs
+++ b/tests/allocs.rs
@@ -4,6 +4,7 @@
     clippy::let_and_return,
     clippy::let_unit_value
 )]
+#![cfg_attr(windows, allow(dead_code, unused_imports))]
 
 use std::alloc::GlobalAlloc;
 use std::alloc::Layout;
@@ -55,6 +56,7 @@ unsafe impl GlobalAlloc for TracingAlloc {
 
 /// Normalize addresses in the current process and print allocation
 /// statistics.
+#[cfg(not(windows))]
 #[test]
 fn normalize_process() {
     let region = Region::new(&GLOBAL);
@@ -63,8 +65,8 @@ fn normalize_process() {
     {
         let normalizer = Normalizer::builder().build();
         let mut addrs = [
-            libc::__errno_location as Addr,
-            libc::dlopen as Addr,
+            libc::atexit as Addr,
+            libc::chdir as Addr,
             libc::fopen as Addr,
             normalize_process as Addr,
             Normalizer::normalize_user_addrs as Addr,

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -3,6 +3,7 @@
     clippy::let_and_return,
     clippy::let_unit_value
 )]
+#![cfg_attr(windows, allow(dead_code, unused_imports))]
 
 use std::collections::HashMap;
 use std::env;
@@ -14,6 +15,7 @@ use std::io::Error;
 use std::io::Read as _;
 use std::io::Write as _;
 use std::ops::Deref as _;
+#[cfg(not(windows))]
 use std::os::unix::ffi::OsStringExt as _;
 use std::path::Path;
 use std::process::Command;
@@ -40,15 +42,13 @@ use blazesym::Pid;
 use blazesym::Result;
 use blazesym::SymType;
 
-use libc::kill;
-use libc::SIGKILL;
-
 use scopeguard::defer;
 
 use tempfile::tempdir;
 use tempfile::NamedTempFile;
 
 use test_log::test;
+use test_tag::tag;
 
 
 /// Make sure that we fail symbolization when providing a non-existent source.
@@ -274,6 +274,7 @@ FUNC 34 11 0 factorial_wrapper
 
 /// Check that we can symbolize an address mapping to a variable in an
 /// ELF file.
+#[tag(windows)]
 #[test]
 fn symbolize_elf_variable() {
     fn test(debug_syms: bool) {
@@ -685,8 +686,12 @@ fn symbolize_process() {
 
 /// Check that we can symbolize an address in a process using a binary
 /// located in a local mount namespace.
+#[cfg(not(windows))]
 #[test]
 fn symbolize_process_in_mount_namespace() {
+    use libc::kill;
+    use libc::SIGKILL;
+
     let test_so = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("libtest-so.so");
@@ -788,6 +793,7 @@ fn symbolize_process_with_custom_dispatch() {
 }
 
 /// Check that we can normalize addresses in an ELF shared object.
+#[cfg(not(windows))]
 #[test]
 fn normalize_elf_addr() {
     fn test(so: &str, map_files: bool) {
@@ -853,6 +859,7 @@ fn normalize_elf_addr() {
 
 
 /// Check that we can enable/disable the reading of build IDs.
+#[cfg(not(windows))]
 #[test]
 fn normalize_build_id_reading() {
     fn test(read_build_ids: bool) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,15 +13,17 @@ use std::panic::catch_unwind;
 use std::panic::UnwindSafe;
 use std::path::Path;
 
-use libc::seteuid;
 use libc::uid_t;
 
 
 /// Run a function with a different effective user ID.
+#[cfg(not(windows))]
 pub fn as_user<F, R>(ruid: uid_t, euid: uid_t, f: F) -> R
 where
     F: FnOnce() -> R + UnwindSafe,
 {
+    use libc::seteuid;
+
     if unsafe { seteuid(euid) } == -1 {
         panic!(
             "failed to set effective user ID to {euid}: {}",
@@ -42,6 +44,14 @@ where
     }
 
     result.unwrap()
+}
+
+#[cfg(windows)]
+pub fn as_user<F, R>(ruid: uid_t, euid: uid_t, f: F) -> R
+where
+    F: FnOnce() -> R + UnwindSafe,
+{
+    unimplemented!()
 }
 
 

--- a/tests/permission.rs
+++ b/tests/permission.rs
@@ -3,28 +3,24 @@
     clippy::let_and_return,
     clippy::let_unit_value
 )]
+#![cfg_attr(windows, allow(dead_code, unused_imports))]
 
+#[cfg(not(windows))]
 mod common;
 
 use std::fs::copy;
 use std::fs::metadata;
 use std::fs::set_permissions;
 use std::io::Error;
-use std::os::unix::fs::PermissionsExt as _;
 use std::path::Path;
 
 use blazesym::symbolize;
 use blazesym::symbolize::Symbolizer;
 use blazesym::ErrorKind;
 
-use libc::getresuid;
-
 use tempfile::NamedTempFile;
 
 use test_log::test;
-
-use common::as_user;
-use common::non_root_uid;
 
 
 fn symbolize_no_permission_impl(path: &Path) {
@@ -39,8 +35,14 @@ fn symbolize_no_permission_impl(path: &Path) {
 
 /// Check that we fail symbolization as expected when we don't have the
 /// permission to open the symbolization source.
+#[cfg(not(windows))]
 #[test]
 fn symbolize_no_permission() {
+    use common::as_user;
+    use common::non_root_uid;
+    use libc::getresuid;
+    use std::os::unix::fs::PermissionsExt as _;
+
     // We run as root. Even if we limit permissions for a root-owned file we can
     // still access it (unlike the behavior for regular users). As such, we have
     // to work as a different user to check handling of permission denied


### PR DESCRIPTION
Now that we started supporting Windows in a very limited capacity, add the necessary infrastructure for starting to run tests on it. As a first step, we test symbolization of addresses in ELF files.