### PR TITLE
Revert "Restrict zip dependency to <2.1.4"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ dump_syms = {version = "2.3", optional = true, default-features = false}
 libc = "0.2.137"
 reqwest = {version = "0.12.0", optional = true, features = ["blocking"]}
 xz2 = {version = "0.1.7", optional = true}
-zip = {version = "2.0.0, <2.1.4", optional = true, default-features = false}
+zip = {version = "2.0.0", optional = true, default-features = false}
 
 [dependencies]
 cpp_demangle = {version = "0.4", optional = true}


### PR DESCRIPTION
Loosen the zip version requirements now that a fix has landed.

This reverts commit aab845abc0df3f01df96bd2b5de4907e5a76f43a.