### PR TITLE
Sync up publish workflow crate version detection

### DIFF
--- a/.github/workflows/publish-capi.yml
+++ b/.github/workflows/publish-capi.yml
@@ -16,12 +16,17 @@ jobs:
       run: |
         cd capi
         cargo generate-lockfile
-        version="$(cargo pkgid | cut -d '#' -f2 | cut -d '@' -f2 | grep -o '[^:]*$')"
-
+        pkgid="$(cargo pkgid)"
+        # Format is typically
+        #   file://<path>/<crate>#<version>
+        # but could also be along the lines of
+        #   file://<path>/<crate>#<actual-crate-name>@<version>
+        version="$(echo ${pkgid} | cut -d '#' -f2 | cut -d '@' -f2 | grep -o '[^:]*$')"
         if [ -z "${version}" ]; then
-          echo "Invalid version number"
+          echo "Invalid version string: ${pkgid}"
           exit 1
         fi
+        echo "Determined crate version: ${version}"
         echo "version=${version}" >> $GITHUB_OUTPUT
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -16,12 +16,17 @@ jobs:
       run: |
         cd cli
         cargo generate-lockfile
-        version="$(cargo pkgid | cut -d '#' -f2 | cut -d '@' -f2 | grep -o '[^:]*$')"
-
+        pkgid="$(cargo pkgid)"
+        # Format is typically
+        #   file://<path>/<crate>#<version>
+        # but could also be along the lines of
+        #   file://<path>/<crate>#<actual-crate-name>@<version>
+        version="$(echo ${pkgid} | cut -d '#' -f2 | cut -d '@' -f2 | grep -o '[^:]*$')"
         if [ -z "${version}" ]; then
-          echo "Invalid version number"
+          echo "Invalid version string: ${pkgid}"
           exit 1
         fi
+        echo "Determined crate version: ${version}"
         echo "version=${version}" >> $GITHUB_OUTPUT
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,17 @@ jobs:
       shell: bash
       run: |
         cargo generate-lockfile
-        version="$(cargo pkgid | cut -d '#' -f2 | cut -d '@' -f2 | grep -o '[^:]*$')"
+        pkgid="$(cargo pkgid)"
+        # Format is typically
+        #   file://<path>/<crate>#<version>
+        # but could also be along the lines of
+        #   file://<path>/<crate>#<actual-crate-name>@<version>
+        version="$(echo ${pkgid} | cut -d '#' -f2 | cut -d '@' -f2 | grep -o '[^:]*$')"
         if [ -z "${version}" ]; then
-          echo "Invalid version number"
+          echo "Invalid version string: ${pkgid}"
           exit 1
         fi
+        echo "Determined crate version: ${version}"
         echo "version=${version}" >> $GITHUB_OUTPUT
   test:
     uses: ./.github/workflows/test.yml


### PR DESCRIPTION
Sync up the crate version detection of the various publish workflows with what we use everywhere else, in an attempt to minimize the maintenance burden down the line.