### PR TITLE
Improve test-release CI job runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -320,7 +320,11 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - run: cargo test --workspace --release
+    - env:
+        # Support incremental compilation here to not penalize CI compile times too much.
+        CARGO_PROFILE_RELEASE_INCREMENTAL: true
+        CARGO_PROFILE_RELEASE_LTO: false
+      run: cargo test --workspace --release
   test-miri:
     name: Test with Miri
     runs-on: ubuntu-latest


### PR DESCRIPTION
As we add more jobs and have existing ones perform more work, CI slows down. One of the main offenders is the 'test-release' job, which is found to have a both cold start runtime but also doesn't play particularly nice with our caching infrastructure. This has potential trickle down effects on other jobs, which may only get scheduled on runners once others have finished (because there exist overall limits on the number of runners in use), potentially delaying overall CI time doubly.
The slowness of this job seems to come down to two things: 1) our release builds use LTO etc., making linking a very lengthy
   process
2) it turns out that release builds are not incremental by default [0],
   causing a lot of recompilation to happen, despite our efforts of
   caching intermediate artifacts

To fix these issues, we disable the link time optimization step in CI and enable incremental compilation. Doing so reduces runtime from >=3min down to ~1min.

[0] https://doc.rust-lang.org/cargo/reference/profiles.html#release