### PR TITLE
cli: Add support for symbolizing kernel addresses

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added support for symbolization of kernel addresses
+
+
 0.1.6
 -----
 - Added `--procmap-query` option to `normalize user` sub-command

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -175,6 +175,7 @@ pub mod symbolize {
         Elf(Elf),
         Gsym(Gsym),
         Process(Process),
+        Kernel(Kernel),
     }
 
     #[derive(Debug, Arguments)]
@@ -245,5 +246,12 @@ pub mod symbolize {
         /// symbolic paths instead.
         #[clap(long)]
         pub no_map_files: bool,
+    }
+
+    #[derive(Debug, Arguments)]
+    pub struct Kernel {
+        /// The addresses to symbolize.
+        #[arg(value_parser = parse_addr)]
+        pub addrs: Vec<Addr>,
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -255,6 +255,13 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
             let input = symbolize::Input::AbsAddr(addrs);
             (src, input, addrs)
         }
+        args::symbolize::Symbolize::Kernel(args::symbolize::Kernel { ref addrs }) => {
+            let kernel = symbolize::Kernel::default();
+            let src = symbolize::Source::from(kernel);
+            let addrs = addrs.as_slice();
+            let input = symbolize::Input::AbsAddr(addrs);
+            (src, input, addrs)
+        }
     };
 
     let symbolizer = builder.build();


### PR DESCRIPTION
Add support for symbolization of kernel addresses to the program. Right now we do not expose any additional options and just rely on the "default" kernel symbolization source.

```
  $ cargo run -p blazecli -- symbolize kernel 0x0000000000019008 0xffffffffc005e378
  > 0x00000000019008: espfix_stack @ 0x19008+0x0
  > 0xffffffffc005e378: bpf_prog_6deef7357e7b4530_sd_fw_ingress @ 0xffffffffc005e2dc+0x9c
```