### PR TITLE
Require that Pod: Clone

### DIFF
--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -108,7 +108,7 @@ pub(crate) trait Has32BitTy {
 }
 
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[repr(C)]
 pub(crate) struct Elf32_Ehdr {
     pub e_ident: [u8; EI_NIDENT],
@@ -131,7 +131,7 @@ pub(crate) struct Elf32_Ehdr {
 unsafe impl Pod for Elf32_Ehdr {}
 
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[repr(C)]
 pub(crate) struct Elf64_Ehdr {
     pub e_ident: [u8; EI_NIDENT], /* ELF "magic number" */
@@ -572,7 +572,7 @@ impl ElfN_Sym<'_> {
 pub(crate) const NT_GNU_BUILD_ID: Elf64_Word = 3;
 
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[repr(C)]
 pub(crate) struct Elf32_Nhdr {
     pub n_namesz: Elf32_Word, /* Length of the note's name. */
@@ -584,7 +584,7 @@ pub(crate) struct Elf32_Nhdr {
 unsafe impl Pod for Elf32_Nhdr {}
 
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[repr(C)]
 pub(crate) struct Elf64_Nhdr {
     pub n_namesz: Elf64_Word,
@@ -600,7 +600,7 @@ impl Has32BitTy for Elf64_Nhdr {
 }
 
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub(crate) struct Elf32_Chdr {
     pub ch_type: Elf32_Word,      /* Compression format. */
@@ -612,7 +612,7 @@ pub(crate) struct Elf32_Chdr {
 unsafe impl Pod for Elf32_Chdr {}
 
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub(crate) struct Elf64_Chdr {
     /// Compression format.

--- a/src/gsym/types.rs
+++ b/src/gsym/types.rs
@@ -17,6 +17,7 @@ pub struct Header {
     pub _uuid: [u8; 20],
 }
 
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub struct FileInfo {
     pub directory: u32,

--- a/src/util.rs
+++ b/src/util.rs
@@ -405,7 +405,7 @@ where
 ///
 /// # Safety
 /// Only safe to implement for types that are valid for any bit pattern.
-pub unsafe trait Pod {}
+pub unsafe trait Pod: Clone {}
 
 unsafe impl Pod for i8 {}
 unsafe impl Pod for u8 {}

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -30,6 +30,7 @@ const FLAG_HAS_DATA_DESCRIPTOR: u16 = 1 << 3;
 
 
 /// See section 4.3.16 of the spec.
+#[derive(Clone, Debug)]
 #[repr(C, packed)]
 struct EndOfCdRecord {
     /// Magic value equal to END_OF_CD_RECORD_MAGIC.
@@ -62,6 +63,7 @@ unsafe impl Pod for EndOfCdRecord {}
 
 
 /// See section 4.3.12 of the spec.
+#[derive(Clone, Debug)]
 #[repr(C, packed)]
 struct CdFileHeader {
     /// Magic value equal to CD_FILE_HEADER_MAGIC.
@@ -93,6 +95,7 @@ unsafe impl Pod for CdFileHeader {}
 
 
 /// See section 4.3.7 of the spec.
+#[derive(Clone, Debug)]
 #[repr(C, packed)]
 struct LocalFileHeader {
     /// Magic value equal to LOCAL_FILE_HEADER_MAGIC.


### PR DESCRIPTION
With upcoming changes we are going to support either working with memory mapped ELF data or with data retrieved using regular file I/O APIs. Obviously, from a memory management perspective the two behave differently: where one just requires some massaging of byte slices, the other necessitates heap allocated buffers.
In order for our ELF types to play nice with the latter, guarantee that everything implementing Pod also is cloneable.