### PR TITLE
Give preference to ELF symbolization for kernel addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Added support for 32 bit ELF binaries
+- Adjusted kernel symbolization logic to give preference to ELF kernel
+  image, if present
 
 
 0.2.0-rc.2

--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -41,13 +41,10 @@ impl KernelResolver {
 
 impl Symbolize for KernelResolver {
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<ResolvedSym<'_>, Reason>> {
-        // TODO: If an `ElfResolver` is available we probably should give
-        //       preference to it, if for no other reason than the fact that it
-        //       may report source code location information.
-        if let Some(ksym_resolver) = self.ksym_resolver.as_ref() {
-            ksym_resolver.find_sym(addr, opts)
+        if let Some(elf_resolver) = self.elf_resolver.as_ref() {
+            elf_resolver.find_sym(addr, opts)
         } else {
-            self.elf_resolver.as_ref().unwrap().find_sym(addr, opts)
+            self.ksym_resolver.as_ref().unwrap().find_sym(addr, opts)
         }
     }
 }


### PR DESCRIPTION
As a side effect of commit 7ee10afffe9e ("Merge
SymResolver::find_code_info() into SymResolver::find_sym()") we changed the behavior of the kernel resolver in that where previously it would consult the ELF resolver for source code information, it no longer did so. That was mostly a result of the kernel resolver giving preference to the internally used KSymResolver, as opposed to the ElfResolver. This change adjusts the logic to make sure that if an ElfResolver is present, we end up using it for symbolization.