### PR TITLE
Speed up parsing of kallsyms data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Unreleased
   IDs when normalizing with `NormalizeOpts::map_files` equal to `false`
 - Adjusted `inspect::Inspector::for_each` to accept callback returning
   `std::ops::ControlFlow` to facilitate early termination
+- Improved `kallsyms` parsing performance to speed up overall kernel
+  address symbolization
 
 
 0.2.0-rc.1


### PR DESCRIPTION
It makes absolutely no sense for us to allocate a vector with the tokens of a line just to check its length and pick out the first three. Just use an iterator directly. This speeds up the kallsyms parsing code by a significant amount.

```
   $ cargo bench --features=nightly -- bench_parse_kallsyms
   > test ksym::tests::bench_parse_kallsyms  ... bench:   4,453,396.50 ns/iter (+/- 136,465.51)
```