### PR TITLE
Return boxed slice from query_line_info() helper

### DIFF
--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -341,7 +341,6 @@ impl<'dwarf> Units<'dwarf> {
     }
 
     /// Find the list of inlined functions that contain `probe`.
-    #[allow(clippy::type_complexity)]
     pub(super) fn find_inlined_functions<'slf>(
         &'slf self,
         probe: u64,

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -259,7 +259,6 @@ struct Cache<'mmap> {
     /// The cached dynamic symbol table.
     dynsym: OnceCell<SymbolTableCache<'mmap>>,
     /// The section data.
-    #[allow(clippy::type_complexity)]
     section_data: OnceCell<Box<[OnceCell<Cow<'mmap, [u8]>>]>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,8 @@
     clippy::collapsible_if,
     clippy::fn_to_numeric_cast,
     clippy::let_and_return,
-    clippy::let_unit_value
+    clippy::let_unit_value,
+    clippy::type_complexity
 )]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -618,7 +618,6 @@ impl<'tmp, 'slf: 'tmp> Resolver<'tmp, 'slf> {
 /// Please note that demangling results are not cached.
 #[derive(Debug)]
 pub struct Symbolizer {
-    #[allow(clippy::type_complexity)]
     #[cfg(feature = "apk")]
     apk_cache: FileCache<(zip::Archive, InsertMap<Range<u64>, Box<dyn Resolve>>)>,
     #[cfg(feature = "breakpad")]


### PR DESCRIPTION
Return a boxed slice from the query_line_info() helper function, to make it clear that the result is not meant to be resized and to cut down on unnecessary information being stored (the vector's capacity).