### PR TITLE
Add example illustrating look up of mangled symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,10 @@ name = "addr2ln_pid"
 [[example]]
 name = "backtrace"
 
+[[example]]
+name = "inspect-mangled"
+required-features = ["demangle", "generate-unit-test-files"]
+
 [[bench]]
 name = "main"
 harness = false

--- a/examples/inspect-mangled.rs
+++ b/examples/inspect-mangled.rs
@@ -1,0 +1,49 @@
+//! An example illustrating how to look up a (mangled) symbol (and its
+//! meta data) based on its expected demangled name.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use blazesym::inspect::Elf;
+use blazesym::inspect::Inspector;
+use blazesym::inspect::Source;
+use blazesym::inspect::SymInfo;
+
+use rustc_demangle::demangle;
+
+
+const TEST_FN: &str = "test::test_function";
+
+
+fn find_test_function(sym: &SymInfo<'_>, test_fn: &mut Option<SymInfo<'static>>) {
+    let name = format!("{:#}", demangle(&sym.name));
+    if name == TEST_FN {
+        if let Some(prev) = test_fn.replace(sym.to_owned()) {
+            // There should exist only a single symbol by that name.
+            panic!("already found one `{TEST_FN}` symbol: {prev:?}")
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let so = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-rs.bin");
+    let inspector = Inspector::new();
+    let src = Source::from(Elf::new(so));
+
+    // We can't really use `Inspector::lookup` here, because we only
+    // know the demangled but not the mangled name. But the mangled name
+    // is what is what `Inspector::lookup` uses in the case of an ELF
+    // source. To look up symbol information based on the demangled
+    // name, we roll our own search based on the `Inspector::for_each`
+    // facility.
+    let mut test_fn_out = None;
+    let () = inspector
+        .for_each(&src, |sym| find_test_function(sym, &mut test_fn_out))
+        .unwrap();
+    let test_fn = test_fn_out.unwrap_or_else(|| panic!("failed to find `{TEST_FN}` symbol"));
+    println!("successfully looked up mangled symbol with demangled name `{TEST_FN}`:\n{test_fn:?}");
+    Ok(())
+}

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -73,8 +73,14 @@ impl Inspector {
     /// For each symbol name, a vector of addresses is returned, i.e. a given
     /// symbol name can correspond to more than one address.
     ///
+    /// If you require some kind of advanced look up scheme, e.g., based on a
+    /// regular expression matching or on demangled names when the source
+    /// contains only mangled symbols, this will have to be built on top of the
+    /// [`Inspector::for_each`] functionality.
+    ///
     /// # Notes
-    /// - no symbol name demangling is performed currently
+    /// - no symbol name demangling is performed and data is reported as it
+    ///   appears in the symbol source
     /// - for the [`Breakpad`](Source::Breakpad) source:
     ///   - no variable support is present
     ///   - file offsets won't be reported


### PR DESCRIPTION
Most symbol sources store mangled symbol names. Hence, the mangled name is what the Inspector::lookup facility matches against. However, that is not always desired. Rather, sometimes filtering needs happen based on the demangled name or other information encoded in the mangled symbol (such as number of function arguments).
We support this use case via the Inspector::for_each functionality, but it's not trivially obvious that this is possible to begin with. With this change we add an example that illustrates such usage.