### PR TITLE
Adjust libtest-so.so to dump await_input() address without text conversion

### DIFF
--- a/data/test-so.c
+++ b/data/test-so.c
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include <stdio.h>
 
 #include "test-so.h"
@@ -11,10 +12,18 @@ int the_ignored_answer(void) {
 }
 
 int await_input(void) {
-  fprintf(stdout, "%p\n", &await_input);
-  fflush(stdout);
+  void* addr = (void*)&await_input;
+  int rc = write(STDOUT_FILENO, &addr, sizeof(addr));
+  if (rc < 0) {
+    perror("failed to write address to stdout");
+    return 1;
+  }
 
-  int c;
-  c = getc(stdin);
+  char buf[2];
+  rc = read(STDIN_FILENO, buf, sizeof(buf));
+  if (rc < 0) {
+    perror("failed to read from stdin");
+    return 1;
+  }
   return 0;
 }

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -14,7 +14,6 @@ use std::path::PathBuf;
 use std::process;
 use std::process::Command;
 use std::process::Stdio;
-use std::str;
 
 use blazesym::helper::ElfResolver;
 use blazesym::inspect;
@@ -794,15 +793,15 @@ fn symbolize_process_in_mount_namespace() {
         let _rc = unsafe { kill(pid as _, SIGKILL) };
     });
 
-    let mut buf = [0u8; 64];
+    let mut buf = [0u8; size_of::<Addr>()];
     let count = child
         .stdout
         .as_mut()
         .unwrap()
         .read(&mut buf)
         .expect("failed to read child output");
-    let addr_str = str::from_utf8(&buf[0..count]).unwrap().trim_end();
-    let addr = Addr::from_str_radix(addr_str.trim_start_matches("0x"), 16).unwrap();
+    assert_eq!(count, buf.len());
+    let addr = Addr::from_ne_bytes(buf);
 
     // Make sure to destroy the symbolizer before terminating the child.
     // Otherwise something holds on to a reference and cleanup may fail.


### PR DESCRIPTION
Currently the libtest-so.so shared object's await_input() function nicely formatted the address of said function before emitting it to stdout. In an attempt to make all "remote process" tests use similar mechanisms, switch to just dumping the address as binary, foregoing the to-text conversion.