### PR TITLE
Introduce required-checks CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -430,3 +430,24 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo doc --workspace --exclude=blazesym-dev --exclude=gsym-in-apk --no-deps
+
+  required-checks:
+    needs: [
+      build,
+      build-cross,
+      build-minimum,
+      nop-rebuilds,
+      test-coverage,
+      test-sanitizers,
+      test-release,
+      test-miri,
+      test-examples,
+      c-header,
+      clippy,
+      rustfmt,
+      cargo-doc,
+    ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'


### PR DESCRIPTION
GitHub Actions comes with an auto-merge feature, which allows for automatically merging PRs once certain requirements are met. For us, these requirements would be the passing of all CI checks. Alas, their !@#*&()$&@!(#* configuration requires us to explicitly list all CI jobs that need to pass, which is an absolute maintenance nightmare. To improve on the situation at least somewhat, introduce a job that captures all required checks, so that the definition of this arbitrary entity is at least co-located with the definition of these jobs and not hidden behind four layers of clicky-bunti UI fluff.

The logic is adapted from:
https://github.com/orgs/community/discussions/75568#discussioncomment-10351973