### PR TITLE
Allow retrieving build-ids in permissionless env

### DIFF
--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -529,10 +529,13 @@ mod tests {
             let output = normalized.outputs[0];
             assert_eq!(output.0, sym.addr);
             let meta = &normalized.meta[output.1].as_elf().unwrap();
-            assert_eq!(
-                meta.build_id,
+            let expected_build_id = if use_map_files || use_procmap_query {
                 Some(read_elf_build_id(&test_so).unwrap().unwrap())
-            );
+            } else {
+                None
+            };
+
+            assert_eq!(meta.build_id, expected_build_id);
         }
 
         for cache_build_ids in [true, false] {

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -192,7 +192,7 @@ impl Handler<Reason> for NormalizationHandler<'_, '_> {
                             // cheap cache look up if build ID caching
                             // is enabled.
                             let build_id = entry.build_id.clone().or_else(|| {
-                                self.build_id_reader.read_build_id(&entry_path.maps_file)
+                                self.build_id_reader.read_build_id(&path)
                             });
                             make_elf_meta(path, build_id)
                         },

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use crate::maps;
 use crate::maps::MapsEntry;
 use crate::maps::PathName;
+use crate::util;
 use crate::Addr;
 use crate::BuildId;
 use crate::Error;
@@ -161,7 +162,10 @@ impl Handler<Reason> for NormalizationHandler<'_, '_> {
     fn handle_entry_addr(&mut self, addr: Addr, entry: &MapsEntry) -> Result<()> {
         match &entry.path_name {
             Some(PathName::Path(entry_path)) => {
-                let path = if self.map_files {
+                // In case, we want to extract the build_id using the symbolic path,
+                // we have to check that the file still exists on disk
+                let file_stat = util::stat(&entry_path.symbolic_path);
+                let path = if self.map_files || file_stat.is_err(){
                     &entry_path.maps_file
                 } else {
                     &entry_path.symbolic_path

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -196,7 +196,7 @@ impl Handler<Reason> for NormalizationHandler<'_, '_> {
                             // cheap cache look up if build ID caching
                             // is enabled.
                             let build_id = entry.build_id.clone().or_else(|| {
-                                self.build_id_reader.read_build_id(&path)
+                                self.build_id_reader.read_build_id(path)
                             });
                             make_elf_meta(path, build_id)
                         },


### PR DESCRIPTION
## What does this PR ?

Addresses issue https://github.com/libbpf/blazesym/issues/821
Use the `symbolic_path` when the normalizer is configured with `map_files=false`.

## Motivation

When Docker container runs in unprivileged mode, even the root-user cannot access the `/proc/XX/map_files`. This prevents from `build-id`s collection in such environment.
By setting `map_files=false` (default being `true`), we instruct the normalizer to retrieve the `build-id`s using the `symbolic_path`.
