### PR TITLE
Use workspace-wide definitions for various meta-data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,23 @@ members = [
 # --workspace is specified.
 default-members = ["."]
 
+[workspace.package]
+edition = "2021"
+rust-version = "1.69"
+license = "BSD-3-Clause"
+repository = "https://github.com/libbpf/blazesym"
+homepage = "https://github.com/libbpf/blazesym"
+
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
 version = "0.2.0-rc.2"
-edition = "2021"
-rust-version = "1.69"
+edition.workspace = true
+rust-version.workspace = true
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]
-license = "BSD-3-Clause"
-repository = "https://github.com/libbpf/blazesym"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 readme = "README.md"
 categories = [
   "algorithms",

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -2,11 +2,12 @@
 name = "blazesym-c"
 description = "C bindings for blazesym"
 version = "0.1.0-rc.2"
-edition = "2021"
-rust-version = "1.69"
+edition.workspace = true
+rust-version.workspace = true
 authors = ["Daniel Müller <deso@posteo.net>"]
-license = "BSD-3-Clause"
-repository = "https://github.com/libbpf/blazesym"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 readme = "README.md"
 categories = [
   "algorithms",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,11 +2,12 @@
 name = "blazecli"
 description = "A command line utility for the blazesym library."
 version = "0.1.7"
-edition = "2021"
-rust-version = "1.69"
+edition.workspace = true
+rust-version.workspace = true
 default-run = "blazecli"
-license = "BSD-3-Clause"
-repository = "https://github.com/libbpf/blazesym"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 readme = "README.md"
 categories = [
   "api-bindings",


### PR DESCRIPTION
As it turns out Cargo now allows us to define certain Cargo meta-data in a workspace-wide manner and then more easily reuse that. We intend to update things such as the edition or supported Rust version for all crates in the workspace. This makes those properties (and others) perfect candidates for this infrastructure.
With this change we switch over to using workspace-wide properties for a bunch of meta-data.