### PR TITLE
Add benchmarks for BPF program kernel address symbolization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,11 +265,11 @@ jobs:
           data/test-stable-addrs*
           data/test-rs.bin
   test-partly-supported:
+    name: Test on ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         runs-on: [macos-latest, windows-latest]
-    name: Test on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     needs: [build-test-artifacts]
     steps:

--- a/src/kernel/bpf/prog.rs
+++ b/src/kernel/bpf/prog.rs
@@ -181,8 +181,8 @@ fn query_line_info(
     let prog_id = info.id;
 
     assert_eq!(
-        info.line_info_rec_size,
-        size_of::<sys::bpf_line_info>() as _
+        info.line_info_rec_size as usize,
+        size_of::<sys::bpf_line_info>()
     );
     let mut line_info = Vec::<sys::bpf_line_info>::with_capacity(info.nr_line_info as _);
     // SAFETY: `bpf_line_info` is valid for any bit pattern, so we

--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -606,7 +606,7 @@ ffffffffc212d000 t ftrace_trampoline    [__builtin__ftrace]
             .unwrap();
     }
 
-    /// Benchmark the parsing a kallsyms file.
+    /// Benchmark the parsing of the kallsyms file.
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_parse_kallsyms(b: &mut Bencher) {


### PR DESCRIPTION
Add benchmarks for the symbolization of BPF program kernel addresses.

```
  $ cargo bench --features=nightly -- bench_symbolize_kernel
  > test symbolize::symbolizer::tests::bench_symbolize_kernel_bpf_cached   ... bench:       2,154.55 ns/iter (+/- 15.81)
  > test symbolize::symbolizer::tests::bench_symbolize_kernel_bpf_uncached ... bench:  24,989,552.60 ns/iter (+/- 1,066,936.44)
```