### PR TITLE
Use maps::parse_filtered() for process symbolization

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -898,7 +898,7 @@ impl Symbolizer {
         perf_map: bool,
         map_files: bool,
     ) -> Result<Vec<Symbolized>> {
-        let mut entry_iter = maps::parse(pid)?;
+        let mut entry_iter = maps::parse_filtered(pid)?;
         let entries = |_addr| entry_iter.next();
 
         let mut handler = SymbolizeHandler {


### PR DESCRIPTION
In general not all entries in `/proc/[pid]/maps` are of interest to us and we perform some pre-filtering based on somewhat coarse grained criteria. However, for one reason or another we didn't do that in the symbolization logic, only when normalizing. Having failed to surface why that is, exactly, let's switch over to using the filtered version nonetheless, as none of our tests fail with the filtered version. Do so should speed up things a bit and make follow-on changes easier to digest.