### PR TITLE
Introduce address based index to ELF symbol table cache

### DIFF
--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -68,6 +68,18 @@ impl<'elf, T> ElfNSlice<'elf, T>
 where
     T: Has32BitTy,
 {
+    pub fn empty(tybit32: bool) -> Self {
+        if tybit32 {
+            Self::B32(&[])
+        } else {
+            Self::B64(&[])
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn get(&self, idx: usize) -> Option<ElfN<'elf, T>> {
         match self {
             Self::B32(slice) => Some(ElfN::B32(slice.get(idx)?)),
@@ -555,6 +567,7 @@ impl Has32BitTy for Elf64_Sym {
 }
 
 pub(crate) type ElfN_Sym<'elf> = ElfN<'elf, Elf64_Sym>;
+pub(crate) type ElfN_Syms<'elf> = ElfNSlice<'elf, Elf64_Sym>;
 pub(crate) type ElfN_BoxedSyms<'elf> = ElfNBoxedSlice<'elf, Elf64_Sym>;
 
 impl ElfN_Sym<'_> {

--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -103,54 +103,6 @@ where
 }
 
 
-#[derive(Debug)]
-pub(crate) enum ElfNBoxedSlice<'elf, T>
-where
-    T: Has32BitTy,
-{
-    B32(Box<[&'elf T::Ty32Bit]>),
-    B64(Box<[&'elf T]>),
-}
-
-impl<'elf, T> ElfNBoxedSlice<'elf, T>
-where
-    T: Has32BitTy,
-{
-    pub fn empty(tybit32: bool) -> Self {
-        if tybit32 {
-            Self::B32(Box::new([]))
-        } else {
-            Self::B64(Box::new([]))
-        }
-    }
-
-    pub fn get(&self, idx: usize) -> Option<ElfN<'elf, T>> {
-        match self {
-            Self::B32(slice) => Some(ElfN::B32(*slice.get(idx)?)),
-            Self::B64(slice) => Some(ElfN::B64(*slice.get(idx)?)),
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        match self {
-            Self::B32(slice) => slice.len(),
-            Self::B64(slice) => slice.len(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn iter(&self, start_idx: usize) -> impl ExactSizeIterator<Item = ElfN<'_, T>> {
-        match self {
-            Self::B32(slice) => Either::A(slice[start_idx..].iter().map(|x| ElfN::B32(*x))),
-            Self::B64(slice) => Either::B(slice[start_idx..].iter().map(|x| ElfN::B64(*x))),
-        }
-    }
-}
-
-
 pub(crate) trait Has32BitTy {
     type Ty32Bit;
 }
@@ -568,7 +520,6 @@ impl Has32BitTy for Elf64_Sym {
 
 pub(crate) type ElfN_Sym<'elf> = ElfN<'elf, Elf64_Sym>;
 pub(crate) type ElfN_Syms<'elf> = ElfNSlice<'elf, Elf64_Sym>;
-pub(crate) type ElfN_BoxedSyms<'elf> = ElfNBoxedSlice<'elf, Elf64_Sym>;
 
 impl ElfN_Sym<'_> {
     #[inline]


### PR DESCRIPTION
So far our symbol table cache had the symbols mapped into memory and then sorted references to them by the respective symbol's address, in a heap allocated array. This is conceptually fine, but it is an approach that is incompatible with future changes.
This change reworks the SymbolTableCache type as follows: 1) we to store the memory mapped symbols as-is; that is, we keep an
   (unsorted) slice of the symbols around
2) we then build an additional index that is sorted by address on top of
   that

In so doing we eliminate the need for keeping unnecessary references to the memory mapped data around. Further more, we could optimize the (heap allocated) index further, by using a smaller index size when the number of symbols is below certain maxima. Third, because symbol filtering now happens inside SymbolTableCache, we remove the duplication for filtering and sorting symbols for 32 and 64 bit, respectively. Lastly, because we no longer heap allocate an array of references, we can ditch the ElfN_BoxedSyms type, which was arguably a weird special case to have, entirely.