### PR TITLE
Cross-compile with 'bpf' feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,7 @@ jobs:
           target: ${{ matrix.target }}
       - run: |
           cargo build --lib
+          cargo build --lib --features=bpf
           cargo build --package=blazesym-c --lib
   build-minimum:
     name: Build using minimum versions of dependencies


### PR DESCRIPTION
The 'bpf' feature is expected to work on all Linux flavors for all supported target architectures etc. Make sure to do our various cross compilations with it enabled, to check that nothing blows up.