### PR TITLE
cli: Attach statically build binary to release

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -1,7 +1,13 @@
-name: Build
+name: Build blazecli
 
 on:
   workflow_call:
+    inputs:
+      upload-release:
+        description: 'The release to upload artifacts to, if any'
+        default: ''
+        required: false
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -29,3 +35,10 @@ jobs:
         with:
           name: blazecli-${{ matrix.target }}
           path: bin/blazecli
+      - if: ${{ inputs.upload-release != '' }}
+        name: Upload release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mv bin/blazecli blazecli-${{ matrix.target }}
+          gh release upload ${{ inputs.upload-release }} blazecli-${{ matrix.target }}

--- a/.github/workflows/publish-capi.yml
+++ b/.github/workflows/publish-capi.yml
@@ -37,10 +37,11 @@ jobs:
         version: ${{ needs.version.outputs.version }}
       run: |
         curl --location \
+          --fail-with-body \
           --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/releases \
           --header "Accept: application/vnd.github+json" \
-          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           --header "X-GitHub-Api-Version: 2022-11-28" \
           --data "{
               \"tag_name\":\"capi-v${version}\",

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -37,6 +37,7 @@ jobs:
         version: ${{ needs.version.outputs.version }}
       run: |
         curl --location \
+          --fail-with-body \
           --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/releases \
           --header "Accept: application/vnd.github+json" \
@@ -56,5 +57,8 @@ jobs:
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   build-artifacts:
+    needs: [publish, version]
     uses: ./.github/workflows/build-cli.yml
     secrets: inherit
+    with:
+      upload-release: cli-v${{ needs.version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,11 @@ jobs:
         version: ${{ needs.version.outputs.version }}
       run: |
         curl --location \
+          --fail-with-body \
           --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/releases \
           --header "Accept: application/vnd.github+json" \
-          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           --header "X-GitHub-Api-Version: 2022-11-28" \
           --data "{
               \"tag_name\":\"v${version}\",


### PR DESCRIPTION
Since forever we have wanted to attach statically linked binaries of blazecli to the corresponding release. However, because GitHub Actions can't seem to get their Matrix workflows interacting with anything, really, that seemed impossible to do.
This change proposes a workaround that makes each job of the matrix attach the binary to the release itself, provided that the associated input argument it set. While at it also make sure to use the --fail-with-body option in all our special-sauce curl invocations, so that errors are bubbled up properly.