### PR TITLE
Make sure to use kallsyms as fallback

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -812,6 +812,10 @@ typedef struct blaze_symbolize_src_kernel {
    * When `NULL`, this will refer to `kallsyms` of the running kernel.
    * If set to `'\0'` (`""`) usage of `kallsyms` will be disabled.
    * Otherwise the copy at the given path will be used.
+   *
+   * If both a kernel image as well as a `kallsyms` file are found,
+   * the kernel image will generally be given preference and
+   * `kallsyms` acts as a fallback.
    */
   const char *kallsyms;
   /**
@@ -822,6 +826,10 @@ typedef struct blaze_symbolize_src_kernel {
    * kernel version. If set to `'\0'` (`""`) usage of a kernel image
    * will be disabled. Otherwise the copy at the given path will be
    * used.
+   *
+   * If both a kernel image as well as a `kallsyms` file are found,
+   * the kernel image will generally be given preference and
+   * `kallsyms` acts as a fallback.
    */
   const char *kernel_image;
   /**

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -108,6 +108,10 @@ pub struct blaze_symbolize_src_kernel {
     /// When `NULL`, this will refer to `kallsyms` of the running kernel.
     /// If set to `'\0'` (`""`) usage of `kallsyms` will be disabled.
     /// Otherwise the copy at the given path will be used.
+    ///
+    /// If both a kernel image as well as a `kallsyms` file are found,
+    /// the kernel image will generally be given preference and
+    /// `kallsyms` acts as a fallback.
     pub kallsyms: *const c_char,
     /// The path of the kernel image to use.
     ///
@@ -116,6 +120,10 @@ pub struct blaze_symbolize_src_kernel {
     /// kernel version. If set to `'\0'` (`""`) usage of a kernel image
     /// will be disabled. Otherwise the copy at the given path will be
     /// used.
+    ///
+    /// If both a kernel image as well as a `kallsyms` file are found,
+    /// the kernel image will generally be given preference and
+    /// `kallsyms` acts as a fallback.
     pub kernel_image: *const c_char,
     /// Whether or not to consult debug symbols from `kernel_image`
     /// to satisfy the request (if present).

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -173,6 +173,10 @@ pub struct Kernel {
     /// By default, this will refer to `kallsyms` of the running kernel.
     /// If set to [`None`][MaybeDefault::None] usage of `kallsyms` will
     /// be disabled. Otherwise the copy at the given path will be used.
+    ///
+    /// If both a kernel image as well as a `kallsyms` file are found,
+    /// the kernel image will generally be given preference and
+    /// `kallsyms` acts as a fallback.
     pub kallsyms: MaybeDefault<PathBuf>,
     /// The path of the kernel image to use.
     ///
@@ -181,6 +185,10 @@ pub struct Kernel {
     /// kernel version. If set to [`None`][MaybeDefault::None] usage of
     /// a kernel image will be disabled. Otherwise the copy at the given
     /// path will be used.
+    ///
+    /// If both a kernel image as well as a `kallsyms` file are found,
+    /// the kernel image will generally be given preference and
+    /// `kallsyms` acts as a fallback.
     pub kernel_image: MaybeDefault<PathBuf>,
     /// Whether or not to consult debug symbols from `kernel_image`
     /// to satisfy the request (if present).


### PR DESCRIPTION
The kernel image file, even if present, is limited in which addresses it is able to resolve. Kernel addresses belonging to modules, for example, can't be symbolized this way. While we may eventually add better support for kernel modules, for now the best course of action seems to be to fall back to usage of kallsyms.