### PR TITLE
cli: Add --procmap-query option to normalize user sub-command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added `--procmap-query` option to `normalize user` sub-command
 - Bumped `blazesym` dependency to `0.2.0-rc.1`
 
 

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -156,6 +156,10 @@ pub mod normalize {
         /// Disable the reading of build IDs of the corresponding binaries.
         #[clap(long)]
         pub no_build_ids: bool,
+        /// Enable the usage of the `PROCMAP_QUERY` ioctl instead of
+        /// parsing `/proc/<pid>/maps` for getting available VMA ranges.
+        #[clap(long)]
+        pub procmap_query: bool,
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -137,9 +137,11 @@ fn normalize(normalize: args::normalize::Normalize) -> Result<()> {
             pid,
             addrs,
             no_build_ids,
+            procmap_query,
         }) => {
             let normalizer = Normalizer::builder()
                 .enable_build_ids(!no_build_ids)
+                .enable_procmap_query(procmap_query)
                 .build();
             let normalized = normalizer
                 .normalize_user_addrs(pid, addrs.as_slice())


### PR DESCRIPTION
Introduce the --procmap-query option to the 'normalize user' sub-command. This option can be used to use the PROCMAP QUERY ioctl for retrieving VMAs instead of parsing parsing the /proc/<pid>/maps file.

  $ cargo run -- normalize user --procmap-query --pid 308844 0x7f7d3b3ae000
  > Error: failed to normalize addresses
  >
  > Caused by:
  >     PROCMAP_QUERY is not supported

On a kernel with PROCMAP_QUERY ioctl support:
  $ blazecli normalize user --procmap-query --pid 96 0x7f504f5a9000
  > 0x007f504f5a9000: file offset 0x28000 in /usr/lib64/libc.so.6 (build ID: 77c77fee058b19c6f001cf2cb0371ce3b8341211)