### PR TITLE
capi: Reference 'reason' more prominently in blaze_sym struct

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -639,6 +639,8 @@ typedef struct blaze_sym {
    * The symbol name is where the given address should belong to.
    *
    * If an address could not be symbolized, this member will be NULL.
+   * Check the `reason` member for additional information pertaining
+   * the failure.
    */
   const char *name;
   /**

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -437,6 +437,8 @@ pub struct blaze_sym {
     /// The symbol name is where the given address should belong to.
     ///
     /// If an address could not be symbolized, this member will be NULL.
+    /// Check the `reason` member for additional information pertaining
+    /// the failure.
     pub name: *const c_char,
     /// The address at which the symbol is located (i.e., its "start").
     ///


### PR DESCRIPTION
Reference the 'reason' member more prominently inside the documentation of the blaze_sym type, to make it easier to discover.