### PR TITLE
Interpret debug link CRC alignment as relative to section start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Unreleased
 - Added support for file based symbolization support on the Windows operating
   system
 - Improved performance for parsing Breakpad files
+- Fixed potentially invalid reading of debug link checksum when
+  `.gnu_debuglink` section is unaligned
 
 
 0.2.0-rc.0


### PR DESCRIPTION
We interpreted the CRC associated with the debug link as being aligned on a four byte boundary relative to the file's start address. However, we have seen a case where that led to an invalid read of the checksum, when both the containing .gnu_debuglink section had no alignment and the CRC was at an unaligned offset as well.
What the specification actually says is that the checksum is aligned relative to the section start. In most cases the outcome is the same, but it may not be if the section itself is unaligned. This change fixes up our logic to treat alignment as given in relation to the start address of the section, not the file.

Closes: #769