### PR TITLE
Add direct links to documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
+documentation = "https://docs.rs/blazesym"
 categories = [
   "algorithms",
   "api-bindings",

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
+documentation = "https://docs.rs/blazesym-c"
 categories = [
   "algorithms",
   "api-bindings",


### PR DESCRIPTION
Make the URL to the documentation of each of the library crates known so that it will be easier to click through to it from a crates.io search.