### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,10 @@ jobs:
             rust: stable
             profile: release
             args: "--lib --no-default-features"
+          - runs-on: windows-latest
+            rust: stable
+            profile: dev
+            args: "--tests --features=dont-generate-unit-test-files"
           - runs-on: ubuntu-latest
             rust: stable
             profile: dev

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -179,9 +179,6 @@ mod tests {
 
     use std::io::Read as _;
     use std::io::Write as _;
-    use std::os::fd::AsRawFd as _;
-    #[cfg(not(windows))]
-    use std::os::unix::fs::symlink;
     use std::thread::sleep;
     use std::time::Duration;
 
@@ -225,6 +222,9 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn file_symlinks() {
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::fs::symlink;
+
         let tmpfile = NamedTempFile::new().unwrap();
         let tmpdir = tempdir().unwrap();
         let link = tmpdir.path().join("symlink");


### PR DESCRIPTION
Fix the Windows build for tests, which broke due to the recently added std::os::fd::AsRawFd import. Also add a CI job building tests for Windows to prevent regressions in the future.