### PR TITLE
Use file size in file offset -> virtual offset translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Unreleased
   `std::ops::ControlFlow` to facilitate early termination
 - Improved `kallsyms` parsing performance to speed up overall kernel
   address symbolization
+- Fixed incorrect file offset to virtual offset translation, resulting
+  in wrong symbolization in certain binaries
 - Bumped minimum supported Rust version to `1.69`
 
 

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -878,7 +878,7 @@ impl ElfParser {
         let phdrs = self.program_headers()?;
         let addr = phdrs.iter().find_map(|phdr| {
             if phdr.p_type == PT_LOAD {
-                if (phdr.p_offset..phdr.p_offset + phdr.p_memsz).contains(&offset) {
+                if (phdr.p_offset..phdr.p_offset + phdr.p_filesz).contains(&offset) {
                     return Some((offset - phdr.p_offset + phdr.p_vaddr) as Addr)
                 }
             }


### PR DESCRIPTION
We were seeing an issue where normalization + file offset symbolization was reporting an incorrect symbolization result for certain addresses in a certain binary.
In short, in a binary with segments:

```
  > Type  Offset     VirtAddr           PhysAddr           FileSiz    MemSiz     Flg Align
  > LOAD  0x949be40  0x000000000969be40 0x000000000969be40 0x11d6c930 0x11d6c930 R E 0x200000
  > LOAD  0x1b208780 0x000000001b409780 0x000000001b409780 0x01b5e8   0x01c1f0   RW  0x1000
  > LOAD  0x1b224980 0x000000001b426980 0x000000001b426980 0x343888   0xca594c   RW  0x1000
  > LOAD  0x1b600000 0x000000001c200000 0x000000001c200000 0x4a358ac  0x4a358ac  R E 0x200000
```

We were normalizing absolute address 0x1c23b4d0 to file offset 0x1b63b4d0. That's based on the calculation

```
  > 0x1c23b4d0 - 0x1c200000 /*VirtAddr*/ + 0x1b600000 /*Offset*/ = 0x1b63b4d0
```

When subsequently symbolizing the file offset we were looking up the wrong segment, because we took into account the segment's memory size:

```
  > 0x1b63b4d0 is in [0x1b224980 /*Offset*/, 0x1b224980 + 0xca594c /*MemSiz*/ = 0x1beca2cc]
```

Because this first fitting segment comes before the one we used as part of normalization, we continued symbolizing virtual offset

```
  > 0x1b63b4d0 - 0x1b224980 /*Offset*/ + 0x1b426980 /*VirtAddr*/ = 0x1b83d4d0
```

which lead to a wrong symbolization. By matching up segments based on the file size instead, we pick the correct segment instead:
```
  > 0x1b63b4d0 is *not* in [0x1b224980 /*Offset*/, 0x1b224980 + 0x343888 /*FileSiz*/ = 0x1b568208]
  > 0x1b63b4d0 is in [0x1b600000 /*Offset*/, 0x1b600000 + 0x4a358ac /*FileSiz*/ = 0x200358ac]
```

So we end up symbolizing virtual offset

```
  > 0x1b63b4d0 - 0x1b600000 /*Offset*/ + 0x1c200000 /*VirtAddr*/ = 0x1c23b4d0
```

which leads to the correct symbolization result.