### PR TITLE
Rename "kernel image" to "vmlinux"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Unreleased
 ----------
 - Added support for 32 bit ELF binaries
-- Adjusted kernel symbolization logic to give preference to ELF kernel
-  image, if present
+- Renamed `symbolize::Source::kernel_image` to `vmlinux`
+- Adjusted kernel symbolization logic to give preference to `vmlinux`
+  file, if present
 - Changed `symbolize::Kernel::{kallsyms,kernel_image}` to support
   disabling of the source
 

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -3,7 +3,9 @@ Unreleased
 - Introduced `blaze_trace` function for tapping into the library's
   tracing functionality
 - Added `size` attribute to `blaze_sym` type
-- Added support for disabling `kallsyms` and ELF kernel image to
+- Renamed `kernel_image` member of `blaze_symbolize_src_kernel` to
+  `vmlinux`
+- Added support for disabling `kallsyms` and `vmlinux` to
   `blaze_symbolize_src_kernel`
 
 

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -794,9 +794,6 @@ typedef struct blaze_symbolize_src_process {
 
 /**
  * The parameters to load symbols and debug information from a kernel.
- *
- * Use a kernel image and a snapshot of its kallsyms as a source of symbols and
- * debug information.
  */
 typedef struct blaze_symbolize_src_kernel {
   /**
@@ -813,28 +810,32 @@ typedef struct blaze_symbolize_src_kernel {
    * If set to `'\0'` (`""`) usage of `kallsyms` will be disabled.
    * Otherwise the copy at the given path will be used.
    *
-   * If both a kernel image as well as a `kallsyms` file are found,
-   * the kernel image will generally be given preference and
-   * `kallsyms` acts as a fallback.
+   * If both a `vmlinux` as well as a `kallsyms` file are found,
+   * `vmlinux` will generally be given preference and `kallsyms` acts
+   * as a fallback.
    */
   const char *kallsyms;
   /**
-   * The path of the kernel image to use.
+   * The path of the `vmlinux` file to use.
    *
-   * When `NULL`, the library will search for kernel image candidates
-   * in various locations, taking into account the currently running
-   * kernel version. If set to `'\0'` (`""`) usage of a kernel image
-   * will be disabled. Otherwise the copy at the given path will be
-   * used.
+   * `vmlinux` is generally an uncompressed and unstripped object
+   * file that is typically used in debugging, profiling, and
+   * similar use cases.
    *
-   * If both a kernel image as well as a `kallsyms` file are found,
-   * the kernel image will generally be given preference and
-   * `kallsyms` acts as a fallback.
+   * When `NULL`, the library will search for `vmlinux` candidates in
+   * various locations, taking into account the currently running
+   * kernel version. If set to `'\0'` (`""`) discovery and usage of a
+   * `vmlinux` will be disabled. Otherwise the copy at the given path
+   * will be used.
+   *
+   * If both a `vmlinux` as well as a `kallsyms` file are found,
+   * `vmlinux` will generally be given preference and `kallsyms` acts
+   * as a fallback.
    */
-  const char *kernel_image;
+  const char *vmlinux;
   /**
-   * Whether or not to consult debug symbols from `kernel_image`
-   * to satisfy the request (if present).
+   * Whether or not to consult debug symbols from `vmlinux` to
+   * satisfy the request (if present).
    */
   bool debug_syms;
   /**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased
 ----------
 - Added `--no-debug-syms` option to `inspect dump elf` sub-command
-- Added `--kallsyms` and `--kernel-image` options to `symbolize-kernel
+- Added `--kallsyms` and `--vmlinux` options to `symbolize-kernel
   sub-command
 
 

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -263,11 +263,11 @@ pub mod symbolize {
         // assignment, whereas `PathBuf` does not.
         #[arg(long, value_hint = ValueHint::FilePath)]
         pub kallsyms: Option<OsString>,
-        /// The kernel image file to use. If not provided, default
-        /// system locations will be searched for suitable candidates.
-        /// To disable usage provide an empty argument.
+        /// The vmlinux file to use. If not provided, default system
+        /// locations will be searched for suitable candidates. To
+        /// disable usage provide an empty argument.
         #[arg(long, value_hint = ValueHint::FilePath)]
-        pub kernel_image: Option<OsString>,
+        pub vmlinux: Option<OsString>,
         /// The addresses to symbolize.
         #[arg(value_parser = parse_addr)]
         pub addrs: Vec<Addr>,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -270,7 +270,7 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
         }
         args::symbolize::Symbolize::Kernel(args::symbolize::Kernel {
             kallsyms,
-            kernel_image,
+            vmlinux,
             ref addrs,
         }) => {
             let kernel = symbolize::Kernel {
@@ -279,7 +279,7 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
                     Some(path) if path.as_os_str().is_empty() => MaybeDefault::None,
                     Some(path) => MaybeDefault::Some(path.into()),
                 },
-                kernel_image: match kernel_image {
+                vmlinux: match vmlinux {
                     None => MaybeDefault::Default,
                     Some(path) if path.as_os_str().is_empty() => MaybeDefault::None,
                     Some(path) => MaybeDefault::Some(path.into()),

--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -28,7 +28,7 @@ impl KernelResolver {
     ) -> Result<KernelResolver> {
         if ksym_resolver.is_none() && elf_resolver.is_none() {
             return Err(Error::with_not_found(
-                    "failed to create kernel resolver: neither ksym resolver nor kernel image ELF resolver are present",
+                "failed to create kernel resolver: neither kallsyms nor vmlinux symbol source are present",
             ))
         }
 
@@ -45,11 +45,11 @@ impl Symbolize for KernelResolver {
             (Some(elf_resolver), None) => elf_resolver.find_sym(addr, opts),
             (None, Some(ksym_resolver)) => ksym_resolver.find_sym(addr, opts),
             (Some(elf_resolver), Some(ksym_resolver)) => {
-                // We give preference to the kernel image resolver, because it
-                // is likely to report more information. If it could not find
-                // an address, though, we fall back to kallsyms. This is
-                // helpful for example for kernel modules, which naturally are
-                // not captured by the core kernel image.
+                // We give preference to vmlinux, because it is likely
+                // to report more information. If it could not find an
+                // address, though, we fall back to kallsyms. This is
+                // helpful for example for kernel modules, which
+                // naturally are not captured by vmlinux.
                 let result = elf_resolver.find_sym(addr, opts)?;
                 if result.is_ok() {
                     Ok(result)

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -174,24 +174,28 @@ pub struct Kernel {
     /// If set to [`None`][MaybeDefault::None] usage of `kallsyms` will
     /// be disabled. Otherwise the copy at the given path will be used.
     ///
-    /// If both a kernel image as well as a `kallsyms` file are found,
-    /// the kernel image will generally be given preference and
-    /// `kallsyms` acts as a fallback.
+    /// If both a `vmlinux` as well as a `kallsyms` file are found,
+    /// `vmlinux` will generally be given preference and `kallsyms` acts
+    /// as a fallback.
     pub kallsyms: MaybeDefault<PathBuf>,
-    /// The path of the kernel image to use.
+    /// The path of the `vmlinux` file to use.
     ///
-    /// By default, the library will search for kernel image candidates
-    /// in various locations, taking into account the currently running
-    /// kernel version. If set to [`None`][MaybeDefault::None] usage of
-    /// a kernel image will be disabled. Otherwise the copy at the given
-    /// path will be used.
+    /// `vmlinux` is generally an uncompressed and unstripped object
+    /// file that is typically used in debugging, profiling, and
+    /// similar use cases.
     ///
-    /// If both a kernel image as well as a `kallsyms` file are found,
-    /// the kernel image will generally be given preference and
-    /// `kallsyms` acts as a fallback.
-    pub kernel_image: MaybeDefault<PathBuf>,
-    /// Whether or not to consult debug symbols from `kernel_image`
-    /// to satisfy the request (if present).
+    /// By default, the library will search for candidates in various
+    /// locations, taking into account the currently running kernel
+    /// version. If set to [`None`][MaybeDefault::None] discovery and
+    /// usage of a vmlinux file will be disabled. Otherwise the copy at
+    /// the given path will be used.
+    ///
+    /// If both a `vmlinux` as well as a `kallsyms` file are found,
+    /// `vmlinux` will generally be given preference and `kallsyms` acts
+    /// as a fallback.
+    pub vmlinux: MaybeDefault<PathBuf>,
+    /// Whether or not to consult debug symbols from `vmlinux` to
+    /// satisfy the request (if present).
     ///
     /// On top of this runtime configuration, the crate needs to be
     /// built with the `dwarf` feature to actually consult debug
@@ -207,7 +211,7 @@ impl Default for Kernel {
     fn default() -> Self {
         Self {
             kallsyms: MaybeDefault::Default,
-            kernel_image: MaybeDefault::Default,
+            vmlinux: MaybeDefault::Default,
             debug_syms: true,
             _non_exhaustive: (),
         }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -941,7 +941,7 @@ impl Symbolizer {
 
         let Kernel {
             kallsyms,
-            kernel_image,
+            vmlinux,
             debug_syms,
             _non_exhaustive: (),
         } = src;
@@ -968,11 +968,11 @@ impl Symbolizer {
             MaybeDefault::None => None,
         };
 
-        let elf_resolver = match kernel_image {
-            MaybeDefault::Some(image) => {
+        let elf_resolver = match vmlinux {
+            MaybeDefault::Some(vmlinux) => {
                 let resolver = self
                     .elf_cache
-                    .elf_resolver(image, self.maybe_debug_dirs(*debug_syms))?;
+                    .elf_resolver(vmlinux, self.maybe_debug_dirs(*debug_syms))?;
                 Some(resolver)
             }
             MaybeDefault::Default => {
@@ -980,23 +980,23 @@ impl Symbolizer {
                 let release = bytes_to_os_str(release.as_bytes())?;
                 let basename = OsStr::new("vmlinux-");
                 let dirs = [Path::new("/boot/"), Path::new("/usr/lib/debug/boot/")];
-                let kernel_image = dirs.iter().find_map(|dir| {
+                let vmlinux = dirs.iter().find_map(|dir| {
                     let mut file = basename.to_os_string();
                     let () = file.push(release);
                     let path = dir.join(file);
                     path.exists().then_some(path)
                 });
 
-                if let Some(image) = kernel_image {
+                if let Some(vmlinux) = vmlinux {
                     let result = self
                         .elf_cache
-                        .elf_resolver(&image, self.maybe_debug_dirs(*debug_syms));
+                        .elf_resolver(&vmlinux, self.maybe_debug_dirs(*debug_syms));
                     match result {
                         Ok(resolver) => Some(resolver),
                         Err(err) => {
                             log::warn!(
-                                "failed to load kernel image {}: {err}; ignoring...",
-                                image.display()
+                                "failed to load vmlinux `{}`: {err}; ignoring...",
+                                vmlinux.display()
                             );
                             None
                         }

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -554,7 +554,7 @@ fn symbolize_breakpad_inlined() {
 }
 
 /// Check that we can symbolize the `abort_creds` function inside a
-/// kernel image properly. Inside of
+/// vmlinux file properly. Inside of
 /// vmlinux-5.17.12-100.fc34.x86_64.dwarf, this function's address range
 /// and name are in separate attributes:
 /// ```text
@@ -1023,7 +1023,7 @@ fn symbolize_zip_with_custom_dispatch_errors() {
 fn symbolize_kernel_no_valid_source() {
     let kernel = Kernel {
         kallsyms: MaybeDefault::None,
-        kernel_image: MaybeDefault::None,
+        vmlinux: MaybeDefault::None,
         ..Default::default()
     };
     let src = Source::Kernel(kernel);
@@ -1043,14 +1043,14 @@ fn symbolize_kernel_no_valid_source() {
 /// file.
 #[test]
 fn symbolize_kernel_kallsyms() {
-    fn test(kernel_image: MaybeDefault<PathBuf>) {
+    fn test(vmlinux: MaybeDefault<PathBuf>) {
         let kernel = Kernel {
             kallsyms: MaybeDefault::from(
                 Path::new(&env!("CARGO_MANIFEST_DIR"))
                     .join("data")
                     .join("kallsyms"),
             ),
-            kernel_image,
+            vmlinux,
             ..Default::default()
         };
         let src = Source::Kernel(kernel);
@@ -1064,7 +1064,7 @@ fn symbolize_kernel_kallsyms() {
     }
 
     test(MaybeDefault::None);
-    // Provide a valid "kernel" image file, but given that it does not
+    // Provide a valid "vmlinux" file, but given that it does not
     // contain the address we attempt to symbolize we should end up
     // falling back to using kallsyms.
     test(MaybeDefault::Some(
@@ -1074,9 +1074,9 @@ fn symbolize_kernel_kallsyms() {
     ));
 }
 
-/// Test symbolization of a "kernel" address in an ELF file.
+/// Test symbolization of a "kernel" address in an vmlinux ELF file.
 #[test]
-fn symbolize_kernel_image() {
+fn symbolize_kernel_vmlinux() {
     #[track_caller]
     fn test(kernel: Kernel, has_code_info: bool) {
         let src = Source::Kernel(kernel);
@@ -1100,10 +1100,9 @@ fn symbolize_kernel_image() {
 
     let mut src = Kernel {
         kallsyms: MaybeDefault::None,
-        // We use a fake kernel image here for testing purposes, which
-        // really is just a regular ELF file, but that's what the kernel
-        // image would be anyway.
-        kernel_image: MaybeDefault::Some(
+        // We use a fake vmlinux here for testing purposes, which really
+        // is just a regular ELF file.
+        vmlinux: MaybeDefault::Some(
             Path::new(&env!("CARGO_MANIFEST_DIR"))
                 .join("data")
                 .join("test-stable-addrs.bin"),
@@ -1119,7 +1118,7 @@ fn symbolize_kernel_image() {
     test(src.clone(), false);
 
     // Source has no debug syms and we do not want to use them.
-    src.kernel_image = MaybeDefault::Some(
+    src.vmlinux = MaybeDefault::Some(
         Path::new(&env!("CARGO_MANIFEST_DIR"))
             .join("data")
             .join("test-stable-addrs-no-dwarf.bin"),


### PR DESCRIPTION
The terms "kernel image" is pretty ambiguous and somewhat nebulous, to the point that it is probably not clear to many what it or its properties should be. What we (and other debugging/profiling tools) really seem to be interested in is what generally seems to be referred to as vmlinux [0].
Switch terminology from "kernel image" to "vmlinux". The latter is much more easily discoverable (both in the sense that the meaning of the word can be pinned down as well as that a file of that name [or with such a prefix] can be found on the file system) and more precisely defined.

[0] https://en.wikipedia.org/w/index.php?title=Vmlinux&oldid=1252541783