### PR TITLE
Replace ad-hoc "mode" with properly structured Perm type

### DIFF
--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -280,6 +280,7 @@ mod tests {
 
     use test_log::test;
 
+    use crate::maps::Perm;
     use crate::normalize::buildid::NoBuildIdReader;
     use crate::BuildId;
     use crate::Error;
@@ -361,7 +362,7 @@ mod tests {
         let mut entry_iter = [
             Ok(MapsEntry {
                 range: 0x10000..0x20000,
-                mode: 0x1,
+                perm: Perm::default(),
                 offset: 0,
                 path_name: Some(PathName::Component(
                     "doesntreallymatternowdoesit".to_string(),
@@ -370,7 +371,7 @@ mod tests {
             }),
             Ok(MapsEntry {
                 range: 0x30000..0x40000,
-                mode: 0x1,
+                perm: Perm::default(),
                 offset: 0,
                 path_name: None,
                 build_id: None,

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1378,6 +1378,7 @@ mod tests {
 
     use test_log::test;
 
+    use crate::maps::Perm;
     use crate::symbolize;
     use crate::symbolize::CodeInfo;
     use crate::test_helper::find_the_answer_fn_in_zip;
@@ -1525,14 +1526,14 @@ mod tests {
         let mut entry_iter = [
             Ok(MapsEntry {
                 range: 0x10000..0x20000,
-                mode: 0x1,
+                perm: Perm::default(),
                 offset: 0,
                 path_name: Some(PathName::Component("a-component".to_string())),
                 build_id: None,
             }),
             Ok(MapsEntry {
                 range: 0x30000..0x40000,
-                mode: 0x1,
+                perm: Perm::default(),
                 offset: 0,
                 path_name: None,
                 build_id: None,


### PR DESCRIPTION
The "mode" thingy that we use in our VMA handling logic is not exactly a joy to deal with: there is barely any type safety and the bit ordering is hard to remember.
Replace it with a proper alternative supporting all the basic operations that we need and that allows us to make the code more expressive via use of aptly named constants. In the process we get rid of the "shared" or "private" flag. Since the introduction of the PROCMAP_QUERY ioctl support we have seen occasional CI failures caused by a difference of this bit between what is being being reported by the text interface versus the ioctl. Investigating the matter briefly, we concluded that the flag is indeed dynamic and may change at the discretion of the kernel. As such, it is probably wise for us to ignore it all together, as we didn't use it for any decision and were just carrying it along because underlying APIs reported it.