### PR TITLE
Provide libtest-so* files to MacOS and Windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,6 +266,7 @@ jobs:
         path: |
           data/test-stable-addrs*
           data/test-rs.bin
+          data/libtest-so*
   test-partly-supported:
     name: Test on ${{ matrix.runs-on }}
     strategy:


### PR DESCRIPTION
Make sure to provide libtest-so* files to the MacOS and Windows test workflows, because some of the tests may want to use them.