### PR TITLE
cli: Add --no-debug-syms option to 'inspect dump elf' sub-command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `--no-debug-syms` option to `inspect dump elf` sub-command
+
+
 0.1.8
 -----
 - Significantly shortened tracing output when enabled (via `-v`)

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -129,6 +129,9 @@ pub mod inspect {
         /// The path to the ELF file.
         #[clap(short, long)]
         pub path: PathBuf,
+        /// Dump ELF symbols instead of DWARF ones.
+        #[clap(long)]
+        pub no_debug_syms: bool,
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -109,8 +109,13 @@ fn inspect(inspect: args::inspect::Inspect) -> Result<()> {
                 args::inspect::Dump::Breakpad(args::inspect::BreakpadDump { path }) => {
                     inspect::Source::from(inspect::Breakpad::new(path))
                 }
-                args::inspect::Dump::Elf(args::inspect::ElfDump { path }) => {
-                    inspect::Source::from(inspect::Elf::new(path))
+                args::inspect::Dump::Elf(args::inspect::ElfDump {
+                    path,
+                    no_debug_syms,
+                }) => {
+                    let mut elf = inspect::Elf::new(path);
+                    elf.debug_syms = !no_debug_syms;
+                    inspect::Source::from(elf)
                 }
             };
             let mut sym_infos = Vec::new();


### PR DESCRIPTION
Introduce the --no-debug-syms option to the 'inspect dump elf' sub-command, so that users can decide whether to dump DWARF or ELF symbols.