### PR TITLE
capi: Enable 'bpf' feature of main library

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -57,7 +57,7 @@ which = {version = "6.0.0", optional = true}
 # Pinned, because we use #[doc(hidden)] APIs.
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["apk", "demangle", "gsym", "zlib"]}
+blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["apk", "bpf", "demangle", "dwarf", "gsym", "zlib"]}
 libc = "0.2.137"
 # TODO: Remove dependency one MSRV is 1.77.
 memoffset = "0.9"


### PR DESCRIPTION
To the degree that is possible, we intend to only ship a single version of blazesym-c, which means that it should have relevant features enabled. It's generally useful to have support for the recently added BPF program symbolization included as well, so enable the 'bpf' feature of the main library. We also enable 'dwarf', but that's just to make it more obvious that it's enabled, as it actually is enabled by default.