### PR TITLE
cli: Bump version to 0.1.8

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.8
+-----
 - Significantly shortened tracing output when enabled (via `-v`)
 
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazecli"
 description = "A command line utility for the blazesym library."
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 default-run = "blazecli"


### PR DESCRIPTION
This change bumps blazecli's version to 0.1.8. The following notable changes have been made since 0.1.7:
- Significantly shortened tracing output when enabled (via -v)