### PR TITLE
Store decompressed ELF section data inside Cache

### DIFF
--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -86,6 +86,13 @@ where
         }
     }
 
+    pub fn len(&self) -> usize {
+        match self {
+            Self::B32(slice) => slice.len(),
+            Self::B64(slice) => slice.len(),
+        }
+    }
+
     pub fn iter(&self) -> impl ExactSizeIterator<Item = ElfN<'elf, T>> {
         match self {
             Self::B32(slice) => Either::A(slice.iter().map(ElfN::B32)),


### PR DESCRIPTION
So far we have layered the decompression of ELF section data on top of our internal Cache type. In an attempt to co-locate everything cached better, move this logic into a new method inside the Cache type. Note that we cannot possibly make decompression fully transparent, because once we decompress we necessarily end up with a lifetime shorter lived than 'mmap.