### PR TITLE
capi: Make 'bpf' feature conditional on target OS

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -57,10 +57,13 @@ which = {version = "6.0.0", optional = true}
 # Pinned, because we use #[doc(hidden)] APIs.
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["apk", "bpf", "demangle", "dwarf", "gsym", "zlib"]}
+blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "zlib"]}
 libc = "0.2.137"
 # TODO: Remove dependency one MSRV is 1.77.
 memoffset = "0.9"
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["bpf"]}
 
 [dev-dependencies]
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,8 +38,11 @@ grev = "0.1.3"
 anyhow = "1.0.68"
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["apk", "bpf", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
+blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
 clap = {version = "4.1.7", features = ["derive"]}
 clap_complete = {version = "4.1.1", optional = true}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["ansi", "env-filter", "fmt"]}
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["bpf"]}


### PR DESCRIPTION
Enable the 'bpf' feature on the main library only for target OSs that support it.