### PR TITLE
Generate large benchmark files for nightly benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -390,14 +390,14 @@ jobs:
       shell: bash
       run: |
         echo '```' >> $GITHUB_STEP_SUMMARY
-        cargo bench --workspace --features=nightly -- bench_ | tee --append $GITHUB_STEP_SUMMARY
+        cargo bench --workspace --features=nightly,blazesym-dev/generate-large-test-files -- bench_ | tee --append $GITHUB_STEP_SUMMARY
         # We use bencher format here for better relation to the above
         # but also because it emits less other crap into our summary.
         # Note that because libtest does not understand the
         # `--output-format` option, we need to specify the benchmark
         # binary (`main`) here and have a different invocation for
         # libtest style benchmarks above. Sigh.
-        cargo bench --workspace --bench=main --bench=capi --features=blazesym-dev/generate-large-test-files,blazesym-dev/dont-generate-unit-test-files -- --output-format=bencher | tee --append $GITHUB_STEP_SUMMARY
+        cargo bench --workspace --bench=main --bench=capi --features=blazesym-dev/dont-generate-unit-test-files -- --output-format=bencher | tee --append $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
   clippy:
     name: Lint with clippy


### PR DESCRIPTION
Currently we only generate the "large" benchmark files for the Criterion benchmarks in our 'bench' CI job, because that is when they are needed. However, with commit 9d1978e66160 ("Add benchmark for ELF "str2symtab" creation") it now one of the earlier nightly benchmarks that already requires one of those files.
Thus, make sure to generate them just a bit earlier.