### PR TITLE
Fix various CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: Check incremental rebuilds
@@ -172,7 +174,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
@@ -258,7 +262,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo check --package=blazesym-dev --features=generate-unit-test-files
@@ -297,7 +303,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
@@ -320,7 +328,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev liblzma-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev liblzma-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
@@ -362,7 +372,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo run --example backtrace
@@ -390,7 +402,9 @@ jobs:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
     - name: Install development dependencies
-      run: sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: Run benchmarks


### PR DESCRIPTION
In yet another cloak-and-dagger operation, Ubuntu managed to break their own !@#&*)(@!&*(! again. This time they are forcing us to apt-get update, because apparently the snapshot shipped with an image isn't good enough and we need yet more exposure to more of their broken !@&*()!@&(*.