### PR TITLE
Introduce KsymResolver::load_from_reader() constructor

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -879,9 +879,8 @@ impl Symbolizer {
         Ok(handler.all_symbols)
     }
 
-    fn create_ksym_resolver(&self, path: &Path, _file: &File) -> Result<Rc<KSymResolver>> {
-        // TODO: Should really use `file` and not `path` for the instantiation.
-        let resolver = KSymResolver::load_file_name(path.to_path_buf())?;
+    fn create_ksym_resolver(&self, path: &Path, file: &File) -> Result<Rc<KSymResolver>> {
+        let resolver = KSymResolver::load_from_reader(file, path)?;
         let resolver = Rc::new(resolver);
         Ok(resolver)
     }


### PR DESCRIPTION
Introduce the KsymResolver::load_from_reader() constructor, which:
1) allows us to better test the resolver, because we can provide an
   in-memory buffer
2) addresses a deficiency where, in the Symbolizer, we were effectively
   circumventing our FileCache construct and re-opening the kallsyms
   file by path