### PR TITLE
Use vmtest-action version 0.8 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
         EOF
         chmod a+x main.sh
     - name: Test and gather coverage
-      uses: danobi/vmtest-action@master
+      uses: danobi/vmtest-action@v0.8
       with:
         kernel: bzImage
         command: sh -c 'cd ${{ github.workspace }} && ./main.sh'

--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -206,7 +206,7 @@ mod tests {
 
     use scopeguard::defer;
 
-    use tempfile::tempfile;
+    use tempfile::NamedTempFile;
 
     use crate::symbolize::Input;
     use crate::symbolize::Process;
@@ -257,9 +257,9 @@ mod tests {
         };
         assert_ne!(format!("{func:?}"), "");
 
-        let mut file = tempfile().unwrap();
+        let mut file = NamedTempFile::new().unwrap();
         let () = file.write_all(SAMPLE_PERF_MAP).unwrap();
-        let perf_map = PerfMap::from_file(Path::new("SAMPLE_PERF_MAP"), &file).unwrap();
+        let perf_map = PerfMap::from_file(file.path(), file.as_file()).unwrap();
         assert_ne!(format!("{perf_map:?}"), "");
     }
 
@@ -295,9 +295,9 @@ mod tests {
     /// Check that we can load a perf map and use it to symbolize an address.
     #[test]
     fn perf_map_symbolization() {
-        let mut file = tempfile().unwrap();
+        let mut file = NamedTempFile::new().unwrap();
         let () = file.write_all(SAMPLE_PERF_MAP).unwrap();
-        let perf_map = PerfMap::from_file(Path::new("SAMPLE_PERF_MAP"), &file).unwrap();
+        let perf_map = PerfMap::from_file(file.path(), file.as_file()).unwrap();
 
         for offset in 0..0xb {
             let sym = perf_map


### PR DESCRIPTION
With vmtest-action version 0.8 released, it makes the most sense for us to consume this version as opposed to the current snapshot from the master branch. This way, we anticipate to consume stable releases and have Dependabot manage version bumps for us.