### PR TITLE
Include "W" symbols in symbolize_kernel_system_vmlinux test

### DIFF
--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -1283,7 +1283,7 @@ fn symbolize_kernel_system_vmlinux() {
                     .get(0..3)?
                     .try_into()
                     .unwrap();
-                if !["T", "t"].contains(&ty) {
+                if !["D", "T", "t", "W"].contains(&ty) {
                     return None
                 }
                 let addr = Addr::from_str_radix(addr, 16).unwrap();
@@ -1343,7 +1343,9 @@ fn symbolize_kernel_system_vmlinux() {
         .unwrap();
     assert_eq!(symbolized.len(), syms.len());
     for (i, sym) in symbolized.iter().enumerate() {
-        let sym = sym.as_sym().unwrap();
+        let sym = sym
+            .as_sym()
+            .unwrap_or_else(|| panic!("failed to symbolize {:x?}", syms[i]));
         assert_eq!(sym.name, syms[i].1, "{sym:?} | {:?}", syms[i]);
     }
 }


### PR DESCRIPTION
We have seen another failure of the symbolize_kernel_system_vmlinux test, caused by a symbol being aliased as both "T" and "W" type, under different names:
```
  $ cat /proc/kallsyms | grep blake2s_compress
  > ffffffff858cd870 T blake2s_compress_generic
  > ffffffff858cd870 W blake2s_compress
```

This is another source of ambiguity that we can't really anticipate in advance. To fix issues of this kind, include "W" symbols (and "D" ones) in the list of candidate ones to symbolize. This way, the alias detection logic will be able to filter them out based on their equal addresses.