### PR TITLE
Split up integration test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ test = []
 nightly = []
 
 [[test]]
-name = "blazesym"
+name = "integration"
 required-features = ["test"]
 
 [[example]]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,10 @@
+//! Integration tests for blazesym.
+
+#![allow(
+    clippy::fn_to_numeric_cast,
+    clippy::let_and_return,
+    clippy::let_unit_value
+)]
+#![cfg_attr(not(linux), allow(dead_code, unused_imports))]
+
+mod suite;

--- a/tests/suite/inspect.rs
+++ b/tests/suite/inspect.rs
@@ -1,0 +1,386 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs::read as read_file;
+use std::ops::ControlFlow;
+use std::ops::Deref as _;
+use std::path::Path;
+use std::str;
+
+use blazesym::inspect;
+use blazesym::inspect::Inspector;
+use blazesym::symbolize;
+use blazesym::SymType;
+
+use test_log::test;
+
+
+/// Check that we can look up an address.
+#[test]
+fn inspect_elf() {
+    fn test(src: inspect::Source, no_vars: bool) {
+        let inspector = Inspector::new();
+        let results = inspector
+            .lookup(&src, &["factorial", "a_variable"])
+            .unwrap();
+        assert_eq!(results.len(), 2);
+
+        let result = &results[0];
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].addr, 0x2000100);
+        assert_eq!(result[0].sym_type, SymType::Function);
+        assert_ne!(result[0].file_offset, None);
+        assert_eq!(
+            result[0].obj_file_name.as_deref().unwrap(),
+            src.path().unwrap()
+        );
+
+        let result = &results[1];
+        if no_vars {
+            assert!(result.is_empty(), "{result:#x?}");
+        } else {
+            assert_eq!(result.len(), 1);
+            assert_eq!(result[0].addr, 0x4001100);
+            assert_eq!(result[0].sym_type, SymType::Variable);
+            assert_ne!(result[0].file_offset, None);
+            assert_eq!(
+                result[0].obj_file_name.as_deref().unwrap(),
+                src.path().unwrap()
+            );
+        }
+    }
+
+    let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-stripped-elf-with-dwarf.bin");
+    let src = inspect::Source::Elf(inspect::Elf::new(test_dwarf));
+    // Our `DwarfResolver` type does not currently support look up of
+    // variables.
+    let no_vars = true;
+    let () = test(src, no_vars);
+
+    let test_elf = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs.bin");
+    for debug_syms in [true, false] {
+        let mut elf = inspect::Elf::new(&test_elf);
+        elf.debug_syms = debug_syms;
+        let src = inspect::Source::Elf(elf);
+        let () = test(src, false);
+    }
+
+    let test_elf = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-no-dwarf.bin");
+    let mut elf = inspect::Elf::new(test_elf);
+    assert!(elf.debug_syms);
+    elf.debug_syms = false;
+    let src = inspect::Source::Elf(elf);
+    let () = test(src, false);
+}
+
+
+/// Check that we can look up a symbol by name in a Breakpad file.
+#[test]
+fn inspect_breakpad() {
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs.sym");
+    let breakpad = inspect::Breakpad::new(path);
+    let src = inspect::Source::from(breakpad);
+
+    let inspector = Inspector::new();
+    let results = inspector
+        .lookup(&src, &["factorial"])
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
+
+    let sym = &results[0];
+    assert_eq!(sym.name, "factorial");
+    assert_eq!(sym.addr, 0x100);
+    assert_eq!(sym.sym_type, SymType::Function);
+    assert_eq!(sym.file_offset, None);
+    assert_eq!(sym.obj_file_name, None);
+}
+
+
+/// Make sure that we can look up a dynamic symbol in an ELF file.
+#[test]
+fn inspect_elf_dynamic_symbol() {
+    #[track_caller]
+    fn test(bin: &str) {
+        let bin = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join(bin);
+
+        let src = inspect::Source::Elf(inspect::Elf::new(&bin));
+        let inspector = Inspector::new();
+        let results = inspector
+            .lookup(&src, &["the_answer"])
+            .unwrap()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(results.len(), 1);
+
+        let src = symbolize::Source::Elf(symbolize::Elf::new(&bin));
+        let symbolizer = symbolize::Symbolizer::new();
+        let result = symbolizer
+            .symbolize_single(&src, symbolize::Input::VirtOffset(results[0].addr))
+            .unwrap()
+            .into_sym()
+            .unwrap();
+
+        assert_eq!(result.name, "the_answer");
+        assert_eq!(result.addr, results[0].addr);
+    }
+
+    test("libtest-so.so");
+    test("libtest-so-stripped.so");
+    test("libtest-so-partly-stripped.so");
+}
+
+/// Make sure that we can look up an indirect in an ELF file.
+#[test]
+fn inspect_elf_indirect_function() {
+    let bin = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-no-dwarf.bin");
+
+    let src = inspect::Source::Elf(inspect::Elf::new(&bin));
+    let inspector = Inspector::new();
+    let results = inspector
+        .lookup(&src, &["indirect_func"])
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
+
+    let src = symbolize::Source::Elf(symbolize::Elf::new(&bin));
+    let symbolizer = symbolize::Symbolizer::new();
+    let result = symbolizer
+        .symbolize_single(&src, symbolize::Input::VirtOffset(results[0].addr))
+        .unwrap()
+        .into_sym()
+        .unwrap();
+
+    // Both functions may legitimately have the same address.
+    assert!(["indirect_func", "resolve_indirect_func"].contains(&result.name.deref()));
+    assert_eq!(result.addr, results[0].addr);
+}
+
+
+/// Read four bytes at the given `offset` in the file identified by `path`.
+fn read_4bytes_at(path: &Path, offset: u64) -> [u8; 4] {
+    let offset = offset as usize;
+    let content = read_file(path).unwrap();
+    let slice = &content[offset..offset + 4];
+    <[u8; 4]>::try_from(slice).unwrap()
+}
+
+
+/// Check that we can correctly retrieve the file offset in an ELF file.
+#[test]
+fn inspect_elf_file_offset() {
+    fn test(file: &str) {
+        let test_elf = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join(file);
+        let elf = inspect::Elf::new(test_elf);
+        let src = inspect::Source::Elf(elf);
+
+        let inspector = Inspector::new();
+        let results = inspector
+            .lookup(&src, &["dummy"])
+            .unwrap()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(results.len(), 1);
+
+        let result = &results[0];
+        assert_ne!(result.file_offset, None);
+        let bytes = read_4bytes_at(src.path().unwrap(), result.file_offset.unwrap());
+        assert_eq!(bytes, [0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    for file in [
+        "test-stable-addrs-no-dwarf.bin",
+        "test-stable-addrs-stripped-with-link.bin",
+    ] {
+        let () = test(file);
+    }
+}
+
+
+/// Check that we can iterate over all symbols in a symbolization source.
+#[test]
+fn inspect_elf_dwarf_breakpad_all_symbols() {
+    fn test(src: &inspect::Source) {
+        let breakpad = matches!(src, inspect::Source::Breakpad(..));
+        let dwarf = matches!(
+            src,
+            inspect::Source::Elf(inspect::Elf {
+                debug_syms: true,
+                ..
+            })
+        );
+        let inspector = Inspector::new();
+        let mut syms = HashMap::<String, inspect::SymInfo>::new();
+        let () = inspector
+            .for_each(src, |sym| {
+                let _inserted = syms.insert(sym.name.to_string(), sym.to_owned());
+                ControlFlow::Continue(())
+            })
+            .unwrap();
+
+        // Breakpad and DWARF don't contain any or any reasonable information
+        // for some symbols.
+        if !breakpad {
+            let sym = syms.get("main").unwrap();
+            assert_eq!(sym.sym_type, SymType::Function);
+        }
+
+        let sym = syms.get("factorial").unwrap();
+        assert_eq!(sym.sym_type, SymType::Function);
+
+        let sym = syms.get("factorial_wrapper").unwrap();
+        assert_eq!(sym.sym_type, SymType::Function);
+
+        let sym = syms.get("factorial_inline_test").unwrap();
+        assert_eq!(sym.sym_type, SymType::Function);
+
+        if !breakpad && !dwarf {
+            let sym = syms.get("indirect_func").unwrap();
+            assert_eq!(sym.sym_type, SymType::Function);
+        }
+
+        let sym = syms.get("my_indirect_func").unwrap();
+        assert_eq!(sym.sym_type, SymType::Function);
+
+        let sym = syms.get("resolve_indirect_func").unwrap();
+        assert_eq!(sym.sym_type, SymType::Function);
+
+        if !breakpad && !dwarf {
+            let sym = syms.get("a_variable").unwrap();
+            assert_eq!(sym.sym_type, SymType::Variable);
+        }
+    }
+
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-no-dwarf.bin");
+    let mut elf = inspect::Elf::new(path);
+    elf.debug_syms = false;
+    let src = inspect::Source::Elf(elf);
+    test(&src);
+
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-stripped-elf-with-dwarf.bin");
+    let elf = inspect::Elf::new(path);
+    let src = inspect::Source::Elf(elf);
+    test(&src);
+
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs.sym");
+    let breakpad = inspect::Breakpad::new(path);
+    let src = inspect::Source::Breakpad(breakpad);
+    test(&src);
+}
+
+
+/// Check that early stopping of symbol iteration works as expected.
+#[test]
+fn inspect_elf_dwarf_breakpad_early_iter_stop() {
+    fn test(src: &inspect::Source) {
+        let mut i = 0;
+        let inspector = Inspector::new();
+        let () = inspector
+            .for_each(src, |_sym| {
+                if i == 0 {
+                    i += 1;
+                    ControlFlow::Break(())
+                } else {
+                    panic!()
+                }
+            })
+            .unwrap();
+    }
+
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-no-dwarf.bin");
+    let mut elf = inspect::Elf::new(path);
+    elf.debug_syms = false;
+    let src = inspect::Source::Elf(elf);
+    test(&src);
+
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-stripped-elf-with-dwarf.bin");
+    let elf = inspect::Elf::new(path);
+    let src = inspect::Source::Elf(elf);
+    test(&src);
+
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs.sym");
+    let breakpad = inspect::Breakpad::new(path);
+    let src = inspect::Source::Breakpad(breakpad);
+    test(&src);
+}
+
+
+/// Make sure that the `debug_syms` flag is honored.
+#[test]
+fn inspect_debug_syms_flag() {
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-no-dwarf.bin");
+    let mut elf = inspect::Elf::new(path);
+    elf.debug_syms = true;
+    let src = inspect::Source::Elf(elf);
+    let inspector = Inspector::new();
+    // There aren't any debug symbols in the source (although there are ELF
+    // symbols).
+    let () = inspector.for_each(&src, |_sym| panic!()).unwrap();
+
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-stripped-elf-with-dwarf.bin");
+    let mut elf = inspect::Elf::new(path);
+    elf.debug_syms = false;
+    let src = inspect::Source::Elf(elf);
+    // There aren't any ELF symbols in the source (although there are DWARF
+    // symbols).
+    let () = inspector.for_each(&src, |_sym| panic!()).unwrap();
+}
+
+
+/// Check that we can iterate over all symbols in an ELF file, without
+/// encountering duplicates caused by dynamic/static symbol overlap.
+#[test]
+fn inspect_elf_all_symbols_without_duplicates() {
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("libtest-so.so");
+    let mut elf = inspect::Elf::new(path);
+    elf.debug_syms = false;
+    let src = inspect::Source::Elf(elf);
+
+    let inspector = Inspector::new();
+    let mut syms = Vec::<String>::new();
+    let () = inspector
+        .for_each(&src, |sym| {
+            let () = syms.push(sym.name.to_string());
+            ControlFlow::Continue(())
+        })
+        .unwrap();
+
+    assert_eq!(syms.iter().filter(|name| *name == "the_answer").count(), 1);
+}

--- a/tests/suite/mod.rs
+++ b/tests/suite/mod.rs
@@ -1,0 +1,3 @@
+mod inspect;
+mod normalize;
+mod symbolize;

--- a/tests/suite/normalize.rs
+++ b/tests/suite/normalize.rs
@@ -1,0 +1,434 @@
+use std::env;
+use std::ffi::CString;
+use std::fs::copy;
+use std::io;
+#[cfg(linux)]
+use std::os::unix::ffi::OsStringExt as _;
+use std::path::Path;
+use std::str;
+
+use blazesym::helper::read_elf_build_id;
+use blazesym::normalize;
+use blazesym::normalize::NormalizeOpts;
+use blazesym::normalize::Normalizer;
+use blazesym::symbolize;
+use blazesym::Addr;
+use blazesym::Mmap;
+use blazesym::Pid;
+use blazesym::__private::find_the_answer_fn;
+use blazesym::__private::zip;
+
+use scopeguard::defer;
+
+use tempfile::tempdir;
+
+use test_log::test;
+
+
+/// Check that we detect unsorted input addresses.
+#[test]
+fn normalize_unsorted_err() {
+    let mut addrs = [
+        libc::atexit as Addr,
+        libc::chdir as Addr,
+        libc::fopen as Addr,
+    ];
+    let () = addrs.sort();
+    let () = addrs.swap(0, 1);
+
+    let opts = NormalizeOpts {
+        sorted_addrs: true,
+        ..Default::default()
+    };
+    let normalizer = Normalizer::new();
+    let err = normalizer
+        .normalize_user_addrs_opts(Pid::Slf, addrs.as_slice(), &opts)
+        .unwrap_err();
+    assert!(err.to_string().contains("are not sorted"), "{err}");
+}
+
+/// Check that we handle unknown addresses as expected.
+#[test]
+fn normalize_unknown_addrs() {
+    // The very first page of the address space should never be
+    // mapped, so use addresses from there.
+    let addrs = [0x500 as Addr, 0x600 as Addr];
+
+    let normalizer = Normalizer::new();
+    let normalized = normalizer
+        .normalize_user_addrs(Pid::Slf, addrs.as_slice())
+        .unwrap();
+    assert_eq!(normalized.outputs.len(), 2);
+    assert_eq!(normalized.meta.len(), 1);
+    assert_eq!(
+        normalized.meta[0],
+        normalize::Unknown {
+            reason: normalize::Reason::Unmapped,
+            _non_exhaustive: ()
+        }
+        .into()
+    );
+    assert_eq!(normalized.outputs[0].1, 0);
+    assert_eq!(normalized.outputs[1].1, 0);
+}
+
+/// Check that we can normalize user addresses in our own process.
+#[cfg(linux)]
+// `libc` on Arm doesn't have `__errno_location`.
+#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+#[test]
+fn normalization_self() {
+    fn test(normalizer: &Normalizer) {
+        let addrs = [
+            libc::__errno_location as Addr,
+            libc::dlopen as Addr,
+            libc::fopen as Addr,
+            normalize_unknown_addrs as Addr,
+            normalization_self as Addr,
+            normalize::Normalizer::new as Addr,
+        ];
+
+        let (errno_idx, _) = addrs
+            .iter()
+            .enumerate()
+            .find(|(_idx, addr)| **addr == libc::__errno_location as Addr)
+            .unwrap();
+
+        let normalized = normalizer
+            .normalize_user_addrs(Pid::Slf, addrs.as_slice())
+            .unwrap();
+        assert_eq!(normalized.outputs.len(), 6);
+
+        let outputs = &normalized.outputs;
+        let meta = &normalized.meta;
+        assert_eq!(meta.len(), 2);
+
+        let errno_meta_idx = outputs[errno_idx].1;
+        assert!(meta[errno_meta_idx]
+            .as_elf()
+            .unwrap()
+            .path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .contains("libc.so"));
+    }
+
+    let normalizer = Normalizer::new();
+    test(&normalizer);
+
+    let normalizer = Normalizer::builder().enable_vma_caching(true).build();
+    test(&normalizer);
+    test(&normalizer);
+}
+
+/// Check that we can normalize addresses in an ELF shared object.
+#[cfg(linux)]
+#[test]
+fn normalize_elf_addr() {
+    fn test(so: &str, map_files: bool) {
+        let test_so = Path::new(&env!("CARGO_MANIFEST_DIR")).join("data").join(so);
+        let so_cstr = CString::new(test_so.clone().into_os_string().into_vec()).unwrap();
+        let handle = unsafe { libc::dlopen(so_cstr.as_ptr(), libc::RTLD_NOW) };
+        assert!(!handle.is_null());
+        defer!({
+            let rc = unsafe { libc::dlclose(handle) };
+            assert_eq!(rc, 0, "{}", io::Error::last_os_error());
+        });
+
+        let the_answer_addr = unsafe { libc::dlsym(handle, "the_answer\0".as_ptr().cast()) };
+        assert!(!the_answer_addr.is_null());
+
+        let opts = NormalizeOpts {
+            sorted_addrs: true,
+            map_files,
+            ..Default::default()
+        };
+        let normalizer = Normalizer::new();
+        let normalized = normalizer
+            .normalize_user_addrs_opts(Pid::Slf, [the_answer_addr as Addr].as_slice(), &opts)
+            .unwrap();
+        assert_eq!(normalized.outputs.len(), 1);
+        assert_eq!(normalized.meta.len(), 1);
+
+        let output = normalized.outputs[0];
+        let meta = &normalized.meta[output.1];
+        let path = &meta.as_elf().unwrap().path;
+        assert_eq!(
+            path.to_str().unwrap().contains("/map_files/"),
+            map_files,
+            "{path:?}"
+        );
+        assert_eq!(path.canonicalize().unwrap(), test_so);
+
+        let elf = symbolize::Elf::new(test_so);
+        let src = symbolize::Source::Elf(elf);
+        let symbolizer = symbolize::Symbolizer::new();
+        let result = symbolizer
+            .symbolize_single(&src, symbolize::Input::FileOffset(output.0))
+            .unwrap()
+            .into_sym()
+            .unwrap();
+
+        assert_eq!(result.name, "the_answer");
+
+        let results = symbolizer
+            .symbolize(&src, symbolize::Input::FileOffset(&[output.0]))
+            .unwrap();
+        assert_eq!(results.len(), 1);
+
+        let sym = results[0].as_sym().unwrap();
+        assert_eq!(sym.name, "the_answer");
+    }
+
+    for map_files in [false, true] {
+        test("libtest-so.so", map_files);
+        test("libtest-so-no-separate-code.so", map_files);
+    }
+}
+
+/// Check that we can normalize user addresses in our own shared object.
+#[test]
+fn normalize_custom_so() {
+    let test_so = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("libtest-so.so");
+
+    let mmap = Mmap::builder().exec().open(&test_so).unwrap();
+    let (sym, the_answer_addr) = find_the_answer_fn(&mmap);
+
+    let normalizer = Normalizer::new();
+    let normalized = normalizer
+        .normalize_user_addrs(Pid::Slf, [the_answer_addr as Addr].as_slice())
+        .unwrap();
+    assert_eq!(normalized.outputs.len(), 1);
+    assert_eq!(normalized.meta.len(), 1);
+
+    let output = normalized.outputs[0];
+    assert_eq!(output.0, sym.file_offset.unwrap());
+    let meta = &normalized.meta[output.1];
+    let expected_elf = normalize::Elf {
+        build_id: Some(read_elf_build_id(&test_so).unwrap().unwrap()),
+        path: test_so.clone(),
+        _non_exhaustive: (),
+    };
+    assert_eq!(meta, &normalize::UserMeta::Elf(expected_elf));
+}
+
+/// Check that we can normalize addresses in our own shared object inside a
+/// zip archive.
+#[test]
+fn normalize_custom_so_in_zip() {
+    fn test(so_name: &str) {
+        let test_zip = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join("test.zip");
+
+        let mmap = Mmap::builder().exec().open(&test_zip).unwrap();
+        let archive = zip::Archive::with_mmap(mmap.clone()).unwrap();
+        let so = archive
+            .entries()
+            .find_map(|entry| {
+                let entry = entry.unwrap();
+                (entry.path == Path::new(so_name)).then_some(entry)
+            })
+            .unwrap();
+
+        let elf_mmap = mmap
+            .constrain(so.data_offset..so.data_offset + so.data.len() as u64)
+            .unwrap();
+        let (sym, the_answer_addr) = find_the_answer_fn(&elf_mmap);
+
+        let opts = NormalizeOpts {
+            sorted_addrs: true,
+            ..Default::default()
+        };
+        let normalizer = Normalizer::new();
+        let normalized = normalizer
+            .normalize_user_addrs_opts(Pid::Slf, [the_answer_addr as Addr].as_slice(), &opts)
+            .unwrap();
+        assert_eq!(normalized.outputs.len(), 1);
+        assert_eq!(normalized.meta.len(), 1);
+
+        let expected_offset = so.data_offset + sym.file_offset.unwrap();
+        let output = normalized.outputs[0];
+        assert_eq!(output.0, expected_offset);
+        let meta = &normalized.meta[output.1];
+        let expected = normalize::Apk {
+            path: test_zip.clone(),
+            _non_exhaustive: (),
+        };
+        assert_eq!(meta, &normalize::UserMeta::Apk(expected));
+
+        // Also symbolize the normalization output.
+        let apk = symbolize::Apk::new(test_zip);
+        let src = symbolize::Source::Apk(apk);
+        let symbolizer = symbolize::Symbolizer::new();
+        let result = symbolizer
+            .symbolize_single(&src, symbolize::Input::FileOffset(output.0))
+            .unwrap()
+            .into_sym()
+            .unwrap();
+
+        assert_eq!(result.name, "the_answer");
+
+        let results = symbolizer
+            .symbolize(&src, symbolize::Input::FileOffset(&[output.0]))
+            .unwrap();
+        assert_eq!(results.len(), 1);
+
+        let sym = results[0].as_sym().unwrap();
+        assert_eq!(sym.name, "the_answer");
+    }
+
+    test("libtest-so.so");
+    test("libtest-so-no-separate-code.so");
+}
+
+fn test_normalize_deleted_so(use_procmap_query: bool) {
+    fn test(use_procmap_query: bool, cache_vmas: bool, cache_build_ids: bool, use_map_files: bool) {
+        let test_so = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join("libtest-so.so");
+        let dir = tempdir().unwrap();
+        let tmp_so = dir.path().join("libtest-so.so");
+        let _count = copy(&test_so, &tmp_so).unwrap();
+
+        let mmap = Mmap::builder().exec().open(&tmp_so).unwrap();
+        let (sym, the_answer_addr) = find_the_answer_fn(&mmap);
+
+        // Remove the temporary directory and with it the mapped shared
+        // object.
+        let () = drop(dir);
+
+        let opts = NormalizeOpts {
+            sorted_addrs: false,
+            map_files: use_map_files,
+            ..Default::default()
+        };
+        let normalizer = Normalizer::builder()
+            .enable_procmap_query(use_procmap_query)
+            .enable_vma_caching(cache_vmas)
+            .enable_build_id_caching(cache_build_ids)
+            .build();
+        let normalized = normalizer
+            .normalize_user_addrs_opts(Pid::Slf, [the_answer_addr as Addr].as_slice(), &opts)
+            .unwrap();
+        assert_eq!(normalized.outputs.len(), 1);
+        assert_eq!(normalized.meta.len(), 1);
+
+        let output = normalized.outputs[0];
+        assert_eq!(output.0, sym.file_offset.unwrap());
+        let meta = &normalized.meta[output.1].as_elf().unwrap();
+        let expected_build_id = if use_map_files || use_procmap_query {
+            Some(read_elf_build_id(&test_so).unwrap().unwrap())
+        } else {
+            None
+        };
+
+        assert_eq!(meta.build_id, expected_build_id);
+    }
+
+    for cache_build_ids in [true, false] {
+        for cache_vmas in [true, false] {
+            for use_map_files in [true, false] {
+                let () = test(
+                    use_procmap_query,
+                    cache_build_ids,
+                    cache_vmas,
+                    use_map_files,
+                );
+            }
+        }
+    }
+}
+
+/// Check that we can normalize user addresses in a shared object
+/// that has been deleted already (but is still mapped) without
+/// errors.
+#[test]
+fn normalize_deleted_so_proc_maps() {
+    test_normalize_deleted_so(false)
+}
+
+/// Check that we can normalize user addresses in a shared object
+/// that has been deleted already (but is still mapped) without
+/// errors.
+#[test]
+#[ignore = "test requires PROCMAP_QUERY ioctl kernel support"]
+fn normalize_deleted_so_ioctl() {
+    test_normalize_deleted_so(true)
+}
+
+/// Check that we can enable/disable the reading of build IDs.
+#[cfg(linux)]
+#[test]
+fn normalize_build_id_reading() {
+    fn test(read_build_ids: bool) {
+        let test_so = Path::new(&env!("CARGO_MANIFEST_DIR"))
+            .join("data")
+            .join("libtest-so.so");
+        let so_cstr = CString::new(test_so.clone().into_os_string().into_vec()).unwrap();
+        let handle = unsafe { libc::dlopen(so_cstr.as_ptr(), libc::RTLD_NOW) };
+        assert!(!handle.is_null());
+
+        let the_answer_addr = unsafe { libc::dlsym(handle, "the_answer\0".as_ptr().cast()) };
+        assert!(!the_answer_addr.is_null());
+
+        let opts = NormalizeOpts {
+            sorted_addrs: true,
+            ..Default::default()
+        };
+        let normalizer = Normalizer::builder()
+            .enable_build_ids(read_build_ids)
+            .build();
+        let normalized = normalizer
+            .normalize_user_addrs_opts(Pid::Slf, [the_answer_addr as Addr].as_slice(), &opts)
+            .unwrap();
+        assert_eq!(normalized.outputs.len(), 1);
+        assert_eq!(normalized.meta.len(), 1);
+
+        let rc = unsafe { libc::dlclose(handle) };
+        assert_eq!(rc, 0, "{}", io::Error::last_os_error());
+
+        let output = normalized.outputs[0];
+        let meta = &normalized.meta[output.1];
+        let elf = meta.as_elf().unwrap();
+        assert_eq!(elf.path, test_so);
+        if read_build_ids {
+            let expected = read_elf_build_id(&test_so).unwrap().unwrap();
+            assert_eq!(elf.build_id.as_ref().unwrap(), &expected);
+        } else {
+            assert_eq!(elf.build_id, None);
+        }
+    }
+
+    test(true);
+    test(false);
+}
+
+/// Make sure that when using the `map_files` normalization option,
+/// we never end up reporting a path referencing "self".
+#[test]
+fn normalize_no_self_vma_path_reporting() {
+    let opts = NormalizeOpts {
+        sorted_addrs: true,
+        map_files: true,
+        ..Default::default()
+    };
+    let normalizer = Normalizer::new();
+    let normalized = normalizer
+        .normalize_user_addrs_opts(
+            Pid::Slf,
+            [normalize_no_self_vma_path_reporting as Addr].as_slice(),
+            &opts,
+        )
+        .unwrap();
+
+    assert_eq!(normalized.outputs.len(), 1);
+    assert_eq!(normalized.meta.len(), 1);
+    let output = normalized.outputs[0];
+    let meta = &normalized.meta[output.1];
+    let elf = meta.as_elf().unwrap();
+    assert!(!elf.path.to_string_lossy().contains("self"), "{elf:?}");
+}


### PR DESCRIPTION
Split up the integration test suite into symbolize, normalize, and inspect modules. Doing so mirrors what we are already doing for benchmarks and is just a more logical grouping all things considered. While at it, rename the integration test suite from 'blazesym', which is quite ambiguous and prevalent throughout the code base, to 'integration'.