### PR TITLE
Incorporate Clippy reported suggestion

### DIFF
--- a/src/kernel/bpf/prog.rs
+++ b/src/kernel/bpf/prog.rs
@@ -63,7 +63,7 @@ impl FromStr for BpfTag {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.as_bytes().len() != 2 * size_of::<BpfTag>() {
+        if s.len() != 2 * size_of::<BpfTag>() {
             return Err(())
         }
 


### PR DESCRIPTION
Clippy complains that we are using str.as_bytes().len() when we could be using str.len(). Point taken. Adjust the code accordingly.