### PR TITLE
capi: Bump version to 0.1.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - Added `is_procmap_query_supported` function to `helper` module
 - Adjusted normalization logic to not fail overall operation on build ID
   read failure
-- Added support for file based symbolization support on the Windows operating
+- Added support for file based symbolization on the Windows operating
   system
 - Improved performance for parsing Breakpad files
 - Made sure to not emit "self" component in normalized paths when

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,4 +1,4 @@
-Unreleased
+0.1.0-rc.1
 ----------
 - Added `procmap_query_ioctl` attribute to `blaze_normalizer_opts`
 - Renamed `blaze_result` to `blaze_syms`

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym-c"
 description = "C bindings for blazesym"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Daniel Müller <deso@posteo.net>"]

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1,7 +1,7 @@
 /*
  * Please refer to the documentation hosted at
  *
- *   https://docs.rs/blazesym-c/0.1.0-rc.0
+ *   https://docs.rs/blazesym-c/0.1.0-rc.1
  */
 
 


### PR DESCRIPTION
This change bumps the blazesym-c's version to 0.1.0-rc.1. The following notable changes have been made since 0.1.0-rc.0:
- Added 'procmap_query_ioctl' attribute to blaze_normalizer_opts
- Renamed blaze_result to blaze_syms
  - Renamed blaze_result_free to blaze_syms_free
- Renamed 'cache_maps' attribute of blaze_normalizer_opts to 'cache_vmas'
- Introduced blaze_supports_procmap_query helper
- Bumped blazesym dependency to 0.2.0-rc.1