### PR TITLE
Remove clippy::byte_char_slices lint allowance

### DIFF
--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -378,8 +378,7 @@ if __name__ == "__main__":
         });
 
         // "Signal" the child to terminate gracefully.
-        #[allow(clippy::byte_char_slices)]
-        let () = child.stdin.as_ref().unwrap().write_all(&[b'\n']).unwrap();
+        let () = child.stdin.as_ref().unwrap().write_all(b"\n").unwrap();
         let _status = child.wait().unwrap();
     }
 }


### PR DESCRIPTION
Let's follow the recommendations of the clippy::byte_char_slices lint instead of ignoring it.