### PR TITLE
capi: Improve test for blaze_read_elf_build_id() helper

### DIFF
--- a/capi/src/helper.rs
+++ b/capi/src/helper.rs
@@ -109,10 +109,11 @@ pub unsafe extern "C" fn blaze_read_elf_build_id(path: *const c_char, len: *mut 
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::ffi::CString;
     use std::path::Path;
-
-    use super::*;
+    use std::slice;
 
     use crate::blaze_err;
     use crate::blaze_err_last;
@@ -140,6 +141,14 @@ mod tests {
         assert_eq!(blaze_err_last(), blaze_err::BLAZE_ERR_OK);
         // The file contains a sha1 build ID, which is always 20 bytes in length.
         assert_eq!(len, 20);
+
+        // Also smoke test that the build ID equals what the Rust API
+        // reports.
+        let build_id_rs = read_elf_build_id(&path).unwrap().unwrap();
+        assert_eq!(
+            unsafe { slice::from_raw_parts(build_id, len) },
+            &*build_id_rs
+        );
         let () = unsafe { libc::free(build_id.cast()) };
 
         let path = Path::new(&env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
The test we have for the blaze_read_elf_build_id() helper function is roughly a copy of that for helper::read_elf_build_id() in Rust. However, it doesn't check all the byte copying stuff that we do to expose the C style array to callers.
This change improves the test by comparing the build ID against the one reported by the Rust API.