### PR TITLE
Improve Breakpad file parsing performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
   read failure
 - Added support for file based symbolization support on the Windows operating
   system
+- Improved performance for parsing Breakpad files
 
 
 0.2.0-rc.0


### PR DESCRIPTION
Our breakpad parser supports various CFI directives and other constructs, despite never actually using them. That is partly necessary: we need to recognize them in order to ignore them. However, we don't have to go all the way and parse them correctly. Rather, we can just skip over them more quickly. Adjust the code to do just that. As a result, we are a bit more lenient in what we accept (except for spurious empty lines that we now no longer accept...), but nobody should be using our parser to judge validity of a file, so being more accepting is fine. As a result, we speed up parsing of breakpad files that contain quite significantly:

```
  > main/symbolize_breakpad
  >   time:   [245.08 ms 245.62 ms 246.20 ms]
  >   change: [−12.182% −11.608% −11.143%] (p = 0.00 < 0.02)
  >   Performance has improved.
```