### PR TITLE
Stop installing recommended packages in CI

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -45,7 +45,7 @@ jobs:
           path: linux/
       - if: steps.restore-cached-kernel.outputs.cache-hit != 'true'
         name: Install required tools
-        run: sudo apt-get install -y libelf-dev
+        run: sudo apt-get install --yes --no-install-recommends libelf-dev
       - if: steps.restore-cached-kernel.outputs.cache-hit != 'true'
         name: Build kernel
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: Check incremental rebuilds
@@ -171,7 +171,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
@@ -255,7 +255,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo check --package=blazesym-dev --features=generate-unit-test-files
@@ -294,7 +294,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
@@ -317,7 +317,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev liblzma-dev
+      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev liblzma-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
@@ -330,7 +330,7 @@ jobs:
       MIRIFLAGS: '-Zmiri-disable-stacked-borrows'
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y libelf-dev zlib1g-dev
+      run: sudo apt-get install --yes --no-install-recommends libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
@@ -355,7 +355,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo run --example backtrace
@@ -383,7 +383,7 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install -y gcc-multilib libelf-dev zlib1g-dev
+      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: Run benchmarks
@@ -404,7 +404,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install development dependencies
-        run: sudo apt-get install -y libelf-dev zlib1g-dev
+        run: sudo apt-get install --yes --no-install-recommends libelf-dev zlib1g-dev
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo clippy --workspace --no-deps --all-targets --features=blazesym-dev/dont-generate-unit-test-files -- -A unknown_lints -D clippy::todo


### PR DESCRIPTION
We don't need "recommended" packages to be installed in CI, but that's what apt-get chooses to do by default. Provide the `--no-install-recommends` option to prevent this from happening.