### PR TITLE
cli: Strip pre-built binaries

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
       - run: |
-          cargo install --path=cli --root=. --target ${{ matrix.target }}
+          CARGO_PROFILE_RELEASE_DEBUG=false CARGO_PROFILE_RELEASE_STRIP=true cargo install --path=cli --root=. --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: blazecli-${{ matrix.target }}

--- a/cli/README.md
+++ b/cli/README.md
@@ -41,7 +41,7 @@ process` sub-command can be used. Please refer to the program's help
 text for additional details.
 
 Pre-built, statically linked binaries for various target triples are available
-on-demand [here][blazecli-bins].
+on-demand [here][blazecli-bins] as well as attached to each published release.
 
 
 ### Shell Completion


### PR DESCRIPTION
Our pre-built binaries are arguably excessively large, because they carry debug and symbol information in them. That may or may not be a reasonable default when building manually, but it may be making the wrong trade-off for pre-built binaries.
For the time being, build those binaries with debug and symbol information stripped.