### PR TITLE
Include `cbindgen.toml` in the published crate

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -22,7 +22,7 @@ keywords = [
   "stacktrace",
   "tracing",
 ]
-include = ["src/**/*", "include/**/*", "!**/examples/**/*", "LICENSE", "README.md", "CHANGELOG.md", "examples/input-struct-init.c", "build.rs"]
+include = ["src/**/*", "include/**/*", "!**/examples/**/*", "LICENSE", "README.md", "CHANGELOG.md", "examples/input-struct-init.c", "build.rs", "cbindgen.toml"]
 autobenches = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This is needed for either
- regenerating the C header with `cargo check --package blazesym-c --features=generate-c-header`
- using `cargo-c` which generates the same header but with version info, for distribution packaging

Verify the file gets included

```
michel in blazesym/capi
$ cargo package --list --allow-dirty | grep cbindgen.toml
cbindgen.toml
```

Without `cbindgen.toml` the default language is C++ and there is no inclusion guard to make sure the header is only included once

With `cbindgen.toml`, regenerating the C header results in an identical header when building in Fedora

Diff of included header and the one `cargo-c` generates

```
michel in build/BUILD/rust-blazesym-c-0.1.0_rc.0-build
$ diff -u blazesym-c-0.1.0-rc.0/include/blazesym.h BUILDROOT/usr/include/blazesym_c/blazesym_c.h
--- blazesym-c-0.1.0-rc.0/include/blazesym.h    2006-07-23 20:21:28.000000000 -0500
+++ BUILDROOT/usr/include/blazesym_c/blazesym_c.h       2024-08-26 17:55:51.178241671 -0500
@@ -1,13 +1,12 @@
-/*
- * Please refer to the documentation hosted at
- *
- *   https://docs.rs/blazesym-c/0.1.0-rc.0
- */
-
-
 #ifndef __blazesym_h_
 #define __blazesym_h_

+
+#define BLAZESYM_C_MAJOR 0
+#define BLAZESYM_C_MINOR 1
+#define BLAZESYM_C_PATCH 0
+
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
```