### PR TITLE
Bump version to 0.2.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Unreleased
+0.2.0-rc.2
 ----------
 - Added support for symbolizing BPF kernel program addresses including
   source code information

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default-members = ["."]
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "=0.2.0-rc.1"
+blazesym = "=0.2.0-rc.2"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 - Fixed various functions accepting `uintptr_t` addresses, when they
   really should be using `uint64_t`
 - Introduced `blaze_read_elf_build_id` helper
+- Bumped `blazesym` dependency to `0.2.0-rc.2`
 
 
 0.1.0-rc.1

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -57,13 +57,13 @@ which = {version = "7.0.0", optional = true}
 # Pinned, because we use #[doc(hidden)] APIs.
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "zlib"]}
+blazesym = {version = "=0.2.0-rc.2", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "zlib"]}
 libc = "0.2.137"
 # TODO: Remove dependency one MSRV is 1.77.
 memoffset = "0.9"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["bpf"]}
+blazesym = {version = "=0.2.0-rc.2", path = "../", features = ["bpf"]}
 
 [dev-dependencies]
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Added support for symbolization of kernel addresses
 - Added `--map-files` option to `normalize user` sub-command
+- Bumped `blazesym` dependency to `0.2.0-rc.2`
 
 
 0.1.6

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,11 +38,11 @@ grev = "0.1.3"
 anyhow = "1.0.68"
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
+blazesym = {version = "=0.2.0-rc.2", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
 clap = {version = "4.1.7", features = ["derive"]}
 clap_complete = {version = "4.1.1", optional = true}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["ansi", "env-filter", "fmt"]}
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-blazesym = {version = "=0.2.0-rc.1", path = "../", features = ["bpf"]}
+blazesym = {version = "=0.2.0-rc.2", path = "../", features = ["bpf"]}

--- a/cli/README.md
+++ b/cli/README.md
@@ -63,5 +63,5 @@ the list of supported shells.
 
 [blazecli-bins]: https://github.com/libbpf/blazesym/actions/workflows/build.yml
 [blazesym]: https://crates.io/crates/blazesym
-[blazesym-sym]: https://docs.rs/blazesym/0.2.0-rc.1/blazesym/symbolize/struct.Symbolizer.html
-[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-rc.1/blazesym/symbolize/enum.Source.html#variant.Elf
+[blazesym-sym]: https://docs.rs/blazesym/0.2.0-rc.2/blazesym/symbolize/struct.Symbolizer.html
+[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-rc.2/blazesym/symbolize/enum.Source.html#variant.Elf

--- a/examples/gsym-in-apk/Cargo.toml
+++ b/examples/gsym-in-apk/Cargo.toml
@@ -11,7 +11,7 @@ name = "gsym-in-apk"
 path = "main.rs"
 
 [dependencies]
-blazesym = {version = "=0.2.0-rc.1", path = "../..", default-features = false, features = [
+blazesym = {version = "=0.2.0-rc.2", path = "../..", default-features = false, features = [
   "apk",
   "gsym",
 ]}

--- a/examples/sym-debuginfod/Cargo.toml
+++ b/examples/sym-debuginfod/Cargo.toml
@@ -12,7 +12,7 @@ path = "main.rs"
 
 [dependencies]
 anyhow = "1.0"
-blazesym = {version = "=0.2.0-rc.1", path = "../..", features = ["tracing"]}
+blazesym = {version = "=0.2.0-rc.2", path = "../..", features = ["tracing"]}
 clap = {version = "4.4", features = ["derive", "string"]}
 debuginfod = {version = "0.1.1", features = ["fs-cache", "tracing"]}
 tracing = "0.1"


### PR DESCRIPTION
This change bumps the version of the crate to 0.2.0-rc.2.