### PR TITLE
cli: Add i686-unknown-linux-gnu build

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -22,6 +22,7 @@ jobs:
           aarch64-linux-android,
           arm-linux-androideabi,
           armv7-linux-androideabi,
+          i686-unknown-linux-gnu,
           x86_64-unknown-linux-musl,
         ]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Please update the build-cli workflow cross-compile matrix when
+        # adding a new target here.
         target: [
           aarch64-linux-android,
           arm-linux-androideabi,


### PR DESCRIPTION
Build `blazecli` for the `i686-unknown-linux-gnu` target, now that we build the main library for it as well.