### PR TITLE
Add test for Perm operations

### DIFF
--- a/src/maps.rs
+++ b/src/maps.rs
@@ -432,6 +432,14 @@ mod tests {
         assert_ne!(maps.map(|entry| entry.unwrap()).count(), 0);
     }
 
+    /// Check that various operations on the `Perm` type work as
+    /// expected.
+    #[test]
+    fn perm_ops() {
+        assert_eq!(Perm::X | Perm::R, Perm::RX);
+        assert_eq!(Perm::RX & Perm::R, Perm::R);
+    }
+
     /// Make sure that we can parse proc maps lines correctly.
     #[tag(miri)]
     #[test]


### PR DESCRIPTION
Most of the "bit" operations on the Perm type are tested indirectly, but the BitAndAssign impl is showing some red in the coverage report. Add explicit tests for this functionality to improve numbers slightly.