### PR TITLE
Fix typo in README of sym-debuginfod example

### DIFF
--- a/examples/sym-debuginfod/README.md
+++ b/examples/sym-debuginfod/README.md
@@ -8,7 +8,7 @@ An example illustrating advanced usage scenarios of **blazesym**, by using a
 ```
 $ echo $DEBUGINFOD_URLS
 > https://debuginfod.fedoraproject.org/
-# PID and addresses we captured out-of-band.
+# PID and addresses were captured out-of-band.
 $ cargo run --package sym-debuginfod -- 3738900 0x7fd4e762a100 0x7fd4e762d200
 > 0x007fd4e762a100: _init @ 0xe000+0x100
 > 0x007fd4e762d200: gobject_init @ 0x10400+0xe00 /usr/src/debug/glib2-2.78.3-1.fc39.x86_64/redhat-linux-build/../gobject/gtype.c:4608:3


### PR DESCRIPTION
Fix a typo in the README of the sym-debuginfod example.