### PR TITLE
Make KernelResolver members private

### DIFF
--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -17,8 +17,8 @@ use super::ksym::KSymResolver;
 
 
 pub(crate) struct KernelResolver {
-    pub ksym_resolver: Option<Rc<KSymResolver>>,
-    pub elf_resolver: Option<Rc<ElfResolver>>,
+    ksym_resolver: Option<Rc<KSymResolver>>,
+    elf_resolver: Option<Rc<ElfResolver>>,
 }
 
 impl KernelResolver {


### PR DESCRIPTION
Declare the members of the KernelResolver type as private, to ensure proper isolation.