### PR TITLE
Remove caching from push-only CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,7 +260,6 @@ jobs:
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
     - run: cargo check --package=blazesym-dev --features=generate-unit-test-files
     - uses: actions/upload-artifact@v4
       with:
@@ -284,7 +283,6 @@ jobs:
         name: test-stable-addrs
         path: data/
     - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
     - run: cargo test --tests --release --features=blazesym-dev/dont-generate-unit-test-files -- ':other_os:'
   test-sanitizers:
     name: Test with ${{ matrix.sanitizer }} sanitizer
@@ -398,7 +396,6 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - name: Install required tools
       run: sudo apt-get install -y llvm-14
-    - uses: Swatinem/rust-cache@v2
     - name: Run benchmarks
       shell: bash
       run: |


### PR DESCRIPTION
Some of our CI jobs only run as part of a push to main and not on the pull request preceding it. Runtime of these jobs is effectively irrelevant, because they are not blocking everything. We are constantly at the disk usage limit of our caches in the CI infrastructure and so it makes sense to relieve some pressure from it by eliminating the caches used by these jobs.