### PR TITLE
Add CHANGELOG entry for #824

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Adjusted normalization logic to use "symbolic path" for reading build
+  IDs when normalizing with `NormalizeOpts::map_files` equal to `false`
+
+
 0.2.0-rc.1
 ----------
 - Added support for using `PROCMAP_QUERY` ioctl during address normalization


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #824, which change the way we read build IDs as part of address normalization when `NormalizeOpts::map_files` is set to `false`.