### PR TITLE
Fix `test_elf64_symtab` test

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -1473,7 +1473,7 @@ mod tests {
         let sym = parser.find_sym(addr, &FindSymOpts::Basic).unwrap().unwrap();
         assert_eq!(sym.addr, addr);
         assert_eq!(sym.name, name);
-        assert_eq!(sym.size, Some(size));
+        assert!(sym.size.is_none() && size == 0 || sym.size.unwrap() == size);
     }
 
     #[test]


### PR DESCRIPTION
The `test_elf64_symtab` test compares the ELF reported symbol size with the one returned by ElfParser::find_sym(). However, those two are not guaranteed to match up: if an ELF symbol has a size of 0 its size is "zero or unknown". As such, we report the size as None instead. Adjust the logic to deal with this condition properly.