### PR TITLE
Properly "dereference" 'self' component in normalized paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Unreleased
 - Added support for file based symbolization support on the Windows operating
   system
 - Improved performance for parsing Breakpad files
+- Made sure to not emit "self" component in normalized paths when
+  `map_files` is in use
 - Fixed potentially invalid reading of debug link checksum when
   `.gnu_debuglink` section is unaligned
 - Renamed `enable_maps_caching` method of `normalize::Normalizer` to


### PR DESCRIPTION
With the introduction of the 'maps_file' option to the normalize APIs, we started reporting /proc/<pid>/.. paths as normalization results, as this information may be useful in certain out-of-band normalization contexts.
What we missed to change, though, was to resolve symbolic "PIDs" such as "self" in those paths. That is a problem, because in an out-of-band symbolization scenario, /proc/self/.. will reference something different in the process where the normalization happens versus that of the symbolization.
The more general solution is to just map self to the actual PID and with this change we do just that.