### PR TITLE
Remove no longer necessary llvm-18 CI dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y llvm-18 gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: Check incremental rebuilds
@@ -171,7 +171,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y llvm-18 gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
@@ -255,7 +255,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y llvm-18 gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo check --package=blazesym-dev --features=generate-unit-test-files
@@ -300,11 +300,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.sanitizer }}
-    - name: Enable debug symbols
-      run: |
-          # to get the symbolizer for debug symbol resolution
-          sudo apt-get install -y llvm-18
-          cat Cargo.toml
     - name: cargo test -Zsanitizer=${{ matrix.sanitizer }}
       env:
         # TODO: Ideally we'd set CFLAGS and CXXFLAGS as well, but some
@@ -322,7 +317,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y llvm-18 gcc-multilib libelf-dev zlib1g-dev liblzma-dev
+      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev liblzma-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
@@ -388,7 +383,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y llvm-18 gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: Run benchmarks


### PR DESCRIPTION
We install the llvm-18 package in a couple of our jobs for <reasons>. Said <reasons> no longer seem to hold for <other-reasons> now, presumably because of the runner image upgrade, but who wants to investigate black box behavior with an iteration time of multiple minutes. Regardless, stop installing the package.