### PR TITLE
Sleep a bit between iterations in vma_comparison test

### DIFF
--- a/src/normalize/ioctl.rs
+++ b/src/normalize/ioctl.rs
@@ -258,6 +258,8 @@ mod tests {
 
     use std::env::current_exe;
     use std::fs::File;
+    use std::thread::sleep;
+    use std::time::Duration;
 
     use crate::maps;
 
@@ -390,6 +392,8 @@ mod tests {
             if from_text == from_ioctl {
                 break
             }
+
+            sleep(Duration::from_millis(500));
         }
 
         assert_eq!(from_text, from_ioctl, "{from_text:#x?}\n{from_ioctl:#x?}");


### PR DESCRIPTION
We are still seeing the occasional flake of the vma_comparison test, caused by a one page difference in the size of one of the memory regions.
In the hopes of achieving more of a quiesced state, sleep a bit between iterations in there.