### PR TITLE
cli: Add --map-files option to normalize user sub-command

### DIFF
--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -610,9 +610,9 @@ unsafe fn blaze_normalize_user_addrs_impl(
     let addrs = unsafe { slice_from_user_array(addrs, addr_cnt) };
     let result = normalizer.normalize_user_addrs_opts(pid.into(), &addrs, opts);
     match result {
-        Ok(addrs) => {
+        Ok(output) => {
             let output_box = Box::new(ManuallyDrop::into_inner(
-                blaze_normalized_user_output::from(addrs),
+                blaze_normalized_user_output::from(output),
             ));
             let () = set_last_err(blaze_err::BLAZE_ERR_OK);
             Box::into_raw(output_box)

--- a/capi/src/util.rs
+++ b/capi/src/util.rs
@@ -101,12 +101,12 @@ mod tests {
     #[test]
     fn slice_creation() {
         let slice = unsafe { slice_from_aligned_user_array::<u64>(ptr::null(), 0) };
-        assert_eq!(slice, &[]);
+        assert_eq!(slice, &[] as &[u64]);
 
         let array = [];
         let slice =
             unsafe { slice_from_aligned_user_array::<u64>(&array as *const _, array.len()) };
-        assert_eq!(slice, &[]);
+        assert_eq!(slice, &[] as &[u64]);
 
         let array = [42u64, 1337];
         let slice =
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn unaligned_slice_creation() {
         let slice = unsafe { slice_from_user_array(ptr::null::<u64>(), 0) };
-        assert_eq!(slice.deref(), &[]);
+        assert_eq!(slice.deref(), &[] as &[u64]);
 
         let mut buffer = [0u64; 8];
         let ptr = unsafe { buffer.as_mut_ptr().byte_add(3) };

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added support for symbolization of kernel addresses
+- Added `--map-files` option to `normalize user` sub-command
 
 
 0.1.6

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -156,6 +156,10 @@ pub mod normalize {
         /// Disable the reading of build IDs of the corresponding binaries.
         #[clap(long)]
         pub no_build_ids: bool,
+        /// Report `/proc/<pid>/map_files/` entry paths instead of
+        /// symbolic paths mentioned in `/proc/<pid>/maps`.
+        #[clap(long)]
+        pub map_files: bool,
         /// Enable the usage of the `PROCMAP_QUERY` ioctl instead of
         /// parsing `/proc/<pid>/maps` for getting available VMA ranges.
         #[clap(long)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,7 @@ use blazesym::helper::read_elf_build_id;
 use blazesym::inspect;
 use blazesym::inspect::Inspector;
 use blazesym::normalize;
+use blazesym::normalize::NormalizeOpts;
 use blazesym::normalize::Normalizer;
 use blazesym::symbolize;
 use blazesym::symbolize::Symbolizer;
@@ -139,14 +140,19 @@ fn normalize(normalize: args::normalize::Normalize) -> Result<()> {
             pid,
             addrs,
             no_build_ids,
+            map_files,
             procmap_query,
         }) => {
             let normalizer = Normalizer::builder()
                 .enable_build_ids(!no_build_ids)
                 .enable_procmap_query(procmap_query)
                 .build();
+            let opts = NormalizeOpts {
+                map_files,
+                ..Default::default()
+            };
             let normalized = normalizer
-                .normalize_user_addrs(pid, addrs.as_slice())
+                .normalize_user_addrs_opts(pid, addrs.as_slice(), &opts)
                 .context("failed to normalize addresses")?;
             for (addr, (output, meta_idx)) in addrs.iter().zip(&normalized.outputs) {
                 print!("{addr:#016x}: ");


### PR DESCRIPTION
Introduce the --map-files option to the 'normalize user' sub-command. This option can be used to switch over to reporting '/proc/<pid>/map_files/' paths as part of the address normalization process.

```
  $ cargo run -p blazecli -- normalize user --pid 13466 0x7fdf2b957000
  > 0x007fdf2b957000: file offset 0x357000 in /usr/lib64/libcrypto.so.3

  $ cargo run -p blazecli -- normalize user --pid 13466 0x7fdf2b957000 --map-files
  > 0x007fdf2b957000: file offset 0x357000 in /proc/13466/map_files/7fdf2b957000-7fdf2ba3c000
```