### PR TITLE
Allow retrieving build-ids in permissionless env

### DIFF
--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -529,10 +529,13 @@ mod tests {
             let output = normalized.outputs[0];
             assert_eq!(output.0, sym.addr);
             let meta = &normalized.meta[output.1].as_elf().unwrap();
-            assert_eq!(
-                meta.build_id,
+            let expected_build_id = if use_map_files || use_procmap_query {
                 Some(read_elf_build_id(&test_so).unwrap().unwrap())
-            );
+            } else {
+                None
+            };
+
+            assert_eq!(meta.build_id, expected_build_id);
         }
 
         for cache_build_ids in [true, false] {

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -191,9 +191,10 @@ impl Handler<Reason> for NormalizationHandler<'_, '_> {
                             // usage. Note that "reading" here could be a
                             // cheap cache look up if build ID caching
                             // is enabled.
-                            let build_id = entry.build_id.clone().or_else(|| {
-                                self.build_id_reader.read_build_id(&entry_path.maps_file)
-                            });
+                            let build_id = entry
+                                .build_id
+                                .clone()
+                                .or_else(|| self.build_id_reader.read_build_id(path));
                             make_elf_meta(path, build_id)
                         },
                     ),


### PR DESCRIPTION
## What does this PR ?

Addresses issue https://github.com/libbpf/blazesym/issues/821
Use the `symbolic_path` when the normalizer is configured with `map_files=false`.

## Motivation

When Docker container runs in unprivileged mode, even the root-user cannot access the `/proc/XX/map_files`. This prevents from `build-id`s collection in such environment.
By setting `map_files=false` (default being `true`), we instruct the normalizer to retrieve the `build-id`s using the `symbolic_path`.

## Note
same as https://github.com/libbpf/blazesym/pull/823 (closed by me by mistake)