### PR TITLE
Move KASLR logic into "generic" kernel module

### DIFF
--- a/src/kernel/kaslr.rs
+++ b/src/kernel/kaslr.rs
@@ -19,8 +19,6 @@ use crate::ErrorExt as _;
 use crate::IntoError as _;
 use crate::Result;
 
-use super::normalizer::Output;
-
 
 /// The absolute path to the `kcore` `proc` node.
 const PROC_KCORE: &str = "/proc/kcore";

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -2,6 +2,10 @@
 mod bpf;
 mod ksym;
 mod resolver;
+// Still work in progress.
+#[allow(unused)]
+#[cfg(test)]
+mod kaslr;
 
 // TODO: KsymResolver should ideally be an implementation detail.
 pub(crate) use ksym::KSymResolver;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -44,10 +44,6 @@
 
 pub(crate) mod buildid;
 pub(crate) mod ioctl;
-// Still work in progress.
-#[allow(unused)]
-#[cfg(test)]
-mod kernel;
 mod meta;
 mod normalizer;
 mod user;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -33,7 +33,7 @@ where
 
     // Make sure that we restore the real user before tearing down,
     // because shut down code may need the original permissions (e.g., for
-    // writing down code coverage files or similar.
+    // writing down code coverage files or similar).
     if unsafe { seteuid(ruid) } == -1 {
         panic!(
             "failed to restore effective user ID to {ruid}: {}",


### PR DESCRIPTION
As it turns out we will need the KASLR logic not just in normalization code but also in parts of the symbolization logic. As such, let's move the containing module out of the normalize functionality and into the more generic parts of the crate.