### PR TITLE
Get rid of cfg_aliases build dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,9 +116,6 @@ codegen-units = 1
 lto = false
 codegen-units = 256
 
-[build-dependencies]
-cfg_aliases = "0.2.1"
-
 [dependencies]
 cpp_demangle = {version = "0.4", optional = true}
 gimli = {version = "0.31", optional = true}

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,10 @@
-use cfg_aliases::cfg_aliases;
+use std::env;
+
 
 fn main() {
-    cfg_aliases! {
-        linux: { any(target_os = "linux", target_os = "android") },
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "linux" || target_os == "android" {
+        println!("cargo:rustc-cfg=linux");
     }
+    println!("cargo:rustc-check-cfg=cfg(linux)");
 }


### PR DESCRIPTION
As it turns out cfg_aliases does a borderline trivial thing, in that it basically just checks an environment variable and emits one or two lines of 'cargo:' directives. When a build system other than Cargo is used that does not honor build scripts we end up having to craft similar logic ourselves. In such an instance, all cfg_aliases does is obfuscate what is really going on.
So we might as well just include the logic ourselves and get rid of the build dependency, given that we have to do it in one shape or form anyway.