### PR TITLE
Run buildid reading tests on "other" OSs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,9 +273,10 @@ jobs:
         name: test-stable-addrs
         if-no-files-found: error
         path: |
-          data/test-stable-addrs*
-          data/test-rs.bin
           data/libtest-so*
+          data/test-no-debug.bin
+          data/test-rs.bin
+          data/test-stable-addrs*
   test-partly-supported:
     name: Test on ${{ matrix.runs-on }}
     strategy:

--- a/src/normalize/buildid.rs
+++ b/src/normalize/buildid.rs
@@ -195,12 +195,15 @@ mod tests {
     use std::fs::File;
 
     use test_log::test;
+    use test_tag::tag;
 
     use crate::ErrorKind;
+    use crate::Result;
 
 
     /// Check that we can read a binary's build ID based on the ELF section name
     /// as well as ELF section type.
+    #[tag(other_os)]
     #[test]
     fn build_id_reading_from_name_and_notes() {
         fn test(file: &str, f: fn(&ElfParser) -> Result<Option<BuildId>>) {
@@ -219,6 +222,7 @@ mod tests {
     }
 
     /// Check that we can read a binary's build ID.
+    #[tag(other_os)]
     #[test]
     fn build_id_reading() {
         let elf = Path::new(&env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Reading of build IDs can be useful on not just Linux hosts. Make sure to run the corresponding tests on all supported operating systems.