### PR TITLE
Introduce ELF Backend type

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -459,9 +459,13 @@ impl<'mmap> Cache<'mmap> {
             .ok_or_invalid_data(|| "ELF e_shoff is invalid")?;
 
         let shdr = if ehdr.is_32bit() {
-            data.read_pod_ref::<Elf32_Shdr>().map(ElfN_Shdr::B32)
+            data.read_pod_ref::<Elf32_Shdr>()
+                .map(Cow::Borrowed)
+                .map(ElfN_Shdr::B32)
         } else {
-            data.read_pod_ref::<Elf64_Shdr>().map(ElfN_Shdr::B64)
+            data.read_pod_ref::<Elf64_Shdr>()
+                .map(Cow::Borrowed)
+                .map(ElfN_Shdr::B64)
         }
         .ok_or_invalid_data(|| "failed to read ELF section header")?;
 
@@ -491,11 +495,13 @@ impl<'mmap> Cache<'mmap> {
         let ehdr = if bit32 {
             elf_data
                 .read_pod_ref::<Elf32_Ehdr>()
+                .map(Cow::Borrowed)
                 .map(ElfN_Ehdr::B32)
                 .ok_or_invalid_data(|| "failed to read ELF header")?
         } else {
             elf_data
                 .read_pod_ref::<Elf64_Ehdr>()
+                .map(Cow::Borrowed)
                 .map(ElfN_Ehdr::B64)
                 .ok_or_invalid_data(|| "failed to read ELF header")?
         };
@@ -1257,7 +1263,7 @@ mod tests {
             e_shstrndx: 29,
         };
         let ehdr = EhdrExt {
-            ehdr: ElfN_Ehdr::B64(&ehdr),
+            ehdr: ElfN_Ehdr::B64(Cow::Borrowed(&ehdr)),
             shnum: 42,
             phnum: 0,
         };
@@ -1700,7 +1706,7 @@ mod tests {
             e_shstrndx: 1,
         };
         let ehdr = EhdrExt {
-            ehdr: ElfN_Ehdr::B64(&ehdr),
+            ehdr: ElfN_Ehdr::B64(Cow::Borrowed(&ehdr)),
             shnum: 3,
             phnum: 0,
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -479,7 +479,7 @@ pub trait ReadRaw<'data> {
         }
     }
 
-    /// Read a reference to something implementing `Pod`.
+    /// Read a slice to something implementing `Pod`.
     #[inline]
     fn read_pod_slice_ref<T>(&mut self, count: usize) -> Option<&'data [T]>
     where


### PR DESCRIPTION
For implementation peculiarities on Linux, we cannot make do with an ELF parser that unconditionally relies on memory mapped data. Rather, for certain /proc files we are actually forced to use file I/O instead. In order to switch between the two, introduce the Backend trait that abstracts over the differences between the two. In a nutshell, for the mmap backend we continue reading references to objects while for the file I/O based one we will work with owned objects instead.