### PR TITLE
Allow 'unreachable_patterns' lint in once.rs

### DIFF
--- a/src/once.rs
+++ b/src/once.rs
@@ -93,6 +93,7 @@ impl<T> OnceCell<T> {
     where
         F: FnOnce() -> T,
     {
+        #[allow(unreachable_patterns)]
         match self.get_or_try_init(|| Ok::<T, Infallible>(f())) {
             Ok(val) => val,
             Err(_) => unsafe { unreachable_unchecked() },


### PR DESCRIPTION
Recent version of Rust seem to be unhappy with our attempt of "handling" the Result::Err variant:

```
  > error: unreachable pattern
  >   --> src/once.rs:98:13
  >    |
  > 98 |             Err(_) => unsafe { unreachable_unchecked() },
  >    |             ^^^^^^
  >    |
  >    = note: this pattern matches no values because `Infallible` is uninhabited
  >    = note: `-D unreachable-patterns` implied by `-D warnings`
  >    = help: to override `-D warnings` add `#[allow(unreachable_patterns)]`
```

That is of course correct, and yet practically speaking utter nonsense. We can't just ignore the Err(_) pattern because that violates match semantics.
Allow the lint.