### PR TITLE
capi: Expose symbol size

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Introduced `blaze_trace` function for tapping into the library's
   tracing functionality
+- Added `size` attribute to `blaze_sym` type
 
 
 0.1.0-rc.2

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -693,6 +693,15 @@ typedef struct blaze_sym {
    */
   size_t offset;
   /**
+   * The size of the symbol.
+   *
+   * If the symbol's size is not available, this member will be `-1`.
+   * Note that some symbol sources may not distinguish between
+   * "unknown" size and `0`. In that case the size will be reported
+   * as `0` here as well.
+   */
+  ptrdiff_t size;
+  /**
    * Source code location information for the symbol.
    */
   struct blaze_symbolize_code_info code_info;


### PR DESCRIPTION
For whatever reason our `blaze_sym` type does not yet capture the symbol's size, which is available in the Rust counterpart. Expose it in the C API as well.