### PR TITLE
Add support for pre-caching process VMA metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 - Adjusted `vmlinux` based kernel address symbolization logic to take
   into account system KASLR state
   - Added `kaslr_offset` member to `symbolize::Kernel`
+- Moved symbolization and inspection sources into `source` sub-module
 
 
 0.2.0-rc.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Added support for 32 bit ELF binaries
+- Added `symbolize::Symbolizer::cache` method for caching process VMA
+  metadata
 - Renamed `symbolize::Source::kernel_image` to `vmlinux`
 - Adjusted kernel symbolization logic to give preference to `vmlinux`
   file, if present

--- a/benches/inspect.rs
+++ b/benches/inspect.rs
@@ -1,7 +1,8 @@
 use std::hint::black_box;
 use std::path::Path;
 
-use blazesym::inspect;
+use blazesym::inspect::source::Elf;
+use blazesym::inspect::source::Source;
 use blazesym::inspect::Inspector;
 
 use criterion::measurement::Measurement;
@@ -14,7 +15,7 @@ fn lookup_elf() {
     let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("vmlinux-5.17.12-100.fc34.x86_64.elf");
-    let src = inspect::Source::Elf(inspect::Elf::new(dwarf_vmlinux));
+    let src = Source::Elf(Elf::new(dwarf_vmlinux));
 
     let inspector = Inspector::new();
     let results = inspector
@@ -35,7 +36,7 @@ fn lookup_dwarf() {
     let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("vmlinux-5.17.12-100.fc34.x86_64.dwarf");
-    let src = inspect::Source::Elf(inspect::Elf::new(dwarf_vmlinux));
+    let src = Source::Elf(Elf::new(dwarf_vmlinux));
 
     let inspector = Inspector::new();
     let results = inspector

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -3,13 +3,13 @@
 use std::hint::black_box;
 use std::path::Path;
 
-use blazesym::symbolize::Breakpad;
-use blazesym::symbolize::Elf;
-use blazesym::symbolize::GsymFile;
+use blazesym::symbolize::source::Breakpad;
+use blazesym::symbolize::source::Elf;
+use blazesym::symbolize::source::GsymFile;
+use blazesym::symbolize::source::Kernel;
+use blazesym::symbolize::source::Process;
+use blazesym::symbolize::source::Source;
 use blazesym::symbolize::Input;
-use blazesym::symbolize::Kernel;
-use blazesym::symbolize::Process;
-use blazesym::symbolize::Source;
 use blazesym::symbolize::Symbolizer;
 use blazesym::Addr;
 use blazesym::Pid;

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
   `vmlinux`
 - Added support for disabling `kallsyms` and `vmlinux` to
   `blaze_symbolize_src_kernel`
+- Added `blaze_symbolize_cache_process` for caching process VMA metadata
 
 
 0.1.0-rc.2

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -280,7 +280,7 @@ typedef struct blaze_inspector blaze_inspector;
 /**
  * An object representing an ELF inspection source.
  *
- * C ABI compatible version of [`inspect::Elf`].
+ * C ABI compatible version of [`inspect::source::Elf`].
  */
 typedef struct blaze_inspect_elf_src {
   /**

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -17,9 +17,9 @@ use std::ptr;
 
 #[cfg(doc)]
 use blazesym::inspect;
-use blazesym::inspect::Elf;
+use blazesym::inspect::source::Elf;
+use blazesym::inspect::source::Source;
 use blazesym::inspect::Inspector;
-use blazesym::inspect::Source;
 use blazesym::inspect::SymInfo;
 use blazesym::Addr;
 use blazesym::SymType;
@@ -38,7 +38,7 @@ pub type blaze_inspector = Inspector;
 
 /// An object representing an ELF inspection source.
 ///
-/// C ABI compatible version of [`inspect::Elf`].
+/// C ABI compatible version of [`inspect::source::Elf`].
 #[repr(C)]
 #[derive(Debug)]
 pub struct blaze_inspect_elf_src {

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -400,6 +400,7 @@ mod tests {
 
 
     /// Check that various types have expected sizes.
+    #[tag(miri)]
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn type_sizes() {

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -746,6 +746,7 @@ mod tests {
 
 
     /// Check that various types have expected sizes.
+    #[tag(miri)]
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn type_sizes() {

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -12,16 +12,16 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::ptr;
 
+use blazesym::symbolize::source::Elf;
+use blazesym::symbolize::source::GsymData;
+use blazesym::symbolize::source::GsymFile;
+use blazesym::symbolize::source::Kernel;
+use blazesym::symbolize::source::Process;
+use blazesym::symbolize::source::Source;
 use blazesym::symbolize::CodeInfo;
-use blazesym::symbolize::Elf;
-use blazesym::symbolize::GsymData;
-use blazesym::symbolize::GsymFile;
 use blazesym::symbolize::InlinedFn;
 use blazesym::symbolize::Input;
-use blazesym::symbolize::Kernel;
-use blazesym::symbolize::Process;
 use blazesym::symbolize::Reason;
-use blazesym::symbolize::Source;
 use blazesym::symbolize::Sym;
 use blazesym::symbolize::Symbolized;
 use blazesym::symbolize::Symbolizer;
@@ -1757,8 +1757,8 @@ mod tests {
             .join("..")
             .join("data")
             .join("test-rs.bin");
-        let elf = inspect::Elf::new(&test_dwarf);
-        let src = inspect::Source::Elf(elf);
+        let elf = inspect::source::Elf::new(&test_dwarf);
+        let src = inspect::source::Source::Elf(elf);
 
         let inspector = inspect::Inspector::new();
         let results = inspector

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,11 +83,11 @@ fn inspect(inspect: args::inspect::Inspect) -> Result<()> {
                     path,
                     ref names,
                 }) => {
-                    let src = inspect::Source::from(inspect::Breakpad::new(path));
+                    let src = inspect::source::Source::from(inspect::source::Breakpad::new(path));
                     (src, names)
                 }
                 args::inspect::Lookup::Elf(args::inspect::ElfLookup { path, ref names }) => {
-                    let src = inspect::Source::from(inspect::Elf::new(path));
+                    let src = inspect::source::Source::from(inspect::source::Elf::new(path));
                     (src, names)
                 }
             };
@@ -108,15 +108,15 @@ fn inspect(inspect: args::inspect::Inspect) -> Result<()> {
         args::inspect::Inspect::Dump(dump) => {
             let src = match dump {
                 args::inspect::Dump::Breakpad(args::inspect::BreakpadDump { path }) => {
-                    inspect::Source::from(inspect::Breakpad::new(path))
+                    inspect::source::Source::from(inspect::source::Breakpad::new(path))
                 }
                 args::inspect::Dump::Elf(args::inspect::ElfDump {
                     path,
                     no_debug_syms,
                 }) => {
-                    let mut elf = inspect::Elf::new(path);
+                    let mut elf = inspect::source::Elf::new(path);
                     elf.debug_syms = !no_debug_syms;
-                    inspect::Source::from(elf)
+                    inspect::source::Source::from(elf)
                 }
             };
             let mut sym_infos = Vec::new();
@@ -227,7 +227,7 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
     let mut builder = Symbolizer::builder();
     let (src, input, addrs) = match symbolize {
         args::symbolize::Symbolize::Breakpad(args::symbolize::Breakpad { path, ref addrs }) => {
-            let src = symbolize::Source::from(symbolize::Breakpad::new(path));
+            let src = symbolize::source::Source::from(symbolize::source::Breakpad::new(path));
             let addrs = addrs.as_slice();
             let input = symbolize::Input::FileOffset(addrs);
             (src, input, addrs)
@@ -243,15 +243,15 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
         }) => {
             builder = builder.set_debug_dirs(debug_dirs);
 
-            let mut elf = symbolize::Elf::new(path);
+            let mut elf = symbolize::source::Elf::new(path);
             elf.debug_syms = !no_debug_syms;
-            let src = symbolize::Source::from(elf);
+            let src = symbolize::source::Source::from(elf);
             let addrs = addrs.as_slice();
             let input = symbolize::Input::VirtOffset(addrs);
             (src, input, addrs)
         }
         args::symbolize::Symbolize::Gsym(args::symbolize::Gsym { path, ref addrs }) => {
-            let src = symbolize::Source::from(symbolize::GsymFile::new(path));
+            let src = symbolize::source::Source::from(symbolize::source::GsymFile::new(path));
             let addrs = addrs.as_slice();
             let input = symbolize::Input::VirtOffset(addrs);
             (src, input, addrs)
@@ -261,9 +261,9 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
             ref addrs,
             no_map_files,
         }) => {
-            let mut process = symbolize::Process::new(pid);
+            let mut process = symbolize::source::Process::new(pid);
             process.map_files = !no_map_files;
-            let src = symbolize::Source::from(process);
+            let src = symbolize::source::Source::from(process);
             let addrs = addrs.as_slice();
             let input = symbolize::Input::AbsAddr(addrs);
             (src, input, addrs)
@@ -273,7 +273,7 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
             vmlinux,
             ref addrs,
         }) => {
-            let kernel = symbolize::Kernel {
+            let kernel = symbolize::source::Kernel {
                 kallsyms: match kallsyms {
                     None => MaybeDefault::Default,
                     Some(path) if path.as_os_str().is_empty() => MaybeDefault::None,
@@ -286,7 +286,7 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
                 },
                 ..Default::default()
             };
-            let src = symbolize::Source::from(kernel);
+            let src = symbolize::source::Source::from(kernel);
             let addrs = addrs.as_slice();
             let input = symbolize::Input::AbsAddr(addrs);
             (src, input, addrs)

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -4,10 +4,10 @@ use anyhow::bail;
 use anyhow::Context as _;
 use anyhow::Result;
 
+use blazesym::symbolize::source::Elf;
+use blazesym::symbolize::source::Source;
 use blazesym::symbolize::CodeInfo;
-use blazesym::symbolize::Elf;
 use blazesym::symbolize::Input;
-use blazesym::symbolize::Source;
 use blazesym::symbolize::Sym;
 use blazesym::symbolize::Symbolized;
 use blazesym::symbolize::Symbolizer;

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -4,10 +4,10 @@ use anyhow::bail;
 use anyhow::Context as _;
 use anyhow::Result;
 
+use blazesym::symbolize::source::Process;
+use blazesym::symbolize::source::Source;
 use blazesym::symbolize::CodeInfo;
 use blazesym::symbolize::Input;
-use blazesym::symbolize::Process;
-use blazesym::symbolize::Source;
 use blazesym::symbolize::Sym;
 use blazesym::symbolize::Symbolized;
 use blazesym::symbolize::Symbolizer;

--- a/examples/backtrace.rs
+++ b/examples/backtrace.rs
@@ -5,10 +5,10 @@ use std::mem::size_of;
 use std::mem::transmute;
 use std::ptr;
 
+use blazesym::symbolize::source::Process;
+use blazesym::symbolize::source::Source;
 use blazesym::symbolize::CodeInfo;
 use blazesym::symbolize::Input;
-use blazesym::symbolize::Process;
-use blazesym::symbolize::Source;
 use blazesym::symbolize::Sym;
 use blazesym::symbolize::Symbolized;
 use blazesym::symbolize::Symbolizer;

--- a/examples/gsym-in-apk/main.rs
+++ b/examples/gsym-in-apk/main.rs
@@ -117,7 +117,7 @@ fn find_the_answer_fn_file_offset() -> Addr {
         .join("data")
         .join("libtest-so.so");
     let inspector = inspect::Inspector::new();
-    let src = inspect::Source::from(inspect::Elf::new(so));
+    let src = inspect::source::Source::from(inspect::source::Elf::new(so));
     let syms = inspector
         .lookup(&src, &["the_answer"])
         .unwrap()
@@ -139,7 +139,7 @@ fn find_the_answer_fn_file_offset() -> Addr {
 fn main() -> Result<()> {
     let fn_file_offset = find_the_answer_fn_file_offset();
     let apk = apk_path();
-    let src = symbolize::Source::Apk(symbolize::Apk::new(apk));
+    let src = symbolize::source::Source::Apk(symbolize::source::Apk::new(apk));
     let symbolizer = Symbolizer::builder()
         // Set a custom "dispatcher" function for symbolizing APKs. This will
         // cause the library to invoke our `dispatch_apk` function with some

--- a/examples/inspect-mangled.rs
+++ b/examples/inspect-mangled.rs
@@ -6,9 +6,9 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use blazesym::inspect::Elf;
+use blazesym::inspect::source::Elf;
+use blazesym::inspect::source::Source;
 use blazesym::inspect::Inspector;
-use blazesym::inspect::Source;
 use blazesym::inspect::SymInfo;
 
 use rustc_demangle::demangle;

--- a/examples/normalize-virt-offset.rs
+++ b/examples/normalize-virt-offset.rs
@@ -6,9 +6,9 @@
 
 use blazesym::helper::ElfResolver;
 use blazesym::normalize::Normalizer;
-use blazesym::symbolize::Elf;
+use blazesym::symbolize::source::Elf;
+use blazesym::symbolize::source::Source;
 use blazesym::symbolize::Input;
-use blazesym::symbolize::Source;
 use blazesym::symbolize::Symbolizer;
 use blazesym::symbolize::TranslateFileOffset as _;
 use blazesym::Addr;

--- a/examples/sym-debuginfod/main.rs
+++ b/examples/sym-debuginfod/main.rs
@@ -177,7 +177,8 @@ fn main() -> Result<()> {
         .context("failed to find valid URLs in DEBUGINFOD_URLS environment variable")?;
     let client = CachingClient::from_env(client)?;
 
-    let src = symbolize::Source::Process(symbolize::Process::new(Pid::from(args.pid)));
+    let src =
+        symbolize::source::Source::Process(symbolize::source::Process::new(Pid::from(args.pid)));
     let symbolizer = Symbolizer::builder()
         .set_process_dispatcher(move |info| dispatch_process(info, &client))
         .build();

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -3,10 +3,11 @@
 //! etc.) by name or iterating over all available symbols.
 //!
 //! ```no_run
-//! use blazesym::inspect;
+//! use blazesym::inspect::source::Elf;
+//! use blazesym::inspect::source::Source;
 //! use blazesym::inspect::Inspector;
 //!
-//! let src = inspect::Source::Elf(inspect::Elf::new("/usr/bin/libc.so"));
+//! let src = Source::Elf(Elf::new("/usr/bin/libc.so"));
 //! let inspector = Inspector::new();
 //! let results = inspector
 //!     .lookup(&src, &["fopen"])
@@ -18,7 +19,7 @@
 
 #[cfg_attr(not(feature = "dwarf"), allow(unused_variables))]
 mod inspector;
-mod source;
+pub mod source;
 
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -30,11 +31,6 @@ use crate::Result;
 use crate::SymType;
 
 pub use inspector::Inspector;
-cfg_breakpad! {
-  pub use source::Breakpad;
-}
-pub use source::Elf;
-pub use source::Source;
 
 
 /// Information about a symbol.

--- a/src/inspect/source.rs
+++ b/src/inspect/source.rs
@@ -1,3 +1,5 @@
+//! Definitions of supported inspection sources.
+
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;

--- a/src/normalize/meta.rs
+++ b/src/normalize/meta.rs
@@ -10,8 +10,8 @@ use super::Reason;
 ///
 /// The corresponding file offset is normalized only to the APK container, not
 /// any potential internal ELF files. Use the
-/// [`Apk`][crate::symbolize::Source::Apk] symbolization source in order to
-/// symbolize the offset:
+/// [`Apk`][crate::symbolize::source::Source::Apk] symbolization source in order
+/// to symbolize the offset:
 /// ```no_run
 /// # use std::path::Path;
 /// # use blazesym::Pid;
@@ -29,7 +29,7 @@ use super::Reason;
 ///
 /// // We assume that we have the APK lying around at the same path as on the
 /// // "remote" system.
-/// let src = symbolize::Source::from(symbolize::Apk::new(&apk.path));
+/// let src = symbolize::source::Source::from(symbolize::source::Apk::new(&apk.path));
 /// let symbolizer = symbolize::Symbolizer::new();
 /// let sym = symbolizer
 ///   .symbolize_single(&src, symbolize::Input::FileOffset(output))

--- a/src/symbolize/cache.rs
+++ b/src/symbolize/cache.rs
@@ -1,0 +1,111 @@
+//! Definitions of symbolization caching targets.
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
+
+use crate::Pid;
+
+
+/// Configuration for caching of process-level data.
+#[derive(Clone)]
+pub struct Process {
+    /// The referenced process' ID.
+    pub pid: Pid,
+    /// Whether to cache the process' VMAs for later use.
+    ///
+    /// Caching VMAs can be useful, because it conceptually enables the
+    /// library to serve a symbolization request targeting a process
+    /// even if said process has since exited the system.
+    ///
+    /// Note that once VMAs have been cached this way, the library will
+    /// refrain from re-reading updated VMAs unless instructed to.
+    /// Hence, if you have reason to believe that a process may have
+    /// changed its memory regions (by loading a new shared object, for
+    /// example), you would have to make another request to cache them
+    /// yourself.
+    ///
+    /// Note furthermore that if you cache VMAs to later symbolize
+    /// addresses after the original process has already exited, you
+    /// will have to opt-out of usage of `/proc/<pid>/map_files/` as
+    /// part of the symbolization request. Refer to
+    /// [`source::Process::map_files`][crate::symbolize::source::Process::map_files].
+    pub cache_vmas: bool,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
+}
+
+impl Process {
+    /// Create a new [`Process`] object using the provided `pid`.
+    ///
+    /// `cache_vmas` default to `true` when using this constructor.
+    #[inline]
+    pub fn new(pid: Pid) -> Self {
+        Self {
+            pid,
+            cache_vmas: true,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl Debug for Process {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let Self {
+            pid,
+            cache_vmas: _,
+            _non_exhaustive: (),
+        } = self;
+
+        f.debug_tuple(stringify!(Process))
+            .field(&format_args!("{pid}"))
+            .finish()
+    }
+}
+
+impl From<Process> for Cache<'static> {
+    #[inline]
+    fn from(process: Process) -> Self {
+        Self::Process(process)
+    }
+}
+
+
+/// A description of what data to use to cache in advance, so that
+/// subsequent symbolization requests can be satisfied quicker.
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum Cache<'dat> {
+    /// Information about a process.
+    Process(Process),
+    #[doc(hidden)]
+    Phantom(&'dat ()),
+}
+
+impl Debug for Cache<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Process(process) => Debug::fmt(process, f),
+            Self::Phantom(()) => unreachable!(),
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let process = Process::new(Pid::Slf);
+        assert_eq!(format!("{process:?}"), "Process(self)");
+        let process = Process::new(Pid::from(1234));
+        assert_eq!(format!("{process:?}"), "Process(1234)");
+        let cache = Cache::from(process);
+        assert_eq!(format!("{cache:?}"), "Process(1234)");
+    }
+}

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -6,9 +6,9 @@
 //! For example, here we symbolize the address of `libc`'s `fopen` and `fseek`
 //! functions, given their addresses in the current process:
 //! ```no_run
+//! use blazesym::symbolize::source::Process;
+//! use blazesym::symbolize::source::Source;
 //! use blazesym::symbolize::Input;
-//! use blazesym::symbolize::Process;
-//! use blazesym::symbolize::Source;
 //! use blazesym::symbolize::Symbolizer;
 //! use blazesym::Addr;
 //! use blazesym::Pid;
@@ -91,7 +91,7 @@
 //! [`gsym-in-apk`](https://github.com/libbpf/blazesym/blob/main/examples/gsym-in-apk)
 //! example, which illustrates the basic workflow.
 
-mod source;
+pub mod source;
 mod symbolizer;
 
 use std::borrow::Cow;
@@ -102,22 +102,6 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::path::Path;
 use std::str;
-
-cfg_apk! {
-    pub use source::Apk;
-}
-cfg_breakpad! {
-    pub use source::Breakpad;
-}
-pub use source::Elf;
-cfg_gsym! {
-    pub use source::Gsym;
-    pub use source::GsymData;
-    pub use source::GsymFile;
-}
-pub use source::Kernel;
-pub use source::Process;
-pub use source::Source;
 
 cfg_apk! {
     pub use symbolizer::ApkDispatch;

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -91,6 +91,7 @@
 //! [`gsym-in-apk`](https://github.com/libbpf/blazesym/blob/main/examples/gsym-in-apk)
 //! example, which illustrates the basic workflow.
 
+pub mod cache;
 pub mod source;
 mod symbolizer;
 

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -1,3 +1,5 @@
+//! Definitions of supported symbolization sources.
+
 use std::cmp::min;
 use std::fmt::Debug;
 use std::fmt::Formatter;

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1442,7 +1442,6 @@ mod tests {
     use test_log::test;
 
     use crate::maps::Perm;
-    use crate::symbolize;
     use crate::symbolize::CodeInfo;
 
 
@@ -1532,39 +1531,39 @@ mod tests {
 
         let unsupported = [
             (
-                symbolize::Source::Apk(symbolize::Apk::new(test_zip)),
+                Source::Apk(Apk::new(test_zip)),
                 &[
                     Input::VirtOffset([40].as_slice()),
                     Input::AbsAddr([41].as_slice()),
                 ][..],
             ),
             (
-                symbolize::Source::Breakpad(symbolize::Breakpad::new(test_sym)),
+                Source::Breakpad(Breakpad::new(test_sym)),
                 &[
                     Input::VirtOffset([50].as_slice()),
                     Input::AbsAddr([51].as_slice()),
                 ][..],
             ),
             (
-                symbolize::Source::Process(symbolize::Process::new(Pid::Slf)),
+                Source::Process(Process::new(Pid::Slf)),
                 &[
                     Input::VirtOffset([42].as_slice()),
                     Input::FileOffset([43].as_slice()),
                 ][..],
             ),
             (
-                symbolize::Source::Kernel(symbolize::Kernel::default()),
+                Source::Kernel(Kernel::default()),
                 &[
                     Input::VirtOffset([44].as_slice()),
                     Input::FileOffset([45].as_slice()),
                 ][..],
             ),
             (
-                symbolize::Source::Elf(symbolize::Elf::new(test_elf)),
+                Source::Elf(Elf::new(test_elf)),
                 &[Input::AbsAddr([46].as_slice())][..],
             ),
             (
-                symbolize::Source::Gsym(symbolize::Gsym::File(symbolize::GsymFile::new(test_gsym))),
+                Source::Gsym(Gsym::File(GsymFile::new(test_gsym))),
                 &[
                     Input::AbsAddr([48].as_slice()),
                     Input::FileOffset([49].as_slice()),

--- a/tests/suite/inspect.rs
+++ b/tests/suite/inspect.rs
@@ -6,10 +6,10 @@ use std::ops::Deref as _;
 use std::path::Path;
 use std::str;
 
-use blazesym::inspect::Breakpad;
-use blazesym::inspect::Elf;
+use blazesym::inspect::source::Breakpad;
+use blazesym::inspect::source::Elf;
+use blazesym::inspect::source::Source;
 use blazesym::inspect::Inspector;
-use blazesym::inspect::Source;
 use blazesym::inspect::SymInfo;
 use blazesym::symbolize;
 use blazesym::SymType;
@@ -128,7 +128,7 @@ fn inspect_elf_dynamic_symbol() {
             .collect::<Vec<_>>();
         assert_eq!(results.len(), 1);
 
-        let src = symbolize::Source::Elf(symbolize::Elf::new(&bin));
+        let src = symbolize::source::Source::Elf(symbolize::source::Elf::new(&bin));
         let symbolizer = symbolize::Symbolizer::new();
         let result = symbolizer
             .symbolize_single(&src, symbolize::Input::VirtOffset(results[0].addr))
@@ -162,7 +162,7 @@ fn inspect_elf_indirect_function() {
         .collect::<Vec<_>>();
     assert_eq!(results.len(), 1);
 
-    let src = symbolize::Source::Elf(symbolize::Elf::new(&bin));
+    let src = symbolize::source::Source::Elf(symbolize::source::Elf::new(&bin));
     let symbolizer = symbolize::Symbolizer::new();
     let result = symbolizer
         .symbolize_single(&src, symbolize::Input::VirtOffset(results[0].addr))

--- a/tests/suite/normalize.rs
+++ b/tests/suite/normalize.rs
@@ -164,8 +164,8 @@ fn normalize_elf_addr() {
         );
         assert_eq!(path.canonicalize().unwrap(), test_so);
 
-        let elf = symbolize::Elf::new(test_so);
-        let src = symbolize::Source::Elf(elf);
+        let elf = symbolize::source::Elf::new(test_so);
+        let src = symbolize::source::Source::Elf(elf);
         let symbolizer = symbolize::Symbolizer::new();
         let result = symbolizer
             .symbolize_single(&src, symbolize::Input::FileOffset(output.0))
@@ -264,8 +264,8 @@ fn normalize_custom_so_in_zip() {
         assert_eq!(meta, &normalize::UserMeta::Apk(expected));
 
         // Also symbolize the normalization output.
-        let apk = symbolize::Apk::new(test_zip);
-        let src = symbolize::Source::Apk(apk);
+        let apk = symbolize::source::Apk::new(test_zip);
+        let src = symbolize::source::Source::Apk(apk);
         let symbolizer = symbolize::Symbolizer::new();
         let result = symbolizer
             .symbolize_single(&src, symbolize::Input::FileOffset(output.0))

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -16,23 +16,23 @@ use std::process;
 use blazesym::helper::ElfResolver;
 use blazesym::inspect;
 use blazesym::normalize;
+use blazesym::symbolize::source::Breakpad;
+use blazesym::symbolize::source::Elf;
+use blazesym::symbolize::source::GsymData;
+use blazesym::symbolize::source::GsymFile;
+use blazesym::symbolize::source::Kernel;
+use blazesym::symbolize::source::Process;
+use blazesym::symbolize::source::Source;
 use blazesym::symbolize::ApkDispatch;
 use blazesym::symbolize::ApkMemberInfo;
-use blazesym::symbolize::Breakpad;
-use blazesym::symbolize::Elf;
 use blazesym::symbolize::FindSymOpts;
-use blazesym::symbolize::GsymData;
-use blazesym::symbolize::GsymFile;
 use blazesym::symbolize::Input;
-use blazesym::symbolize::Kernel;
-use blazesym::symbolize::Process;
 use blazesym::symbolize::ProcessDispatch;
 use blazesym::symbolize::ProcessMemberInfo;
 use blazesym::symbolize::ProcessMemberType;
 use blazesym::symbolize::Reason;
 use blazesym::symbolize::Resolve;
 use blazesym::symbolize::ResolvedSym;
-use blazesym::symbolize::Source;
 use blazesym::symbolize::Symbolize;
 use blazesym::symbolize::Symbolized;
 use blazesym::symbolize::Symbolizer;
@@ -239,7 +239,7 @@ fn symbolize_zero_size_gsym() {
     let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("test-stable-addrs.bin");
-    let src = inspect::Source::Elf(inspect::Elf::new(path));
+    let src = inspect::source::Source::Elf(inspect::source::Elf::new(path));
     let inspector = inspect::Inspector::new();
     let results = inspector
         .lookup(&src, &["zero_size"])
@@ -703,8 +703,8 @@ fn symbolize_dwarf_demangle() {
     let test_dwarf = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
         .join("test-rs.bin");
-    let elf = inspect::Elf::new(&test_dwarf);
-    let src = inspect::Source::Elf(elf);
+    let elf = inspect::source::Elf::new(&test_dwarf);
+    let src = inspect::source::Source::Elf(elf);
 
     let inspector = inspect::Inspector::new();
     let results = inspector


### PR DESCRIPTION
Users may legitimately be interested in being able to symbolize addresses inside a process even if the process has exited in the meantime.

To support such use cases, introduce a new top-level API to the Symbolizer: the cache() method allows for caching various data pertaining a symbolization source. At this point we only support caching of process VMA metadata, but in the future we can support pre-parsing ELF and DWARF metadata and similar, which could speed up symbolization requests significantly.
