### PR TITLE
Only cache build IDs when build ID reading is enabled

### DIFF
--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -100,7 +100,7 @@ impl Builder {
         Normalizer {
             cache_maps,
             build_ids,
-            cache_build_ids,
+            cache_build_ids: build_ids && cache_build_ids,
             cached_entries: InsertMap::new(),
             cached_build_ids: FileCache::default(),
         }
@@ -185,6 +185,9 @@ impl Normalizer {
                 &DefaultBuildIdReader as &dyn BuildIdReader
             }
         } else {
+            // Build ID caching always implies reading of build IDs to
+            // begin with.
+            debug_assert!(!self.cache_build_ids);
             &NoBuildIdReader as &dyn BuildIdReader
         };
 


### PR DESCRIPTION
Currently we only cache build IDs when reading of them is enabled, which is logical. However, we don't enforce this invariant in the flags. That's fine right now and not causing trouble, but to be safe in the presence of future changes, make sure to only enable caching of build IDs if reading is also enabled.