### PR TITLE
capi: Set last error on all paths of blaze_supports_procmap_query()

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -885,6 +885,11 @@ const char *blaze_err_str(enum blaze_err err);
 
 /**
  * Check whether the `PROCMAP_QUERY` ioctl is supported by the system.
+ *
+ * This function returns `true` if the system supports the
+ * `PROCMAP_QUERY` ioctl and `false` in all other cases, including when
+ * an error occurred. Use [`blaze_err_last`] to optionally retrieve
+ * this error.
  */
 bool blaze_supports_procmap_query(void);
 

--- a/capi/src/helper.rs
+++ b/capi/src/helper.rs
@@ -1,13 +1,24 @@
 use blazesym::helper::is_procmap_query_supported;
 
+use crate::blaze_err;
+#[cfg(doc)]
+use crate::blaze_err_last;
 use crate::set_last_err;
 
 
 /// Check whether the `PROCMAP_QUERY` ioctl is supported by the system.
+///
+/// This function returns `true` if the system supports the
+/// `PROCMAP_QUERY` ioctl and `false` in all other cases, including when
+/// an error occurred. Use [`blaze_err_last`] to optionally retrieve
+/// this error.
 #[no_mangle]
 pub extern "C" fn blaze_supports_procmap_query() -> bool {
     match is_procmap_query_supported() {
-        Ok(supported) => supported,
+        Ok(supported) => {
+            let () = set_last_err(blaze_err::BLAZE_ERR_OK);
+            supported
+        }
         Err(err) => {
             let () = set_last_err(err.kind().into());
             false


### PR DESCRIPTION
Make sure to set the last error on all paths of the blaze_supports_procmap_query() helper, not just in case of error. Also, improve documentation slightly.