### PR TITLE
Silence clippy reported "issue"

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1097,7 +1097,7 @@ void blaze_symbolizer_free(blaze_symbolizer *symbolizer);
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_process`] object
- * -`abs_addrs` point to an array of `abs_addr_cnt` addresses
+ * - `abs_addrs` point to an array of `abs_addr_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_process_abs_addrs(blaze_symbolizer *symbolizer,
                                                            const struct blaze_symbolize_src_process *src,
@@ -1119,7 +1119,7 @@ const struct blaze_syms *blaze_symbolize_process_abs_addrs(blaze_symbolizer *sym
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_kernel`] object
- * -`abs_addrs` point to an array of `abs_addr_cnt` addresses
+ * - `abs_addrs` point to an array of `abs_addr_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_kernel_abs_addrs(blaze_symbolizer *symbolizer,
                                                           const struct blaze_symbolize_src_kernel *src,
@@ -1141,7 +1141,7 @@ const struct blaze_syms *blaze_symbolize_kernel_abs_addrs(blaze_symbolizer *symb
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
- * -`virt_offsets` point to an array of `virt_offset_cnt` addresses
+ * - `virt_offsets` point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_elf_virt_offsets(blaze_symbolizer *symbolizer,
                                                           const struct blaze_symbolize_src_elf *src,
@@ -1163,7 +1163,7 @@ const struct blaze_syms *blaze_symbolize_elf_virt_offsets(blaze_symbolizer *symb
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
- * -`file_offsets` point to an array of `file_offset_cnt` addresses
+ * - `file_offsets` point to an array of `file_offset_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_elf_file_offsets(blaze_symbolizer *symbolizer,
                                                           const struct blaze_symbolize_src_elf *src,
@@ -1185,7 +1185,7 @@ const struct blaze_syms *blaze_symbolize_elf_file_offsets(blaze_symbolizer *symb
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_gsym_data`] object
- * -`virt_offsets` point to an array of `virt_offset_cnt` addresses
+ * - `virt_offsets` point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_gsym_data_virt_offsets(blaze_symbolizer *symbolizer,
                                                                 const struct blaze_symbolize_src_gsym_data *src,
@@ -1207,7 +1207,7 @@ const struct blaze_syms *blaze_symbolize_gsym_data_virt_offsets(blaze_symbolizer
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_gsym_file`] object
- * -`virt_offsets` point to an array of `virt_offset_cnt` addresses
+ * - `virt_offsets` point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_gsym_file_virt_offsets(blaze_symbolizer *symbolizer,
                                                                 const struct blaze_symbolize_src_gsym_file *src,

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -858,7 +858,7 @@ unsafe fn blaze_symbolize_impl(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_process`] object
-/// -`abs_addrs` point to an array of `abs_addr_cnt` addresses
+/// - `abs_addrs` point to an array of `abs_addr_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_process_abs_addrs(
     symbolizer: *mut blaze_symbolizer,
@@ -891,7 +891,7 @@ pub unsafe extern "C" fn blaze_symbolize_process_abs_addrs(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_kernel`] object
-/// -`abs_addrs` point to an array of `abs_addr_cnt` addresses
+/// - `abs_addrs` point to an array of `abs_addr_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_kernel_abs_addrs(
     symbolizer: *mut blaze_symbolizer,
@@ -924,7 +924,7 @@ pub unsafe extern "C" fn blaze_symbolize_kernel_abs_addrs(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
-/// -`virt_offsets` point to an array of `virt_offset_cnt` addresses
+/// - `virt_offsets` point to an array of `virt_offset_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_elf_virt_offsets(
     symbolizer: *mut blaze_symbolizer,
@@ -963,7 +963,7 @@ pub unsafe extern "C" fn blaze_symbolize_elf_virt_offsets(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
-/// -`file_offsets` point to an array of `file_offset_cnt` addresses
+/// - `file_offsets` point to an array of `file_offset_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_elf_file_offsets(
     symbolizer: *mut blaze_symbolizer,
@@ -1003,7 +1003,7 @@ pub unsafe extern "C" fn blaze_symbolize_elf_file_offsets(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_gsym_data`] object
-/// -`virt_offsets` point to an array of `virt_offset_cnt` addresses
+/// - `virt_offsets` point to an array of `virt_offset_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_gsym_data_virt_offsets(
     symbolizer: *mut blaze_symbolizer,
@@ -1042,7 +1042,7 @@ pub unsafe extern "C" fn blaze_symbolize_gsym_data_virt_offsets(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_gsym_file`] object
-/// -`virt_offsets` point to an array of `virt_offset_cnt` addresses
+/// - `virt_offsets` point to an array of `virt_offset_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_gsym_file_virt_offsets(
     symbolizer: *mut blaze_symbolizer,

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -825,6 +825,7 @@ impl ElfParser {
     }
 
     /// Perform an operation on each symbol.
+    #[allow(clippy::needless_borrows_for_generic_args)]
     pub(crate) fn for_each(
         &self,
         opts: &FindAddrOpts,


### PR DESCRIPTION
With Rust 1.80, clippy complains about some supposedly unnecessary borrow. Except it isn't unnecessary at all, as removing it causes a compilation failure. Silence the nonsense.