### PR TITLE
Remove explicit LeakSanitizer usage from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,7 +263,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, leak]
+        sanitizer: [address]
     runs-on: ubuntu-latest
     env:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-14
@@ -277,10 +277,6 @@ jobs:
       run: |
           # to get the symbolizer for debug symbol resolution
           sudo apt-get install -y llvm-14
-          # to fix buggy leak analyzer:
-          # https://github.com/japaric/rust-san#unrealiable-leaksanitizer
-          sed -i '/\[features\]/i [profile.dev]' Cargo.toml
-          sed -i '/profile.dev/a opt-level = 1' Cargo.toml
           cat Cargo.toml
     - name: cargo test -Zsanitizer=${{ matrix.sanitizer }}
       env:
@@ -290,8 +286,7 @@ jobs:
         #CFLAGS: "-fsanitize=${{ matrix.sanitizer }}"
         #CXXFLAGS: "-fsanitize=${{ matrix.sanitizer }}"
         RUSTFLAGS: "-Zsanitizer=${{ matrix.sanitizer }}"
-        ASAN_OPTIONS: "detect_odr_violation=0:detect_leaks=0"
-        LSAN_OPTIONS: ""
+        ASAN_OPTIONS: "detect_odr_violation=0:detect_leaks=1"
       run: cargo test --workspace --lib --tests --target x86_64-unknown-linux-gnu
   test-release:
     name: Test with release build


### PR DESCRIPTION
Running with LeakSanitizer enabled is a mess: we are seeing spurious failures in CI on completely unrelated changes to the symbolize_process_symbolic_paths test. Attempting to reproduce locally them is denied with line noise such as:

> LeakSanitizer: CHECK failed: lsan_interceptors.cpp:82 "((!lsan_init_is_running)) != (0)" (0x0, 0x0) (tid=29001)

The suspicion is that more recent version of LLVM (compared to the CI environment) are b0rked.
In any event, AddressSanitizer comes with leak detection support and so let's just use that instead -- it hasn't caused any problems and we haven't seen any issues using it locally either.