### PR TITLE
Rename `KSymResolver` -> `KsymResolver`

### DIFF
--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -8,6 +8,6 @@ mod resolver;
 mod kaslr;
 
 // TODO: KsymResolver should ideally be an implementation detail.
-pub(crate) use ksym::KSymResolver;
+pub(crate) use ksym::KsymResolver;
 pub(crate) use ksym::KALLSYMS;
 pub(crate) use resolver::KernelResolver;

--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -13,17 +13,17 @@ use crate::Addr;
 use crate::Error;
 use crate::Result;
 
-use super::ksym::KSymResolver;
+use super::ksym::KsymResolver;
 
 
 pub(crate) struct KernelResolver {
-    ksym_resolver: Option<Rc<KSymResolver>>,
+    ksym_resolver: Option<Rc<KsymResolver>>,
     elf_resolver: Option<Rc<ElfResolver>>,
 }
 
 impl KernelResolver {
     pub(crate) fn new(
-        ksym_resolver: Option<Rc<KSymResolver>>,
+        ksym_resolver: Option<Rc<KsymResolver>>,
         elf_resolver: Option<Rc<ElfResolver>>,
     ) -> Result<KernelResolver> {
         if ksym_resolver.is_none() && elf_resolver.is_none() {
@@ -94,7 +94,7 @@ mod tests {
     /// Exercise the `Debug` representation of various types.
     #[test]
     fn debug_repr() {
-        let ksym = Rc::new(KSymResolver::load_file_name(Path::new(KALLSYMS)).unwrap());
+        let ksym = Rc::new(KsymResolver::load_file_name(Path::new(KALLSYMS)).unwrap());
         let kernel = KernelResolver::new(Some(ksym), None).unwrap();
         assert_ne!(format!("{kernel:?}"), "");
     }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -22,8 +22,8 @@ use crate::file_cache::FileCache;
 #[cfg(feature = "gsym")]
 use crate::gsym::GsymResolver;
 use crate::insert_map::InsertMap;
-use crate::kernel::KSymResolver;
 use crate::kernel::KernelResolver;
+use crate::kernel::KsymResolver;
 use crate::kernel::KALLSYMS;
 use crate::log;
 use crate::maps;
@@ -625,7 +625,7 @@ pub struct Symbolizer {
     elf_cache: FileCache<ElfResolverData>,
     #[cfg(feature = "gsym")]
     gsym_cache: FileCache<GsymResolver<'static>>,
-    ksym_cache: FileCache<Rc<KSymResolver>>,
+    ksym_cache: FileCache<Rc<KsymResolver>>,
     perf_map_cache: FileCache<PerfMap>,
     process_cache: InsertMap<PathName, Option<Box<dyn Resolve>>>,
     find_sym_opts: FindSymOpts,
@@ -922,13 +922,13 @@ impl Symbolizer {
         Ok(handler.all_symbols)
     }
 
-    fn create_ksym_resolver(&self, path: &Path, file: &File) -> Result<Rc<KSymResolver>> {
-        let resolver = KSymResolver::load_from_reader(file, path)?;
+    fn create_ksym_resolver(&self, path: &Path, file: &File) -> Result<Rc<KsymResolver>> {
+        let resolver = KsymResolver::load_from_reader(file, path)?;
         let resolver = Rc::new(resolver);
         Ok(resolver)
     }
 
-    fn ksym_resolver<'slf>(&'slf self, path: &Path) -> Result<&'slf Rc<KSymResolver>> {
+    fn ksym_resolver<'slf>(&'slf self, path: &Path) -> Result<&'slf Rc<KsymResolver>> {
         let (file, cell) = self.ksym_cache.entry(path)?;
         let resolver = cell.get_or_try_init(|| self.create_ksym_resolver(path, file))?;
         Ok(resolver)


### PR DESCRIPTION
Rename `KSymResolver` to `KsymResolver` to better match existing naming with `Ksyms`.