### PR TITLE
Include KASLR offset in vmlinux based symbolization logic

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -34,8 +34,8 @@ jobs:
       - uses: actions/cache/restore@v4
         id: restore-cached-kernel
         with:
-          path: build/arch/x86/boot/bzImage
-          key: linux-kernel-${{ inputs.rev }}-${{ hashFiles(inputs.config) }}
+          path: build/
+          key: linux-kernel-wtf-${{ inputs.rev }}-${{ hashFiles(inputs.config) }}
       - if: steps.restore-cached-kernel.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
         with:
@@ -52,7 +52,7 @@ jobs:
           config=$(readlink --canonicalize-existing ${{ inputs.config }})
           build=$(pwd)/build/
 
-          cd linux/
+          pushd linux/
           export KBUILD_OUTPUT="${build}"
           mkdir "${KBUILD_OUTPUT}"
 
@@ -62,12 +62,17 @@ jobs:
           cat "${KBUILD_OUTPUT}/.config"
           echo "::endgroup::"
 
-          make O="${KBUILD_OUTPUT}" --jobs $(($(nproc) * 2))
+          make O="${KBUILD_OUTPUT}" --jobs $(($(nproc) * 2)) bzImage vmlinux
+
+          popd
+          mv build/arch/x86/boot/bzImage build/
       - if: steps.restore-cached-kernel.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/arch/x86/boot/bzImage
-          key: linux-kernel-${{ inputs.rev }}-${{ hashFiles(inputs.config) }}
+          path: |
+            build/bzImage
+            build/vmlinux
+          key: linux-kernel-wtf-${{ inputs.rev }}-${{ hashFiles(inputs.config) }}
       - uses: actions/upload-artifact@v4
         id: upload-linux-kernel
         # TODO: Having a single path/name may be problematic should we
@@ -78,4 +83,6 @@ jobs:
           if-no-files-found: error
           # The kernel image is already compressed.
           compression-level: 0
-          path: build/arch/x86/boot/bzImage
+          path: |
+            build/bzImage
+            build/vmlinux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     secrets: inherit
     with:
+      # Please keep in sync with vmlinux release version specification
+      # below.
       rev: v6.11
       config: 'data/config'
   build:
@@ -221,8 +223,10 @@ jobs:
           --header "X-GitHub-Api-Version: 2022-11-28" \
           --output artifact.zip \
           "${ARTIFACT_URL}"
-        # This unzip will produce the kernel bzImage.
+        # This unzip will produce the kernel bzImage and vmlinux.
         unzip artifact.zip
+        # Put vmlinux file into a location amenable to auto-discovery.
+        sudo mv vmlinux /boot/vmlinux-6.11.0
 
         cat <<EOF > main.sh
         #!/bin/sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
   file, if present
 - Changed `symbolize::Kernel::{kallsyms,kernel_image}` to support
   disabling of the source
+- Adjusted `vmlinux` based kernel address symbolization logic to take
+  into account system KASLR state
+  - Added `kaslr_offset` member to `symbolize::Kernel`
 
 
 0.2.0-rc.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ anyhow = "1.0.71"
 blazesym-dev = {path = "dev", features = ["generate-unit-test-files"]}
 # TODO: Use 0.5.2 once released.
 criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}
+rand = {version = "0.9", default-features = false, features = ["std", "thread_rng"]}
 scopeguard = "1.2"
 stats_alloc = {version = "0.1.1", features = ["nightly"]}
 tempfile = "3.4"

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -171,6 +171,7 @@ impl From<blaze_symbolize_src_kernel> for Kernel {
         Self {
             kallsyms: to_maybe_path(kallsyms),
             vmlinux: to_maybe_path(vmlinux),
+            kaslr_offset: None,
             debug_syms,
             _non_exhaustive: (),
         }

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -11,7 +11,6 @@ pub(crate) mod types;
 //       of concerns that is not a workable location.
 pub(crate) static DEFAULT_DEBUG_DIRS: &[&str] = &["/usr/lib/debug", "/lib/debug/"];
 
-#[cfg(test)]
 pub(crate) use parser::BackendImpl;
 pub(crate) use parser::ElfParser;
 pub(crate) use resolver::ElfResolverData;

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -887,7 +887,6 @@ where
     _backend: B::ObjTy,
 }
 
-#[cfg(test)]
 impl ElfParser<File> {
     fn open_file_io<P>(file: File, path: P) -> Self
     where

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,11 +1,8 @@
 #[cfg(feature = "bpf")]
 mod bpf;
+mod kaslr;
 mod ksym;
 mod resolver;
-// Still work in progress.
-#[allow(unused)]
-#[cfg(test)]
-mod kaslr;
 
 // TODO: KsymResolver should ideally be an implementation detail.
 pub(crate) use ksym::KsymResolver;

--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -11,20 +11,25 @@ use crate::symbolize::ResolvedSym;
 use crate::symbolize::Symbolize;
 use crate::Addr;
 use crate::Error;
+use crate::ErrorExt as _;
+use crate::IntoError as _;
 use crate::Result;
 
+use super::kaslr::find_kalsr_offset;
 use super::ksym::KsymResolver;
 
 
 pub(crate) struct KernelResolver {
     ksym_resolver: Option<Rc<KsymResolver>>,
     elf_resolver: Option<Rc<ElfResolver>>,
+    kaslr_offset: u64,
 }
 
 impl KernelResolver {
     pub(crate) fn new(
         ksym_resolver: Option<Rc<KsymResolver>>,
         elf_resolver: Option<Rc<ElfResolver>>,
+        kaslr_offset: Option<u64>,
     ) -> Result<KernelResolver> {
         if ksym_resolver.is_none() && elf_resolver.is_none() {
             return Err(Error::with_not_found(
@@ -32,17 +37,35 @@ impl KernelResolver {
             ))
         }
 
+        let kaslr_offset = if let Some(kaslr_offset) = kaslr_offset {
+            kaslr_offset
+        } else {
+            find_kalsr_offset()
+                .context("failed to query system KASLR offset")?
+                .unwrap_or_default()
+        };
+
         Ok(KernelResolver {
             ksym_resolver,
             elf_resolver,
+            kaslr_offset,
         })
     }
 }
 
 impl Symbolize for KernelResolver {
     fn find_sym(&self, addr: Addr, opts: &FindSymOpts) -> Result<Result<ResolvedSym<'_>, Reason>> {
+        let elf_addr = || {
+            addr.checked_sub(self.kaslr_offset).ok_or_invalid_input(|| {
+                format!(
+                    "address {addr:#x} is less than KASLR offset ({:#x})",
+                    self.kaslr_offset
+                )
+            })
+        };
+
         match (self.elf_resolver.as_ref(), self.ksym_resolver.as_ref()) {
-            (Some(elf_resolver), None) => elf_resolver.find_sym(addr, opts),
+            (Some(elf_resolver), None) => elf_resolver.find_sym(elf_addr()?, opts),
             (None, Some(ksym_resolver)) => ksym_resolver.find_sym(addr, opts),
             (Some(elf_resolver), Some(ksym_resolver)) => {
                 // We give preference to vmlinux, because it is likely
@@ -50,7 +73,7 @@ impl Symbolize for KernelResolver {
                 // address, though, we fall back to kallsyms. This is
                 // helpful for example for kernel modules, which
                 // naturally are not captured by vmlinux.
-                let result = elf_resolver.find_sym(addr, opts)?;
+                let result = elf_resolver.find_sym(elf_addr()?, opts)?;
                 if result.is_ok() {
                     Ok(result)
                 } else {
@@ -95,7 +118,7 @@ mod tests {
     #[test]
     fn debug_repr() {
         let ksym = Rc::new(KsymResolver::load_file_name(Path::new(KALLSYMS)).unwrap());
-        let kernel = KernelResolver::new(Some(ksym), None).unwrap();
+        let kernel = KernelResolver::new(Some(ksym), None, Some(0)).unwrap();
         assert_ne!(format!("{kernel:?}"), "");
     }
 }

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -194,6 +194,13 @@ pub struct Kernel {
     /// `vmlinux` will generally be given preference and `kallsyms` acts
     /// as a fallback.
     pub vmlinux: MaybeDefault<PathBuf>,
+    /// The KASLR offset to use.
+    ///
+    /// Given a value of `None`, the library will attempt to deduce the
+    /// offset itself. Note that this value only has relevance when a
+    /// kernel image is used for symbolization, because `kallsyms` based
+    /// data already include randomization adjusted addresses.
+    pub kaslr_offset: Option<u64>,
     /// Whether or not to consult debug symbols from `vmlinux` to
     /// satisfy the request (if present).
     ///
@@ -212,6 +219,7 @@ impl Default for Kernel {
         Self {
             kallsyms: MaybeDefault::Default,
             vmlinux: MaybeDefault::Default,
+            kaslr_offset: None,
             debug_syms: true,
             _non_exhaustive: (),
         }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -942,6 +942,7 @@ impl Symbolizer {
         let Kernel {
             kallsyms,
             vmlinux,
+            kaslr_offset,
             debug_syms,
             _non_exhaustive: (),
         } = src;
@@ -992,7 +993,10 @@ impl Symbolizer {
                         .elf_cache
                         .elf_resolver(&vmlinux, self.maybe_debug_dirs(*debug_syms));
                     match result {
-                        Ok(resolver) => Some(resolver),
+                        Ok(resolver) => {
+                            log::debug!("found suitable vmlinux file `{}`", vmlinux.display());
+                            Some(resolver)
+                        }
                         Err(err) => {
                             log::warn!(
                                 "failed to load vmlinux `{}`: {err}; ignoring...",
@@ -1008,7 +1012,7 @@ impl Symbolizer {
             MaybeDefault::None => None,
         };
 
-        KernelResolver::new(ksym_resolver.cloned(), elf_resolver.cloned())
+        KernelResolver::new(ksym_resolver.cloned(), elf_resolver.cloned(), *kaslr_offset)
     }
 
     #[cfg(not(linux))]


### PR DESCRIPTION
Our vmlinux based symbolization can only work properly of the kernel location is not randomized, because then the in-memory addresses should match up with those in the file.
To make sure that symbolization will work properly when KASLR (kernel address space layout randomization) is enabled, query the corresponding randomization offset and incorporate it in symbolization requests. Also add a new attribute, `kaslr_offset`, to the Kernel symbolization source that allows for passing in the offset if necessary.