### PR TITLE
Run more examples in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -338,6 +338,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo run --example backtrace
+    - run: cargo run --example inspect-mangled
+    - run: cargo run --example normalize-virt-offset
     - run: cargo run --package gsym-in-apk
   c-header:
     name: Check generated C header


### PR DESCRIPTION
Run two more example that work without user input as part of our regular CI checks.