### PR TITLE
De-duplicate definition of stat() functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,14 @@ pub mod helper {
     }
 }
 
+/// Implementation details shared with other closely related crates.
+///
+/// NOT PART OF PUBLIC API SURFACE!
+#[doc(hidden)]
+pub mod __private {
+    pub use crate::util::stat;
+}
+
 
 #[cfg(feature = "tracing")]
 #[macro_use]

--- a/src/util.rs
+++ b/src/util.rs
@@ -263,7 +263,8 @@ where
 }
 
 
-pub(crate) fn stat(path: &Path) -> io::Result<libc::stat> {
+#[doc(hidden)]
+pub fn stat(path: &Path) -> io::Result<libc::stat> {
     let mut dst = MaybeUninit::uninit();
     let mut path = path_to_bytes(path)?.to_vec();
     let () = path.push(b'\0');

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,12 +6,10 @@
 
 use std::env::current_exe;
 use std::io::Error;
-use std::io::Result;
-use std::mem::MaybeUninit;
-use std::os::unix::ffi::OsStrExt as _;
 use std::panic::catch_unwind;
 use std::panic::UnwindSafe;
-use std::path::Path;
+
+use blazesym::__private::stat;
 
 use libc::uid_t;
 
@@ -52,23 +50,6 @@ where
     F: FnOnce() -> R + UnwindSafe,
 {
     unimplemented!()
-}
-
-
-// TODO: Copy of logic from the main crate. If usage proliferates we
-//       should think of a way to share.
-fn stat(path: &Path) -> Result<libc::stat> {
-    let mut dst = MaybeUninit::uninit();
-    let mut path = path.as_os_str().as_bytes().to_vec();
-    let () = path.push(b'\0');
-
-    let rc = unsafe { libc::stat(path.as_ptr().cast::<libc::c_char>(), dst.as_mut_ptr()) };
-    if rc < 0 {
-        return Err(Error::last_os_error())
-    }
-
-    // SAFETY: The object is initialized on success of `stat`.
-    Ok(unsafe { dst.assume_init() })
 }
 
 /// Attempt to infer a usable non-root UID on the system.


### PR DESCRIPTION
In the future we are likely to need to share more functionality between blazesym and adjacent crates (blazecli, blazesym-c, or integration tests) to simplify our lives. As such, introduce the means for doing so and de-duplicate the existing definition of stat().