### PR TITLE
Properly read e_ident separately

### DIFF
--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -1,7 +1,7 @@
 use crate::util::Pod;
 use crate::SymType;
 
-const EI_NIDENT: usize = 16;
+pub(crate) const EI_NIDENT: usize = 16;
 
 type Elf64_Addr = u64;
 type Elf64_Half = u16;


### PR DESCRIPTION
It's not entirely correct to read the fully blown Elf64_Ehdr object and only then look at the e_ident contained in it: if the ELF file is a 32 bit thing then only a Elf32_Ehdr would be present. This type is smaller meaning that the read of a larger object could legitimately fail (of course that would only happen if no other data is present, which is at best possible in artificially constructed cases). With this change we make sure to read the e_ident array first, check that we properly support the file, and only continue then.