### PR TITLE
Rename run_user_symbolization_test -> run_unprivileged_process_test

### DIFF
--- a/tests/suite/common/mod.rs
+++ b/tests/suite/common/mod.rs
@@ -74,7 +74,7 @@ pub fn non_root_uid() -> uid_t {
 }
 
 #[cfg(linux)]
-pub fn run_user_symbolization_test<F>(callback_fn: F)
+pub fn run_unprivileged_process_test<F>(callback_fn: F)
 where
     F: FnOnce(Pid, u64, &Path) + UnwindSafe,
 {
@@ -140,7 +140,7 @@ where
 }
 
 #[cfg(not(linux))]
-pub fn run_user_symbolization_test<F>(_callback_fn: F)
+pub fn run_unprivileged_process_test<F>(_callback_fn: F)
 where
     F: FnOnce(Pid, u64, &Path) + UnwindSafe,
 {

--- a/tests/suite/normalize.rs
+++ b/tests/suite/normalize.rs
@@ -25,7 +25,7 @@ use tempfile::tempdir;
 use test_fork::test as forked_test;
 use test_log::test;
 
-use crate::suite::common::run_user_symbolization_test;
+use crate::suite::common::run_unprivileged_process_test;
 
 
 /// Check that we detect unsorted input addresses.
@@ -462,5 +462,5 @@ fn normalize_permissionless_impl(pid: Pid, addr: Addr, test_lib: &Path) {
 #[cfg(linux)]
 #[forked_test]
 fn normalize_process_symbolic_paths() {
-    run_user_symbolization_test(normalize_permissionless_impl)
+    run_unprivileged_process_test(normalize_permissionless_impl)
 }

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -64,7 +64,7 @@ use test_tag::tag;
 
 use crate::suite::common::as_user;
 use crate::suite::common::non_root_uid;
-use crate::suite::common::run_user_symbolization_test;
+use crate::suite::common::run_unprivileged_process_test;
 
 
 /// Make sure that we fail symbolization when providing a non-existent source.
@@ -1034,7 +1034,7 @@ fn symbolize_permissionless_impl(pid: Pid, addr: Addr, _test_lib: &Path) {
 #[cfg(linux)]
 #[forked_test]
 fn symbolize_process_symbolic_paths() {
-    run_user_symbolization_test(symbolize_permissionless_impl)
+    run_unprivileged_process_test(symbolize_permissionless_impl)
 }
 
 /// Check that we can symbolize an address residing in a zip archive, using


### PR DESCRIPTION
Rename the `run_user_symbolization_test` test to
`run_unprivileged_process_test`, to better reflect its intended purpose.