### PR TITLE
Incorporate Clippy reported suggestions

### DIFF
--- a/src/dwarf/location.rs
+++ b/src/dwarf/location.rs
@@ -108,7 +108,7 @@ impl<'unit, 'dwarf> LocationRangeUnitIter<'unit, 'dwarf> {
     }
 }
 
-impl<'unit, 'dwarf> Iterator for LocationRangeUnitIter<'unit, 'dwarf> {
+impl<'unit> Iterator for LocationRangeUnitIter<'unit, '_> {
     type Item = (u64, u64, Location<'unit>);
 
     fn next(&mut self) -> Option<(u64, u64, Location<'unit>)> {

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -341,6 +341,7 @@ impl<'dwarf> Units<'dwarf> {
     }
 
     /// Find the list of inlined functions that contain `probe`.
+    #[allow(clippy::type_complexity)]
     pub(super) fn find_inlined_functions<'slf>(
         &'slf self,
         probe: u64,


### PR DESCRIPTION
Incorporate some suggestions made by Clippy that cause CI to fail with newer versions of Rust.