### PR TITLE
Introduce ElfN_Nhdr type

### DIFF
--- a/src/elf/types.rs
+++ b/src/elf/types.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::mem::size_of;
 
 use crate::util::Either;
 use crate::util::Pod;
@@ -612,6 +613,10 @@ unsafe impl Pod for Elf64_Nhdr {}
 impl Has32BitTy for Elf64_Nhdr {
     type Ty32Bit = Elf32_Nhdr;
 }
+
+const _: () = assert!(size_of::<Elf32_Nhdr>() == size_of::<Elf64_Nhdr>());
+
+pub(crate) type ElfN_Nhdr = Elf64_Nhdr;
 
 
 #[derive(Clone, Debug)]

--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 use std::path::Path;
 
 use crate::elf;
-use crate::elf::types::Elf32_Nhdr;
-use crate::elf::types::Elf64_Nhdr;
+use crate::elf::types::ElfN_Nhdr;
 use crate::elf::ElfParser;
 use crate::file_cache::FileCache;
 use crate::log::warn;
@@ -27,14 +26,9 @@ fn read_build_id_from_notes(parser: &ElfParser) -> Result<Option<BuildId<'_>>> {
             // SANITY: We just found the index so the section data should always
             //         be found.
             let mut bytes = parser.section_data(idx).unwrap();
-            let (n_type, n_namesz, n_descsz) = if shdr.is_32bit() {
+            let (n_type, n_namesz, n_descsz) = {
                 let nhdr = bytes
-                    .read_pod_ref::<Elf32_Nhdr>()
-                    .ok_or_invalid_data(|| "failed to read build ID section header")?;
-                (nhdr.n_type, nhdr.n_namesz, nhdr.n_descsz)
-            } else {
-                let nhdr = bytes
-                    .read_pod_ref::<Elf64_Nhdr>()
+                    .read_pod_ref::<ElfN_Nhdr>()
                     .ok_or_invalid_data(|| "failed to read build ID section header")?;
                 (nhdr.n_type, nhdr.n_namesz, nhdr.n_descsz)
             };
@@ -75,14 +69,9 @@ fn read_build_id_from_section_name(parser: &ElfParser) -> Result<Option<BuildId<
         // SANITY: We just found the index so the section should always be
         //         found.
         let mut bytes = parser.section_data(idx).unwrap();
-        let (n_namesz, n_descsz) = if shdr.is_32bit() {
+        let (n_namesz, n_descsz) = {
             let nhdr = bytes
-                .read_pod_ref::<Elf32_Nhdr>()
-                .ok_or_invalid_data(|| "failed to read build ID section header")?;
-            (nhdr.n_namesz, nhdr.n_descsz)
-        } else {
-            let nhdr = bytes
-                .read_pod_ref::<Elf64_Nhdr>()
+                .read_pod_ref::<ElfN_Nhdr>()
                 .ok_or_invalid_data(|| "failed to read build ID section header")?;
             (nhdr.n_namesz, nhdr.n_descsz)
         };


### PR DESCRIPTION
The `Elf32_Nhdr` and `Elf64_Nhdr` types have the same size and layout. So far we have not exploited this fact and just stuck to the existing logic of differentiating between 32 and 64 bit types depending on the ELF bitness, as we do elsewhere.
However, there is a certain amount of complexity associated with supporting the two bitnesses. With this change we introduce the `ElfN_Nhdr` type as an alias to `Elf64_Nhdr` and rely solely on it.