### PR TITLE
Remove copyright holder names from LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, Kuifeng Lee
+Copyright (c) 2024
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
It confusing and a maintenance nightmare to have copyright holder names embedded in the LICENSE file. GitHub does so for MIT and BSD-3-clause license templates, but not for, say, GPLv3. Hence, it can't really be a necessity to have them there. Just remove the names. They are listed inside the individual Cargo.toml files. While at it, update the copyright year.

Reported-by: Michel Lind <salimma@fedoraproject.org>