### PR TITLE
Add i686-unknown-linux-gnu as CI cross-compilation target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,7 @@ jobs:
           aarch64-linux-android,
           arm-linux-androideabi,
           armv7-linux-androideabi,
+          i686-unknown-linux-gnu,
           x86_64-unknown-linux-musl,
         ]
     steps:


### PR DESCRIPTION
Add i686-unknown-linux-gnu as a cross-compilation target in CI to have another one representing a 32 bit system.