### PR TITLE
cli: Bump version to 0.1.7

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.7
+-----
 - Added support for symbolization of kernel addresses
 - Added `--map-files` option to `normalize user` sub-command
 - Bumped `blazesym` dependency to `0.2.0-rc.2`

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazecli"
 description = "A command line utility for the blazesym library."
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.69"
 default-run = "blazecli"


### PR DESCRIPTION
This change bumps blazecli's version to 0.1.7. The following notable changes have been made since 0.1.6:
- Added support for symbolization of kernel addresses
- Added '--map-files' option to 'normalize user' sub-command
- Bumped blazesym dependency to 0.2.0-rc.2