### PR TITLE
Unbreak Windows CI builds

### DIFF
--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -39,6 +39,10 @@ xz2 = {version = "0.1.7", optional = true}
 zip = {version = "2.0.0", optional = true, default-features = false}
 zstd = {version = "0.13.1", default-features = false, optional = true}
 
+[target.'cfg(target_os = "windows")'.build-dependencies]
+# Broken Windows builds.
+_symbolic_demangle_lowered = {package = "symbolic-demangle", version = "<12.13.0"}
+
 [dependencies]
 # TODO: Enable `zstd` feature once toolchain support for it is more
 #       widespread (enabled by default in `ld`). Remove conditionals in


### PR DESCRIPTION
The 12.13.x releases of symbolic-demangle result in broken Windows builds. Until that is fixed upstream, make sure that we use a lower version.