### PR TITLE
capi: Allow non_camel_case_types lint

### DIFF
--- a/capi/src/error.rs
+++ b/capi/src/error.rs
@@ -7,7 +7,6 @@ use blazesym::ErrorKind;
 /// An enum providing a rough classification of errors.
 ///
 /// C ABI compatible version of [`blazesym::ErrorKind`].
-#[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum blaze_err {

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -30,6 +30,7 @@
 //! ```
 
 #![allow(
+    non_camel_case_types,
     clippy::collapsible_if,
     clippy::fn_to_numeric_cast,
     clippy::let_and_return,
@@ -85,11 +86,8 @@ macro_rules! input_sanitize {
 
 mod error;
 mod helper;
-#[allow(non_camel_case_types)]
 mod inspect;
-#[allow(non_camel_case_types)]
 mod normalize;
-#[allow(non_camel_case_types)]
 mod symbolize;
 mod util;
 


### PR DESCRIPTION
Allow the non_camel_case_types lint throughout the entire crate, as it is common to use non-camcel case types when interacting with C code.