### PR TITLE
Exclude user_address_normalization() test on Arm

### DIFF
--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -343,6 +343,8 @@ mod tests {
 
     /// Check that we can normalize user addresses.
     #[cfg(not(windows))]
+    // `libc` on Arm doesn't have `__errno_location`.
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     #[test]
     fn user_address_normalization() {
         fn test(normalizer: &Normalizer) {


### PR DESCRIPTION
The libc crate doesn't have the `__errno_location` variable on Arm, requiring repeated massaging of code whenever we need to run tests there. Just exclude the test in question when building for this target.