### PR TITLE
Run more tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,8 +179,8 @@ jobs:
         name: test-stable-addrs
         if-no-files-found: error
         path: |
-          data/test-stable-addrs.bin
-          data/test-stable-addrs-stripped.bin
+          data/test-stable-addrs*
+          data/test-rs.bin
   test-windows:
     name: Test on Windows
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 - Adjusted normalization logic to not fail overall operation on build ID
   read failure
+- Added support for file based symbolization support on the Windows operating
+  system
 
 
 0.2.0-rc.0

--- a/README.md
+++ b/README.md
@@ -83,9 +83,14 @@ Here is rough roadmap of currently planned features (in no particular order):
 
 ### OS Support
 The library's primary target operating system is Linux (it should work on all
-semi-recent kernel versions and distributions). MacOS is not actively supported
-at this point (though it may work), but we would be happy to incorporate pull
-requests to fix any potential short comings.
+semi-recent kernel versions and distributions).
+
+MacOS is not actively supported at this point (though it may work), but we would
+be happy to incorporate pull requests to fix any potential short comings.
+
+Windows is supported for file based symbolization (i.e., using one of the
+`Breakpad`, `Elf`, or `Gsym` symbolization sources). Standalone address
+normalization as well as process or kernel symbolization are not supported.
 
 
 ## Build & Use

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -52,6 +52,7 @@ use test_tag::tag;
 
 
 /// Make sure that we fail symbolization when providing a non-existent source.
+#[tag(windows)]
 #[test]
 fn error_on_non_existent_source() {
     let non_existent = Path::new("/does-not-exists");
@@ -70,6 +71,7 @@ fn error_on_non_existent_source() {
 }
 
 /// Check that we can symbolize an address using ELF, DWARF, and GSYM.
+#[tag(windows)]
 #[test]
 fn symbolize_elf_dwarf_gsym() {
     fn test(src: symbolize::Source, has_code_info: bool) {
@@ -165,6 +167,7 @@ fn symbolize_elf_dwarf_gsym() {
 
 /// Check that we correctly symbolize zero sized symbols.
 // TODO: Extend this test to more formats.
+#[tag(windows)]
 #[test]
 fn symbolize_zero_size_gsym() {
     let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
@@ -198,6 +201,7 @@ fn symbolize_zero_size_gsym() {
 }
 
 /// Check that we can symbolize an address using Breakpad.
+#[tag(windows)]
 #[test]
 fn symbolize_breakpad() {
     let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
@@ -250,6 +254,7 @@ fn symbolize_breakpad() {
 
 /// Make sure that Breakpad symbol file errors are reported in a
 /// somewhat decent fashion.
+#[tag(windows)]
 #[test]
 fn symbolize_breakpad_error() {
     let content = br#"MODULE Linux x86_64 C00D0279606DFBCD53805DDAD2CA66A30 test-stable-addrs.bin
@@ -346,6 +351,7 @@ fn symbolize_elf_stripped() {
 
 /// Make sure that we report (enabled) or don't report (disabled) inlined
 /// functions with DWARF and Gsym sources.
+#[tag(windows)]
 #[test]
 fn symbolize_dwarf_gsym_inlined() {
     fn test(src: symbolize::Source, inlined_fns: bool) {
@@ -413,6 +419,7 @@ fn symbolize_dwarf_gsym_inlined() {
 
 /// Make sure that we fail loading linked debug information on CRC
 /// mismatch.
+#[tag(windows)]
 #[test]
 fn symbolize_dwarf_wrong_debug_link_crc() {
     let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
@@ -431,6 +438,7 @@ fn symbolize_dwarf_wrong_debug_link_crc() {
 }
 
 /// Check that we do not error out when a debug link does not exist.
+#[tag(windows)]
 #[test]
 fn symbolize_dwarf_non_existent_debug_link() {
     let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
@@ -448,6 +456,7 @@ fn symbolize_dwarf_non_existent_debug_link() {
 }
 
 /// Check that we honor configured debug directories as one would expect.
+#[tag(windows)]
 #[test]
 fn symbolize_configurable_debug_dirs() {
     let dir = tempdir().unwrap();
@@ -492,6 +501,7 @@ fn symbolize_configurable_debug_dirs() {
 
 /// Make sure that we report (enabled) or don't report (disabled) inlined
 /// functions with Breakpad sources.
+#[tag(windows)]
 #[test]
 fn symbolize_breakpad_inlined() {
     fn test(src: symbolize::Source, inlined_fns: bool) {
@@ -583,6 +593,7 @@ fn symbolize_dwarf_complex() {
 
 /// Symbolize an address inside a DWARF file, with and without auto-demangling
 /// enabled.
+#[tag(windows)]
 #[test]
 fn symbolize_dwarf_demangle() {
     fn test(test_dwarf: &Path, addr: Addr) -> Result<(), ()> {


### PR DESCRIPTION
Enable more tests to run on the Windows target. This should provide us with some confidence that basic workings of ELF, DWARF, Gsym, and Breakpad symbolization are working on Windows.