### PR TITLE
Define align_up() helper via macro

### DIFF
--- a/src/dwarf/debug_link.rs
+++ b/src/dwarf/debug_link.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 
 use crate::elf::ElfParser;
 use crate::error::IntoError as _;
-use crate::util::align_up;
+use crate::util::align_up_usize;
 use crate::util::bytes_to_os_str;
 use crate::util::ReadRaw as _;
 use crate::Result;
@@ -162,7 +162,7 @@ fn parse_debug_link_section_data(mut data: &[u8]) -> Result<Option<(&OsStr, u32)
     // The offset is aligned to the next four byte boundary relative to
     // the start of the section.
     let align = 4;
-    let crc_offset = align_up(cur_offset, align);
+    let crc_offset = align_up_usize(cur_offset, align);
     let () = data
         .advance(crc_offset - cur_offset)
         .ok_or_invalid_data(|| {

--- a/src/util.rs
+++ b/src/util.rs
@@ -82,15 +82,21 @@ where
 }
 
 
-/// Align a value to the next power of two.
-pub(crate) fn align_up(value: usize, align_to: usize) -> usize {
-    debug_assert_eq!(
-        align_to.next_power_of_two(),
-        align_to,
-        "alignment ({align_to}) is no power of two"
-    );
-    (value + (align_to - 1)) & !(align_to - 1)
+macro_rules! def_align_up {
+    ($name:ident, $type:ty) => {
+        /// Align a value to the next power of two.
+        pub(crate) fn $name(value: $type, align_to: $type) -> $type {
+            debug_assert_eq!(
+                align_to.next_power_of_two(),
+                align_to,
+                "alignment ({align_to}) is no power of two"
+            );
+            (value + (align_to - 1)) & !(align_to - 1)
+        }
+    };
 }
+
+def_align_up!(align_up_usize, usize);
 
 
 /// Split a byte slice at the first byte for which `check` returns
@@ -733,12 +739,12 @@ mod tests {
     #[tag(miri)]
     #[test]
     fn upwards_alignment() {
-        assert_eq!(align_up(0, 4), 0);
-        assert_eq!(align_up(1, 4), 4);
-        assert_eq!(align_up(2, 4), 4);
-        assert_eq!(align_up(3, 4), 4);
-        assert_eq!(align_up(4, 4), 4);
-        assert_eq!(align_up(5, 4), 8);
+        assert_eq!(align_up_usize(0, 4), 0);
+        assert_eq!(align_up_usize(1, 4), 4);
+        assert_eq!(align_up_usize(2, 4), 4);
+        assert_eq!(align_up_usize(3, 4), 4);
+        assert_eq!(align_up_usize(4, 4), 4);
+        assert_eq!(align_up_usize(5, 4), 8);
     }
 
     /// Make sure that `align_up` panics when attempting to align to
@@ -748,7 +754,7 @@ mod tests {
     #[test]
     #[should_panic = "alignment (3) is no power of two"]
     fn upwards_alignment_no_power_of_two() {
-        assert_eq!(align_up(0, 3), 0);
+        assert_eq!(align_up_usize(0, 3), 0);
     }
 
     /// Check that we can reorder elements in an array as expected.


### PR DESCRIPTION
We may need additional variants of the align_up() helper function for different integer types in the future. While it is possible to abstract over all the nitty gritty details of generic integer operations, it requires complex trait machinery in the form of the num-traits crate. For us it makes more sense to just duplicate the logic via macros. Prepare for that by defining align_up() in terms of a macro.

Signed-off-by: Daniel Müller <deso@posteo.net