### PR TITLE
Only run Windows tests on push to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,10 @@ jobs:
       with:
         files: lcov.info
   build-test-artifacts:
+    # Only run Windows tests on the final push. They are very unlikely to break
+    # at runtime (we build them anyway), but take quite a bit longer than Linux
+    # based ones.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Build test artifacts for Windows
     runs-on: ubuntu-22.04
     env:


### PR DESCRIPTION
It should be pretty unlikely that tests break on Windows but not on other targets. As such, the regular and merge delaying testing on every pull request for this target seems unnecessary -- especially given that it takes quite a bit longer than running tests on Linux. As such, only run Windows based tests on push to the main branch.