### PR TITLE
Use 6.11 kernel in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,7 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     secrets: inherit
     with:
-      # TODO: Bump to v6.11 once tagged.
-      rev: 44eacec2cec1c5f83074e74d00208d15390b00bc
+      rev: v6.11
       config: 'data/config'
   build:
     name: Build [${{ matrix.runs-on }}, ${{ matrix.rust }}, ${{ matrix.profile }}, ${{ matrix.args }}]


### PR DESCRIPTION
Switch over to using kernel 6.11 in CI, now that the necessary changes have made it upstream.