### PR TITLE
Work around Miri failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,8 +313,12 @@ jobs:
       MIRIFLAGS: '-Zmiri-disable-stacked-borrows'
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
       with:
+        # TODO: Recent nightly versions fail with what *seems* to be a
+        #       false positive. Fall back to a known good version. We
+        #       should come back to this eventually.
+        toolchain: nightly-2024-08-06
         components: miri
     # Miri would honor our custom test runner, but doesn't work with it. We
     # could conceivably override that by specifying


### PR DESCRIPTION
Recent nightly version of Rust fail running one of our tests under Miri [0]. The claim is that data is used uninitialized, but it's not really clear why there would be anything uninitialized at this point and this test has been working fine ever since its inception. Suspicion is that nightly Miri could have a bug. And even if it's a bug in our code it would be in test code itself, rather than the library. Pin the version we use to a known good one for the time being to get us back to green.

[0] https://github.com/libbpf/blazesym/actions/runs/10842437849/job/30216935620