### PR TITLE
Implement BitAnd for Perm in terms of BitAndAssign

### DIFF
--- a/src/maps.rs
+++ b/src/maps.rs
@@ -101,8 +101,10 @@ impl BitAnd for Perm {
     type Output = Perm;
 
     #[inline]
-    fn bitand(self, rhs: Self) -> Self::Output {
-        Self(self.0 & rhs.0)
+    fn bitand(self, other: Self) -> Self::Output {
+        let mut result = self;
+        result &= other;
+        result
     }
 }
 


### PR DESCRIPTION
Implement the BitAnd impl for the Perm type by reusing the existing BitAndAssign impl. This makes for slightly better code sharing.