### PR TITLE
capi: Bump version to 0.1.0-rc.2

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,4 +1,4 @@
-Unreleased
+0.1.0-rc.2
 ----------
 - Fixed various functions accepting `uintptr_t` addresses, when they
   really should be using `uint64_t`

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym-c"
 description = "C bindings for blazesym"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Daniel Müller <deso@posteo.net>"]

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1,7 +1,7 @@
 /*
  * Please refer to the documentation hosted at
  *
- *   https://docs.rs/blazesym-c/0.1.0-rc.1
+ *   https://docs.rs/blazesym-c/0.1.0-rc.2
  */
 
 


### PR DESCRIPTION
This change bumps the blazesym-c's version to `0.1.0-rc.2`. The following notable changes have been made since `0.1.0-rc.1`:
- Fixed various functions accepting `uintptr_t` addresses, when they really should be using `uint64_t`
- Introduced `blaze_read_elf_build_id` helper
- Bumped `blazesym` dependency to `0.2.0-rc.2`