### PR TITLE
Add "offset" argument to ElfNSlice::iter

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -985,7 +985,7 @@ impl ElfParser {
     // method instead.
     pub(crate) fn find_file_offset(&self, addr: Addr) -> Result<Option<u64>> {
         let phdrs = self.program_headers()?;
-        let offset = phdrs.iter().find_map(|phdr| {
+        let offset = phdrs.iter(0).find_map(|phdr| {
             let phdr = phdr.to_64bit();
 
             if phdr.p_type == PT_LOAD {
@@ -1019,7 +1019,7 @@ impl ElfParser {
     /// Translate a file offset into a virtual offset.
     pub(crate) fn file_offset_to_virt_offset(&self, offset: u64) -> Result<Option<Addr>> {
         let phdrs = self.program_headers()?;
-        let addr = phdrs.iter().find_map(|phdr| {
+        let addr = phdrs.iter(0).find_map(|phdr| {
             let phdr = phdr.to_64bit();
             if phdr.p_type == PT_LOAD {
                 if (phdr.p_offset..phdr.p_offset + phdr.p_filesz).contains(&offset) {

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -82,10 +82,10 @@ where
         }
     }
 
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = ElfN<'elf, T>> {
+    pub fn iter(&self, start_idx: usize) -> impl ExactSizeIterator<Item = ElfN<'elf, T>> {
         match self {
-            Self::B32(slice) => Either::A(slice.iter().map(ElfN::B32)),
-            Self::B64(slice) => Either::B(slice.iter().map(ElfN::B64)),
+            Self::B32(slice) => Either::A(slice[start_idx..].iter().map(|x| ElfN::B32(x))),
+            Self::B64(slice) => Either::B(slice[start_idx..].iter().map(|x| ElfN::B64(x))),
         }
     }
 }

--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -22,7 +22,7 @@ pub type BuildId<'src> = Cow<'src, [u8]>;
 /// [`NT_GNU_BUILD_ID`][elf::types::NT_GNU_BUILD_ID].
 fn read_build_id_from_notes(parser: &ElfParser) -> Result<Option<BuildId<'_>>> {
     let shdrs = parser.section_headers()?;
-    for (idx, shdr) in shdrs.iter().enumerate() {
+    for (idx, shdr) in shdrs.iter(0).enumerate() {
         if shdr.type_() == elf::types::SHT_NOTE {
             // SANITY: We just found the index so the section data should always
             //         be found.


### PR DESCRIPTION
So far iteration over an `ElfNSlice` was assumed to always start with the slice's first element. With upcoming changes we are going to adjust that, similarly to how things already work for `ElfN_BoxedSyms`. With this change we introduce a start index argument to the `ElfNSlice::iter()` method, which causes iteration to start at said index.