### PR TITLE
Use ReadRaw::read_array() in Gsym parsing code

### DIFF
--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -101,9 +101,7 @@ impl GsymContext<'_> {
             let num_addrs = data.read_u32()?;
             let strtab_offset = data.read_u32()?;
             let strtab_size = data.read_u32()?;
-            // SANITY: We know that the slice has 20 elements if read
-            //         successful.
-            let uuid = <[u8; 20]>::try_from(data.read_slice(20)?).unwrap();
+            let uuid = data.read_array::<20>()?;
 
             let addr_tab = data.read_slice(num_addrs as usize * usize::from(addr_off_size))?;
             let () = data.align(align_of::<u32>())?;


### PR DESCRIPTION
We don't have to use the ReadRaw::read_slice() method in conjunction with a fallible cast to read a compile-time-sized amount of bytes, but can use the ReadRaw::read_array() helper.