### PR TITLE
Pin vmtest-action to working version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
         EOF
         chmod a+x main.sh
     - name: Test and gather coverage
-      uses: danobi/vmtest-action@master
+      uses: danobi/vmtest-action@f8c84191b5925c3290595743fc46eaaafd827bf3
       with:
         kernel: bzImage
         command: sh -c 'cd ${{ github.workspace }} && ./main.sh'


### PR DESCRIPTION
With release 0.14 vmtest has become unusable for us. The reason being that it turns out that with the usage of the host's /tmp/ handling of temporary files broke due to deficiencies in the 9P file system [0]. Given that by now vmtest-action@master uses this very version, our CI is broken.
To work around the issue until a permanent fix is found, pin vmtest-action to a usable SHA-1.

[0] https://github.com/danobi/vmtest/issues/83