### PR TITLE
Use dynamic dispatch in ElfParser::for_each_sym_impl()

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -785,16 +785,13 @@ impl ElfParser {
         Ok(syms)
     }
 
-    fn for_each_sym_impl<F>(
+    fn for_each_sym_impl(
         &self,
         opts: &FindAddrOpts,
         syms: &[&Elf64_Sym],
         str2sym: &[(&str, usize)],
-        mut f: F,
-    ) -> Result<()>
-    where
-        F: FnMut(&SymInfo<'_>),
-    {
+        f: &mut dyn FnMut(&SymInfo<'_>),
+    ) -> Result<()> {
         let shdrs = self.cache.ensure_shdrs()?;
 
         for (name, idx) in str2sym {


### PR DESCRIPTION
Instead of relying on a generic function, let's use a function pointer for the callback function provided to ElfParser::for_each_sym_impl(). Doing so brings us more in line with the rest of the iteration code, which was adjusted earlier to use dynamic dispatch.