### PR TITLE
Provide more control over kernel symbolization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 - Added support for 32 bit ELF binaries
 - Adjusted kernel symbolization logic to give preference to ELF kernel
   image, if present
+- Changed `symbolize::Kernel::{kallsyms,kernel_image}` to support
+  disabling of the source
 
 
 0.2.0-rc.2

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 - Introduced `blaze_trace` function for tapping into the library's
   tracing functionality
 - Added `size` attribute to `blaze_sym` type
+- Added support for disabling `kallsyms` and ELF kernel image to
+  `blaze_symbolize_src_kernel`
 
 
 0.1.0-rc.2

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -807,21 +807,21 @@ typedef struct blaze_symbolize_src_kernel {
    */
   size_t type_size;
   /**
-   * The path of a copy of kallsyms.
+   * The path of a `kallsyms` file to use.
    *
-   * It can be `"/proc/kallsyms"` for the running kernel on the
-   * device.  However, you can make copies for later.  In that situation,
-   * you should give the path of a copy.
-   * Passing a `NULL`, by default, will result in `"/proc/kallsyms"`.
+   * When `NULL`, this will refer to `kallsyms` of the running kernel.
+   * If set to `'\0'` (`""`) usage of `kallsyms` will be disabled.
+   * Otherwise the copy at the given path will be used.
    */
   const char *kallsyms;
   /**
-   * The path of a kernel image.
+   * The path of the kernel image to use.
    *
-   * The path of a kernel image should be, for instance,
-   * `"/boot/vmlinux-xxxx"`.  For a `NULL` value, it will locate the
-   * kernel image of the running kernel in `"/boot/"` or
-   * `"/usr/lib/debug/boot/"`.
+   * When `NULL`, the library will search for kernel image candidates
+   * in various locations, taking into account the currently running
+   * kernel version. If set to `'\0'` (`""`) usage of a kernel image
+   * will be disabled. Otherwise the copy at the given path will be
+   * used.
    */
   const char *kernel_image;
   /**

--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -74,7 +74,6 @@ mod tests {
     use super::*;
 
     use crate::kernel::KALLSYMS;
-    use crate::ErrorKind;
 
 
     /// Exercise the `Debug` representation of various types.
@@ -83,12 +82,5 @@ mod tests {
         let ksym = Rc::new(KSymResolver::load_file_name(Path::new(KALLSYMS)).unwrap());
         let kernel = KernelResolver::new(Some(ksym), None).unwrap();
         assert_ne!(format!("{kernel:?}"), "");
-    }
-
-    /// Exercise the error path when no sub-resolver is provided.
-    #[test]
-    fn no_sub_resolver() {
-        let err = KernelResolver::new(None, None).unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::NotFound);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,25 @@ pub enum SymType {
 }
 
 
+/// A type representing an optional value or a default.
+#[derive(Clone, Debug, PartialEq)]
+pub enum MaybeDefault<T> {
+    /// Nothing.
+    None,
+    /// Use the context-dependent default value.
+    Default,
+    /// A provided value.
+    Some(T),
+}
+
+impl<T> From<T> for MaybeDefault<T> {
+    #[inline]
+    fn from(value: T) -> Self {
+        Self::Some(value)
+    }
+}
+
+
 /// Utility functionality not specific to any overarching theme.
 pub mod helper {
     use super::*;

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -4,6 +4,7 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::path::PathBuf;
 
+use crate::MaybeDefault;
 use crate::Pid;
 
 #[cfg(doc)]
@@ -162,32 +163,32 @@ impl Debug for Elf {
 }
 
 
-/// Linux Kernel's binary image and a copy of `/proc/kallsyms`.
+/// Configuration for kernel address symbolization.
 ///
 /// This type is used in the [`Source::Kernel`] variant.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Kernel {
-    /// The path of a kallsyms copy.
+    /// The path of a `kallsyms` file to use.
     ///
-    /// For the running kernel on the device, it can be
-    /// "/proc/kallsyms".  However, you can make a copy for later.
-    /// In that situation, you should give the path of the
-    /// copy.  Passing `None`, by default, will be
-    /// `"/proc/kallsyms"`.
-    pub kallsyms: Option<PathBuf>,
-    /// The path of a kernel image.
+    /// By default, this will refer to `kallsyms` of the running kernel.
+    /// If set to [`None`][MaybeDefault::None] usage of `kallsyms` will
+    /// be disabled. Otherwise the copy at the given path will be used.
+    pub kallsyms: MaybeDefault<PathBuf>,
+    /// The path of the kernel image to use.
     ///
-    /// This should be the path of a kernel image.  For example,
-    /// `"/boot/vmlinux-xxxx"`.  A `None` value will find the
-    /// kernel image of the running kernel in `"/boot/"` or
-    /// `"/usr/lib/debug/boot/"`.
-    pub kernel_image: Option<PathBuf>,
+    /// By default, the library will search for kernel image candidates
+    /// in various locations, taking into account the currently running
+    /// kernel version. If set to [`None`][MaybeDefault::None] usage of
+    /// a kernel image will be disabled. Otherwise the copy at the given
+    /// path will be used.
+    pub kernel_image: MaybeDefault<PathBuf>,
     /// Whether or not to consult debug symbols from `kernel_image`
     /// to satisfy the request (if present).
     ///
     /// On top of this runtime configuration, the crate needs to be
     /// built with the `dwarf` feature to actually consult debug
-    /// symbols. If neither is satisfied, ELF symbols will be used.
+    /// symbols. If either is not satisfied, only ELF symbols will be
+    /// used.
     pub debug_syms: bool,
     /// The struct is non-exhaustive and open to extension.
     #[doc(hidden)]
@@ -197,8 +198,8 @@ pub struct Kernel {
 impl Default for Kernel {
     fn default() -> Self {
         Self {
-            kallsyms: None,
-            kernel_image: None,
+            kallsyms: MaybeDefault::Default,
+            kernel_image: MaybeDefault::Default,
             debug_syms: true,
             _non_exhaustive: (),
         }


### PR DESCRIPTION
Currently there is no (reasonable) way for users to opt out of usage of kallsyms or the ELF kernel image: if they specify to use "None" a default will be used and if an actual value is provided so will it. That can be a problem in many conceivable scenarios.
To allow the user to specify either a specific value, the library default, or to disable either of the sources, introduce a tri-choice enum.