### PR TITLE
Add end-to-end test for #875

### DIFF
--- a/data/test-block-augmented.ld
+++ b/data/test-block-augmented.ld
@@ -1,0 +1,10 @@
+/* Linker script meant to augment the default one and insert some
+ * fill bytes at a relatively low address (hopefully before any of the
+ * regular relevant code. */
+
+SECTIONS {
+  .whatevs (0x100000): {
+    FILL(0xdead)
+    . = ABSOLUTE(. + 0x300000);
+  }
+}

--- a/data/test-block.c
+++ b/data/test-block.c
@@ -1,0 +1,46 @@
+/* A binary basically just blocking waiting for input and exiting. It also write
+ * the address of its `_start` function to stdout (unformatted; just a byte
+ * dump).
+ *
+ * It uses raw system calls to avoid dependency on libc, which pulls in
+ * start up code and various other artifacts that perturb ELF layout in
+ * semi-unforeseeable ways, in an attempt to provide us with maximum
+ * control over the final binary.
+ *
+ * Likely only works on x86_64.
+ */
+
+#include <unistd.h>
+#include <sys/syscall.h>
+
+
+void _start(void) {
+  char buf[2];
+  int rc;
+  void* addr = (void*)&_start;
+  /* Write the address of `_start` to stderr. We use stderr because it's
+     unbuffered, so we spare ourselves from the pains of writing a
+     newline as well... */
+  asm volatile (
+      "syscall"
+      : "=a"(rc)
+      : "a"(SYS_write), "D"(STDERR_FILENO), "S"(&addr), "d"(sizeof(addr))
+      : "rcx", "r11", "memory"
+  );
+  asm volatile (
+      "syscall"
+      : "=a"(rc)
+      : "a"(SYS_read), "D"(STDIN_FILENO), "S"(buf), "d"(sizeof(buf))
+      : "rcx", "r11", "memory"
+  );
+  if (rc > 0) {
+    /* No error, so we can exit successfully. */
+    rc = 0;
+  }
+  asm volatile (
+      "syscall"
+      : "=a"(rc)
+      : "a"(SYS_exit), "D"(rc)
+      : "rcx", "r11", "memory"
+  );
+}

--- a/dev/build.rs
+++ b/dev/build.rs
@@ -477,6 +477,18 @@ fn prepare_test_files() {
     let src = data_dir.join("test-mnt-ns.c");
     cc(&src, "test-mnt-ns.bin", &[]);
 
+    let src = data_dir.join("test-block.c");
+    let ld_script = data_dir.join("test-block-augmented.ld");
+    let args = &[
+        "-static",
+        "-Wl,--build-id=none",
+        "-nostdlib",
+        // Just passing the linker script as "regular" input file causes
+        // it to "augment" the default linker script.
+        ld_script.to_str().unwrap(),
+    ];
+    cc(&src, "test-block.bin", args);
+
     cc_stable_addrs(
         "test-stable-addrs.bin",
         &["-gdwarf-4", "-Wl,--build-id=none", "-O0"],


### PR DESCRIPTION
Add an end-to-end test for the fix provided by pull request #875. The test basically normalizes an address in a specially crafted binary and symbolizes the resulting file offset. It fails without commit 1a4e10740652 ("Use file size in file offset -> virtual offset translation"), because then the file offset to virtual offset translation produces a virtual offset that can't be symbolized to the expected _start function.