### PR TITLE
Add BPF programs to "format" matrix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ format supports and whether **blazesym** can currently use this feature:
 | Ksym          | symbol size                      | ✖️                    | ✖️                      |
 |               | source code location information | ✖️                    | ✖️                      |
 |               | inlined function information     | ✖️                    | ✖️                      |
+| BPF program   | symbol size                      | ✖️ (?)                | ✖️                      |
+|               | source code location information | ✔️                    | ✔️                      |
+|               | inlined function information     | ✖️                    | ✖️                      |
 
 
 Here is rough roadmap of currently planned features (in no particular order):


### PR DESCRIPTION
Extend the "format" table in the README with lines detailing the support for BPF programs.