### PR TITLE
capi: Remove a bunch of unnecessary cbindgen options

### DIFF
--- a/capi/cbindgen.toml
+++ b/capi/cbindgen.toml
@@ -18,17 +18,3 @@ item_types = ["globals", "enums", "structs", "unions", "typedefs", "opaque", "fu
 
 [fn]
 args = "Vertical"
-rename_args = "none"
-
-[struct]
-associated_constants_in_body = true
-derive_eq = true
-derive_ostream = true
-
-[enum]
-add_sentinel = false
-derive_helper_methods = true
-derive_ostream = true
-
-[macro_expansion]
-bitflags = true


### PR DESCRIPTION
Remove a bunch of unnecessary cbindgen options from the configuration. It makes no sense to set a config such as derive_ostream, when we are generating a C header. Others are just what is the default or similarly have no bearing on the generated header.