### PR TITLE
Adjust test-block to emit address to stdout

### DIFF
--- a/data/test-block.c
+++ b/data/test-block.c
@@ -18,13 +18,10 @@ void _start(void) {
   char buf[2];
   int rc;
   void* addr = (void*)&_start;
-  /* Write the address of `_start` to stderr. We use stderr because it's
-     unbuffered, so we spare ourselves from the pains of writing a
-     newline as well... */
   asm volatile (
       "syscall"
       : "=a"(rc)
-      : "a"(SYS_write), "D"(STDERR_FILENO), "S"(&addr), "d"(sizeof(addr))
+      : "a"(SYS_write), "D"(STDOUT_FILENO), "S"(&addr), "d"(sizeof(addr))
       : "rcx", "r11", "memory"
   );
   asm volatile (

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -1403,8 +1403,8 @@ fn symbolize_normalized_large_memsize() {
         .join("test-block.bin");
     let mut child = Command::new(&test_block)
         .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
         .spawn()
         .unwrap();
     let pid = child.id();
@@ -1418,7 +1418,7 @@ fn symbolize_normalized_large_memsize() {
 
     let mut buf = [0u8; size_of::<Addr>()];
     let count = child
-        .stderr
+        .stdout
         .as_mut()
         .unwrap()
         .read(&mut buf)


### PR DESCRIPTION
Adjust the test-block binary to emit the address of its _start function to stdout rather than stderr. Doing so is the first step towards unifying more of our "remote process" tests. Line buffering, as mentioned in the comment, does not seem to be an issue, presumably because it's a libc thing and we are directly using system calls.