### PR TITLE
Rename UserMeta getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Unreleased
   `.gnu_debuglink` section is unaligned
 - Renamed `enable_maps_caching` method of `normalize::Normalizer` to
   `enable_vma_caching`
+- Renamed `UserMeta::{apk,elf,unknown}` methods by prefixing them with `as_`
 
 
 0.2.0-rc.0

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -1576,7 +1576,7 @@ mod tests {
 
         let output = normalized.outputs[0];
         let meta = &normalized.meta[output.1];
-        assert_eq!(meta.elf().unwrap().path, test_so);
+        assert_eq!(meta.as_elf().unwrap().path, test_so);
 
         let symbolizer = blaze_symbolizer_new();
         let elf_src = blaze_symbolize_src_elf {

--- a/src/normalize/meta.rs
+++ b/src/normalize/meta.rs
@@ -25,7 +25,7 @@ use super::Reason;
 ///     .unwrap();
 /// let (output, meta_idx) = normalized.outputs[0];
 /// let meta = &normalized.meta[meta_idx];
-/// let apk = meta.apk().unwrap();
+/// let apk = meta.as_apk().unwrap();
 ///
 /// // We assume that we have the APK lying around at the same path as on the
 /// // "remote" system.
@@ -113,7 +113,7 @@ pub enum UserMeta<'src> {
 impl<'src> UserMeta<'src> {
     /// Retrieve the [`Apk`] of this enum, if this variant is active.
     #[inline]
-    pub fn apk(&self) -> Option<&Apk> {
+    pub fn as_apk(&self) -> Option<&Apk> {
         match self {
             Self::Apk(entry) => Some(entry),
             _ => None,
@@ -122,7 +122,7 @@ impl<'src> UserMeta<'src> {
 
     /// Retrieve the [`Elf`] of this enum, if this variant is active.
     #[inline]
-    pub fn elf(&self) -> Option<&Elf<'src>> {
+    pub fn as_elf(&self) -> Option<&Elf<'src>> {
         match self {
             Self::Elf(elf) => Some(elf),
             _ => None,
@@ -131,7 +131,7 @@ impl<'src> UserMeta<'src> {
 
     /// Retrieve the [`Unknown`] of this enum, if this variant is active.
     #[inline]
-    pub fn unknown(&self) -> Option<&Unknown> {
+    pub fn as_unknown(&self) -> Option<&Unknown> {
         match self {
             Self::Unknown(unknown) => Some(unknown),
             _ => None,
@@ -153,25 +153,25 @@ mod tests {
             path: PathBuf::from("/tmp/archive.apk"),
             _non_exhaustive: (),
         });
-        assert!(meta.apk().is_some());
-        assert!(meta.elf().is_none());
-        assert!(meta.unknown().is_none());
+        assert!(meta.as_apk().is_some());
+        assert!(meta.as_elf().is_none());
+        assert!(meta.as_unknown().is_none());
 
         let meta = UserMeta::Elf(Elf {
             path: PathBuf::from("/tmp/executable.bin"),
             build_id: None,
             _non_exhaustive: (),
         });
-        assert!(meta.apk().is_none());
-        assert!(meta.elf().is_some());
-        assert!(meta.unknown().is_none());
+        assert!(meta.as_apk().is_none());
+        assert!(meta.as_elf().is_some());
+        assert!(meta.as_unknown().is_none());
 
         let meta = UserMeta::Unknown(Unknown {
             reason: Reason::Unsupported,
             _non_exhaustive: (),
         });
-        assert!(meta.apk().is_none());
-        assert!(meta.elf().is_none());
-        assert!(meta.unknown().is_some());
+        assert!(meta.as_apk().is_none());
+        assert!(meta.as_elf().is_none());
+        assert!(meta.as_unknown().is_some());
     }
 }

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -444,7 +444,7 @@ mod tests {
 
             let errno_meta_idx = outputs[errno_idx].1;
             assert!(meta[errno_meta_idx]
-                .elf()
+                .as_elf()
                 .unwrap()
                 .path
                 .file_name()
@@ -528,7 +528,7 @@ mod tests {
 
             let output = normalized.outputs[0];
             assert_eq!(output.0, sym.addr);
-            let meta = &normalized.meta[output.1].elf().unwrap();
+            let meta = &normalized.meta[output.1].as_elf().unwrap();
             assert_eq!(
                 meta.build_id,
                 Some(read_elf_build_id(&test_so).unwrap().unwrap())
@@ -658,7 +658,7 @@ mod tests {
         assert_eq!(normalized.meta.len(), 1);
         let output = normalized.outputs[0];
         let meta = &normalized.meta[output.1];
-        let elf = meta.elf().unwrap();
+        let elf = meta.as_elf().unwrap();
         assert!(!elf.path.to_string_lossy().contains("self"), "{elf:?}");
     }
 }

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -430,7 +430,7 @@ mod tests {
         assert_eq!(normalized.outputs.len(), 1);
         assert_eq!(normalized.meta.len(), 1);
         assert!(
-            normalized.meta[0].elf().is_some(),
+            normalized.meta[0].as_elf().is_some(),
             "{:?}",
             normalized.meta[0]
         );

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -835,7 +835,7 @@ fn normalize_elf_addr() {
 
         let output = normalized.outputs[0];
         let meta = &normalized.meta[output.1];
-        let path = &meta.elf().unwrap().path;
+        let path = &meta.as_elf().unwrap().path;
         assert_eq!(
             path.to_str().unwrap().contains("/map_files/"),
             map_files,
@@ -903,7 +903,7 @@ fn normalize_build_id_reading() {
 
         let output = normalized.outputs[0];
         let meta = &normalized.meta[output.1];
-        let elf = meta.elf().unwrap();
+        let elf = meta.as_elf().unwrap();
         assert_eq!(elf.path, test_so);
         if read_build_ids {
             let expected = read_elf_build_id(&test_so).unwrap().unwrap();


### PR DESCRIPTION
Rename the UserMeta::{apk,elf,unkown}() getters by prefixing the methods with as_. If nothing else, this is more consistent with the already present Symbolized::as_sym(), which has very similar semantics.