### PR TITLE
Rename 'Build' workflow to 'Build blazecli'

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build blazecli
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -56,5 +56,5 @@ jobs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   build-artifacts:
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/build-cli.yml
     secrets: inherit


### PR DESCRIPTION
The 'Build' workflow is not very telling in its function. Rename it to 'Build blazecli' to make it more clear what it is about.