### PR TITLE
Unbreak Windows CI builds^2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,9 +244,9 @@ jobs:
       with:
         files: lcov.info
   build-test-artifacts:
-    # Only run tests on other operating systems tests on the final push.
-    # They are very unlikely to break at runtime (we build them anyway),
-    # but take quite a bit longer than Linux based ones.
+    # Only run tests on other operating systems on the final push. They
+    # are very unlikely to break at runtime (we build them anyway), but
+    # take quite a bit longer than Linux based ones.
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Build test artifacts
     runs-on: ubuntu-24.04

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -39,9 +39,12 @@ xz2 = {version = "0.1.7", optional = true}
 zip = {version = "2.0.0", optional = true, default-features = false}
 zstd = {version = "0.13.1", default-features = false, optional = true}
 
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.build-dependencies]
+libbpf-sys = {version = "1.4.1", default-features = false, optional = true}
+
 [target.'cfg(target_os = "windows")'.build-dependencies]
-# Broken Windows builds.
-_symbolic_demangle_lowered = {package = "symbolic-demangle", version = "<12.13.0"}
+# 12.13.x causes broken Windows builds.
+_symbolic_demangle_lowered = {package = "symbolic-demangle", version = "=12.12.4"}
 
 [dependencies]
 # TODO: Enable `zstd` feature once toolchain support for it is more
@@ -52,6 +55,3 @@ libc = "0.2.137"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = "0.24"
-
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.build-dependencies]
-libbpf-sys = {version = "1.4.1", default-features = false, optional = true}


### PR DESCRIPTION
Force usage of 12.12.4. Evidently, with a constraint of <12.13.0 we end up picking 11 in addition to the most recent 12.13.x o_O