### PR TITLE
Make Clippy aware of MSRV

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,6 @@
 # For general information about this file, check
 # https://doc.rust-lang.org/stable/clippy/configuration.html
 
+msrv = "1.65"
+
 absolute-paths-allowed-crates = [ "gimli" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,8 +109,8 @@ jobs:
       - run: cargo +nightly -Z minimal-versions update
       - uses: dtolnay/rust-toolchain@master
         with:
-          # Please adjust README and rust-version field in Cargo.toml files when
-          # bumping version.
+          # Please adjust README, `rust-version` field in Cargo.toml,
+          # and `msrv` in .clippy.toml when bumping version.
           toolchain: 1.65.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --features="apk,backtrace,demangle,dwarf,gsym,tracing"


### PR DESCRIPTION
Tell Clippy our minimum supported Rust version, in the hopes that it won't recommend changes that would cause it to be bumped.