### PR TITLE
Convert Path into Rc<Path> more directly

### DIFF
--- a/src/kernel/bpf/prog.rs
+++ b/src/kernel/bpf/prog.rs
@@ -13,7 +13,6 @@ use std::os::fd::AsFd as _;
 use std::os::fd::AsRawFd as _;
 use std::os::fd::BorrowedFd;
 use std::path::Path;
-use std::path::PathBuf;
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -244,7 +243,7 @@ fn query_line_info(
             // around.
             let path = match file_cache.entry(file) {
                 Entry::Vacant(vacancy) => {
-                    let path = Rc::<Path>::from(PathBuf::from(file).into_boxed_path());
+                    let path = Rc::<Path>::from(Path::new(file));
                     vacancy.insert(path)
                 }
                 Entry::Occupied(occupancy) => occupancy.into_mut(),


### PR DESCRIPTION
In the query_line_info() helper function, we convert a Path into a PathBuf into a Box<Path> into an Rc<Path>. However, it turns out there exists a direct conversion from Path to Rc<Path>, so use that instead.