### PR TITLE
Cross-compile blazesym-c in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
           target: ${{ matrix.target }}
       - run: |
           cargo build --lib
+          cargo build --package=blazesym-c --lib
   build-minimum:
     name: Build using minimum versions of dependencies
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make sure to cross-compile not just blazesym but also blazesym-c in CI for various targets.