### PR TITLE
Add more tests for KernelResolver

### DIFF
--- a/src/kernel/bpf/prog.rs
+++ b/src/kernel/bpf/prog.rs
@@ -189,7 +189,7 @@ fn query_line_info(
     //         can adjust the vector's length to its capacity.
     let () = unsafe { line_info.set_len(line_info.capacity()) };
 
-    assert_eq!(info.jited_line_info_rec_size, size_of::<u64>() as _);
+    assert_eq!(info.jited_line_info_rec_size as usize, size_of::<u64>());
     let mut jited_line_info = Vec::<u64>::with_capacity(info.nr_jited_line_info as _);
     // SAFETY: `u64` is valid for any bit pattern, so we can adjust
     //         the vector's length to its capacity.

--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -179,7 +179,7 @@ pub(crate) struct KSymResolver {
 
 impl KSymResolver {
     #[cfg(test)]
-    fn load_file_name(path: &Path) -> Result<Self> {
+    pub fn load_file_name(path: &Path) -> Result<Self> {
         let f = File::open(path)?;
         Self::load_from_reader(f, path)
     }

--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -70,3 +70,28 @@ impl Debug for KernelResolver {
         )
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::kernel::KALLSYMS;
+    use crate::ErrorKind;
+
+
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let ksym = Rc::new(KSymResolver::load_file_name(Path::new(KALLSYMS)).unwrap());
+        let kernel = KernelResolver::new(Some(ksym), None).unwrap();
+        assert_ne!(format!("{kernel:?}"), "");
+    }
+
+    /// Exercise the error path when no sub-resolver is provided.
+    #[test]
+    fn no_sub_resolver() {
+        let err = KernelResolver::new(None, None).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+    }
+}


### PR DESCRIPTION
Everything and anything pertaining kernel symbolization has been notoriously under-tested in the past. Add two tests for the KernelResolver in an attempt to start mitigating this situation somewhat and increasing our code coverage numbers.