### PR TITLE
Fix key used for kernel artifact upload

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: build/arch/x86/boot/bzImage
-          key: linux-kernel-${{ hashFiles(inputs.config) }}
+          key: linux-kernel-${{ inputs.rev }}-${{ hashFiles(inputs.config) }}
       - uses: actions/upload-artifact@v4
         id: upload-linux-kernel
         # TODO: Having a single path/name may be problematic should we


### PR DESCRIPTION
We missed adjusting the cache key for the kernel in one location as part of commit 798bb5274445 ("Generalize build-linux CI workflow"), causing caching to be broken. Fix it up.