### PR TITLE
Introduce 'linux' config alias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,9 @@ codegen-units = 1
 lto = false
 codegen-units = 256
 
+[build-dependencies]
+cfg_aliases = "0.2.1"
+
 [dependencies]
 cpp_demangle = {version = "0.4", optional = true}
 gimli = {version = "0.31", optional = true}

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,6 @@ use cfg_aliases::cfg_aliases;
 
 fn main() {
     cfg_aliases! {
-        linux: { target_os = "linux" },
+        linux: { any(target_os = "linux", target_os = "android") },
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    cfg_aliases! {
+        linux: { target_os = "linux" },
+    }
+}

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -39,5 +39,5 @@ xz2 = {version = "0.1.7", optional = true}
 zip = {version = "2.0.0", optional = true, default-features = false}
 zstd = {version = "0.13.1", default-features = false, optional = true}
 
-[target.'cfg(target_os = "linux")'.build-dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.build-dependencies]
 libbpf-sys = {version = "1.4.1", default-features = false, optional = true}

--- a/dev/build.rs
+++ b/dev/build.rs
@@ -32,7 +32,7 @@ fn data_dir() -> PathBuf {
 }
 
 /// Retrieve the system's page size.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn page_size() -> Result<usize> {
     // SAFETY: `sysconf` is always safe to call.
     let rc = unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) };
@@ -45,7 +45,7 @@ fn page_size() -> Result<usize> {
     Ok(usize::try_from(rc).unwrap())
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 fn page_size() -> Result<usize> {
     unimplemented!()
 }

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -19,7 +19,7 @@ struct FileMeta {
     inode: libc::ino_t,
     size: libc::off_t,
     mtime_sec: libc::time_t,
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     mtime_nsec: i64,
 }
 
@@ -32,7 +32,7 @@ impl From<&libc::stat> for FileMeta {
             inode: other.st_ino as _,
             size: other.st_size as _,
             mtime_sec: other.st_mtime,
-            #[cfg(target_os = "linux")]
+            #[cfg(linux)]
             mtime_nsec: other.st_mtime_nsec as _,
         }
     }
@@ -219,7 +219,7 @@ mod tests {
 
     /// Check that our `FileCache` does not represent symbolic links
     /// pointing to the same file as equal entries.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     #[test]
     fn file_symlinks() {
         use std::os::fd::AsRawFd as _;

--- a/src/kernel/bpf/mod.rs
+++ b/src/kernel/bpf/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(linux))]
 compile_error!("BPF support is only present on Linux, please disable `bpf` feature");
 
 mod btf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
     )),
     allow(dead_code, unused_imports)
 )]
-#![cfg_attr(not(target_os = "linux"), allow(dead_code, unused_imports))]
+#![cfg_attr(not(linux), allow(dead_code, unused_imports))]
 
 
 #[cfg(feature = "nightly")]

--- a/src/normalize/ioctl.rs
+++ b/src/normalize/ioctl.rs
@@ -139,7 +139,7 @@ fn vma_flags_to_perm(vma_flags: u64) -> Perm {
 /// The caller is responsible for checking that the returned `MapsEntry`
 /// actually covers the provided address. If it does not, it represents
 /// the next known entry.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 pub(crate) fn query_procmap(
     file: &File,
     pid: Pid,
@@ -224,7 +224,7 @@ pub(crate) fn query_procmap(
     Ok(Some(entry))
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(linux))]
 pub(crate) fn query_procmap(
     _file: &File,
     _pid: Pid,

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -412,7 +412,7 @@ mod tests {
     }
 
     /// Check that we can normalize user addresses.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     // `libc` on Arm doesn't have `__errno_location`.
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     #[test]

--- a/src/symbolize/perf_map.rs
+++ b/src/symbolize/perf_map.rs
@@ -311,7 +311,7 @@ mod tests {
     }
 
     /// Check that we can symbolize an address using a perf map.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     #[test]
     #[ignore = "test requires python 3.12 or higher"]
     fn symbolize_perf_map() {

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -36,7 +36,7 @@ use crate::symbolize::InlinedFn;
 use crate::symbolize::Resolve;
 use crate::symbolize::TranslateFileOffset;
 use crate::util;
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 use crate::util::uname_release;
 use crate::util::Dbg;
 #[cfg(feature = "tracing")]
@@ -891,7 +891,7 @@ impl Symbolizer {
         Ok(resolver)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     fn create_kernel_resolver(&self, src: &Kernel) -> Result<KernelResolver> {
         let Kernel {
             kallsyms,
@@ -954,7 +954,7 @@ impl Symbolizer {
         KernelResolver::new(ksym_resolver.cloned(), elf_resolver.cloned())
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(linux))]
     fn create_kernel_resolver(&self, _src: &Kernel) -> Result<KernelResolver> {
         Err(Error::with_unsupported(
             "kernel address symbolization is unsupported on operating systems other than Linux",
@@ -1375,7 +1375,7 @@ impl Default for Symbolizer {
 mod tests {
     use super::*;
 
-    #[cfg(all(target_os = "linux", feature = "nightly"))]
+    #[cfg(all(linux, feature = "nightly"))]
     use test::Bencher;
 
     use test_log::test;
@@ -1384,7 +1384,7 @@ mod tests {
     use crate::symbolize;
     use crate::symbolize::CodeInfo;
     use crate::test_helper::find_the_answer_fn_in_zip;
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     use crate::test_helper::with_bpf_symbolization_target_addrs;
 
 
@@ -1694,7 +1694,7 @@ mod tests {
     }
 
     /// Test symbolization of a kernel address inside a BPF program.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     #[test]
     fn symbolize_kernel_bpf_program() {
         with_bpf_symbolization_target_addrs(|handle_getpid, subprogram| {
@@ -1731,7 +1731,7 @@ mod tests {
     }
 
     /// Benchmark the symbolization of BPF program kernel addresses.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_symbolize_kernel_bpf_uncached(b: &mut Bencher) {
@@ -1754,7 +1754,7 @@ mod tests {
 
     /// Benchmark the symbolization of BPF program kernel addresses when
     /// relevant data is readily cached.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_symbolize_kernel_bpf_cached(b: &mut Bencher) {

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -58,7 +58,7 @@ pub(crate) fn find_the_answer_fn_in_zip(mmap: &Mmap) -> (inspect::SymInfo<'stati
 }
 
 
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 mod bpf {
     use super::*;
 
@@ -166,5 +166,5 @@ mod bpf {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 pub(crate) use bpf::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -280,7 +280,7 @@ pub fn stat(path: &Path) -> io::Result<libc::stat> {
 }
 
 
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 #[cfg(test)]
 #[allow(clippy::absolute_paths)]
 fn fstat(fd: std::os::unix::io::RawFd) -> io::Result<libc::stat> {
@@ -295,7 +295,7 @@ fn fstat(fd: std::os::unix::io::RawFd) -> io::Result<libc::stat> {
 }
 
 
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 pub(crate) fn uname_release() -> io::Result<CString> {
     let mut dst = MaybeUninit::uninit();
     let rc = unsafe { libc::uname(dst.as_mut_ptr()) };
@@ -741,7 +741,7 @@ mod tests {
 
     /// Check that we can retrieve meta-data about a file using `stat`
     /// and `fstat`.
-    #[cfg(target_os = "linux")]
+    #[cfg(linux)]
     #[test]
     fn file_stating() {
         use std::os::fd::AsRawFd as _;

--- a/tests/allocs.rs
+++ b/tests/allocs.rs
@@ -4,7 +4,7 @@
     clippy::let_and_return,
     clippy::let_unit_value
 )]
-#![cfg_attr(not(target_os = "linux"), allow(dead_code, unused_imports))]
+#![cfg_attr(not(linux), allow(dead_code, unused_imports))]
 
 use std::alloc::GlobalAlloc;
 use std::alloc::Layout;
@@ -56,7 +56,7 @@ unsafe impl GlobalAlloc for TracingAlloc {
 
 /// Normalize addresses in the current process and print allocation
 /// statistics.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 #[test]
 fn normalize_process() {
     let region = Region::new(&GLOBAL);

--- a/tests/blazesym.rs
+++ b/tests/blazesym.rs
@@ -3,7 +3,7 @@
     clippy::let_and_return,
     clippy::let_unit_value
 )]
-#![cfg_attr(not(target_os = "linux"), allow(dead_code, unused_imports))]
+#![cfg_attr(not(linux), allow(dead_code, unused_imports))]
 
 use std::collections::HashMap;
 use std::env;
@@ -16,7 +16,7 @@ use std::io::Read as _;
 use std::io::Write as _;
 use std::ops::ControlFlow;
 use std::ops::Deref as _;
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 use std::os::unix::ffi::OsStringExt as _;
 use std::path::Path;
 use std::process::Command;
@@ -699,7 +699,7 @@ fn symbolize_process() {
 
 /// Check that we can symbolize an address in a process using a binary
 /// located in a local mount namespace.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 #[test]
 fn symbolize_process_in_mount_namespace() {
     use libc::kill;
@@ -806,7 +806,7 @@ fn symbolize_process_with_custom_dispatch() {
 }
 
 /// Check that we can normalize addresses in an ELF shared object.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 #[test]
 fn normalize_elf_addr() {
     fn test(so: &str, map_files: bool) {
@@ -872,7 +872,7 @@ fn normalize_elf_addr() {
 
 
 /// Check that we can enable/disable the reading of build IDs.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 #[test]
 fn normalize_build_id_reading() {
     fn test(read_build_ids: bool) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,7 +15,7 @@ use libc::uid_t;
 
 
 /// Run a function with a different effective user ID.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 pub fn as_user<F, R>(ruid: uid_t, euid: uid_t, f: F) -> R
 where
     F: FnOnce() -> R + UnwindSafe,
@@ -44,7 +44,7 @@ where
     result.unwrap()
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(linux))]
 pub fn as_user<F, R>(ruid: uid_t, euid: uid_t, f: F) -> R
 where
     F: FnOnce() -> R + UnwindSafe,

--- a/tests/permission.rs
+++ b/tests/permission.rs
@@ -3,9 +3,9 @@
     clippy::let_and_return,
     clippy::let_unit_value
 )]
-#![cfg_attr(not(target_os = "linux"), allow(dead_code, unused_imports))]
+#![cfg_attr(not(linux), allow(dead_code, unused_imports))]
 
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 mod common;
 
 use std::fs::copy;
@@ -35,7 +35,7 @@ fn symbolize_no_permission_impl(path: &Path) {
 
 /// Check that we fail symbolization as expected when we don't have the
 /// permission to open the symbolization source.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 #[test]
 fn symbolize_no_permission() {
     use common::as_user;

--- a/tests/permissionless.rs
+++ b/tests/permissionless.rs
@@ -3,9 +3,9 @@
     clippy::let_and_return,
     clippy::let_unit_value
 )]
-#![cfg_attr(not(target_os = "linux"), allow(dead_code, unused_imports))]
+#![cfg_attr(not(linux), allow(dead_code, unused_imports))]
 
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 mod common;
 
 use std::io::Error;
@@ -75,7 +75,7 @@ fn normalize_permissionless_impl(pid: Pid, addr: Addr, test_lib: &Path) {
     );
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 fn run_test<F>(callback_fn: F)
 where
     F: FnOnce(Pid, u64, &Path) + UnwindSafe,
@@ -145,7 +145,7 @@ where
 
 /// Check that we can symbolize an address in a process using only
 /// symbolic paths.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 #[test]
 fn symbolize_process_symbolic_paths() {
     run_test(symbolize_permissionless_impl)
@@ -153,7 +153,7 @@ fn symbolize_process_symbolic_paths() {
 
 /// Check that we can normalize an address in a process using only
 /// symbolic paths.
-#[cfg(target_os = "linux")]
+#[cfg(linux)]
 #[test]
 fn normalize_process_symbolic_paths() {
     run_test(normalize_permissionless_impl)


### PR DESCRIPTION
Introduce a cfg alias for the `target_os = "linux"` dance. Right now this is effectively just a syntactic simplification, but down the line it will allow us to more easily also capture Android -- as a Linux variant -- under the Linux umbrella.