### PR TITLE
Introduce is_procmap_query_supported() helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Added support for using `PROCMAP_QUERY` ioctl during address normalization
   - Added `enable_procmap_query` to `normalize::Normalizer`
+  - Added `is_procmap_query_supported` function to `helper` module
 - Adjusted normalization logic to not fail overall operation on build ID
   read failure
 - Added support for file based symbolization support on the Windows operating

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
   - Renamed `blaze_result_free` to `blaze_syms_free`
 - Renamed `cache_maps` attribute of `blaze_normalizer_opts` to
   `cache_vmas`
+- Introduced `blaze_supports_procmap_query` helper
 
 
 0.1.0-rc.0

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -297,6 +297,11 @@ typedef struct blaze_normalizer_opts {
    * Whether or not to use the `PROCMAP_QUERY` ioctl instead of
    * parsing `/proc/<pid>/maps` for getting available VMA ranges.
    *
+   * Refer to
+   * [`blaze_supports_procmap_query`][crate::helper::blaze_supports_procmap_query]
+   * as a way to check whether your system supports this
+   * functionality.
+   *
    * # Notes
    *
    * Support for this ioctl is only present in very recent kernels
@@ -877,6 +882,11 @@ enum blaze_err blaze_err_last(void);
  * Retrieve a textual representation of the error code.
  */
 const char *blaze_err_str(enum blaze_err err);
+
+/**
+ * Check whether the `PROCMAP_QUERY` ioctl is supported by the system.
+ */
+bool blaze_supports_procmap_query(void);
 
 /**
  * Lookup symbol information in an ELF file.

--- a/capi/src/helper.rs
+++ b/capi/src/helper.rs
@@ -1,0 +1,34 @@
+use blazesym::helper::is_procmap_query_supported;
+
+use crate::set_last_err;
+
+
+/// Check whether the `PROCMAP_QUERY` ioctl is supported by the system.
+#[no_mangle]
+pub extern "C" fn blaze_supports_procmap_query() -> bool {
+    match is_procmap_query_supported() {
+        Ok(supported) => supported,
+        Err(err) => {
+            let () = set_last_err(err.kind().into());
+            false
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::blaze_err;
+    use crate::blaze_err_last;
+
+
+    /// Test that we can check whether the `PROCMAP_QUERY` ioctl is
+    /// supported.
+    #[test]
+    fn procmap_query_supported() {
+        let _supported = blaze_supports_procmap_query();
+        assert_eq!(blaze_err_last(), blaze_err::BLAZE_ERR_OK);
+    }
+}

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -82,6 +82,7 @@ macro_rules! input_sanitize {
 }
 
 
+mod helper;
 #[allow(non_camel_case_types)]
 mod inspect;
 #[allow(non_camel_case_types)]
@@ -95,6 +96,7 @@ use std::ffi::c_char;
 
 use blazesym::ErrorKind;
 
+pub use helper::*;
 pub use inspect::*;
 pub use normalize::*;
 pub use symbolize::*;

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -45,6 +45,11 @@ pub struct blaze_normalizer_opts {
     /// Whether or not to use the `PROCMAP_QUERY` ioctl instead of
     /// parsing `/proc/<pid>/maps` for getting available VMA ranges.
     ///
+    /// Refer to
+    /// [`blaze_supports_procmap_query`][crate::helper::blaze_supports_procmap_query]
+    /// as a way to check whether your system supports this
+    /// functionality.
+    ///
     /// # Notes
     ///
     /// Support for this ioctl is only present in very recent kernels

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ pub mod helper {
 
     pub use crate::normalize::buildid::read_elf_build_id;
     pub use crate::normalize::buildid::read_elf_build_id_from_mmap;
+    pub use crate::normalize::ioctl::is_procmap_query_supported;
 
     cfg_breakpad! {
         pub use crate::breakpad::BreakpadResolver;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -39,7 +39,7 @@
 //! ```
 
 pub(crate) mod buildid;
-mod ioctl;
+pub(crate) mod ioctl;
 mod meta;
 mod normalizer;
 mod user;

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -70,6 +70,11 @@ impl Builder {
     /// Enable/disable the usage of the `PROCMAP_QUERY` ioctl instead of
     /// parsing `/proc/<pid>/maps` for getting available VMA ranges.
     ///
+    /// Refer to
+    /// [`helper::is_procmap_query_supported`][crate::helper::is_procmap_query_supported]
+    /// as a way to check whether your system supports this
+    /// functionality.
+    ///
     /// # Notes
     ///
     /// Support for this ioctl is only present in very recent kernels


### PR DESCRIPTION
Add a way to check for support of the PROCMAP QUERY ioctl via the public is_procmap_query_supported() helper. On an otherwise unknown system, this function allows to selectively enable (or disable) the usage of the corresponding code paths.