### PR TITLE
Fix warnings about elided lifetimes

### DIFF
--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -402,7 +402,7 @@ impl<'dwarf> Units<'dwarf> {
     pub(crate) fn find_name<'s, 'slf: 's>(
         &'slf self,
         name: &'s str,
-    ) -> impl Iterator<Item = Result<&Function<'dwarf>, gimli::Error>> + 's {
+    ) -> impl Iterator<Item = Result<&'slf Function<'dwarf>, gimli::Error>> + 's {
         self.units
             .iter()
             .filter_map(move |unit| unit.find_name(name, self).transpose())
@@ -413,7 +413,7 @@ impl<'dwarf> Units<'dwarf> {
     pub(crate) fn unit_ref<'unit>(
         &'unit self,
         unit: &'unit gimli::Unit<R<'dwarf>>,
-    ) -> gimli::UnitRef<'_, R<'dwarf>> {
+    ) -> gimli::UnitRef<'unit, R<'dwarf>> {
         gimli::UnitRef::new(&self.dwarf, unit)
     }
 

--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -39,7 +39,7 @@ struct Function<'mmap> {
 
 
 /// Parse a line of a perf map file.
-fn parse_perf_map_line<'line>(line: &'line [u8]) -> Result<Function<'_>> {
+fn parse_perf_map_line<'line>(line: &'line [u8]) -> Result<Function<'line>> {
     let full_line = line;
 
     let split_once = |line: &'line [u8], component| -> Result<(&'line [u8], &'line [u8])> {
@@ -378,6 +378,7 @@ if __name__ == "__main__":
         });
 
         // "Signal" the child to terminate gracefully.
+        #[allow(clippy::byte_char_slices)]
         let () = child.stdin.as_ref().unwrap().write_all(&[b'\n']).unwrap();
         let _status = child.wait().unwrap();
     }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -697,7 +697,7 @@ impl Symbolizer {
         &'slf self,
         addrs: &[Addr],
         resolver: &Resolver<'_, 'slf>,
-    ) -> Result<Vec<Symbolized>> {
+    ) -> Result<Vec<Symbolized<'slf>>> {
         addrs
             .iter()
             .map(|addr| self.symbolize_with_resolver(*addr, resolver))


### PR DESCRIPTION
Newer versions of Rust warn about elided lifetimes that get resolved to otherwise declared ones. Use said declared ones to prevent any such warnings from showing up.