### PR TITLE
Fix Normalizer documentation incorrectly citing "virtual addresses"

### DIFF
--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -161,9 +161,9 @@ impl Default for Builder {
 /// Address normalization is the process of taking virtual absolute
 /// addresses as they are seen by, say, a process (which include
 /// relocation and process specific layout randomizations, among other
-/// things) and converting them to "normalized" virtual addresses as
-/// they are present in, say, an ELF binary or a DWARF debug info file,
-/// and one would be able to see them using tools such as readelf(1).
+/// things) and converting them to file offsets. This is typically a
+/// very fast running operation. The file offsets can subsequently be
+/// used as symbolization input.
 ///
 /// If caching of data is enabled, an instance of this type is the unit
 /// at which caching happens. If you are normalizing address in a large

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -479,7 +479,7 @@ mod tests {
         assert_eq!(normalized.meta.len(), 1);
 
         let output = normalized.outputs[0];
-        assert_eq!(output.0, sym.addr);
+        assert_eq!(output.0, sym.file_offset.unwrap());
         let meta = &normalized.meta[output.1];
         let expected_elf = Elf {
             build_id: Some(read_elf_build_id(&test_so).unwrap().unwrap()),
@@ -527,7 +527,7 @@ mod tests {
             assert_eq!(normalized.meta.len(), 1);
 
             let output = normalized.outputs[0];
-            assert_eq!(output.0, sym.addr);
+            assert_eq!(output.0, sym.file_offset.unwrap());
             let meta = &normalized.meta[output.1].as_elf().unwrap();
             let expected_build_id = if use_map_files || use_procmap_query {
                 Some(read_elf_build_id(&test_so).unwrap().unwrap())


### PR DESCRIPTION
The result of address normalization are file offsets, not virtual addresses. The documentation of the normalize::Normalizer type is outdated in that respect, presumably from times when virtual address were still reported (i.e., before commit 9f3c71344f9f ("Make normalization report file offsets")).
Adjust the documentation to mention files offset.

Reported-by: Nicolas Savoire <nicolas.savoire@datadoghq.com>