### PR TITLE
Move `.text.factorial` section of `test-stable-addrs*` binaries

### DIFF
--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -689,7 +689,7 @@ mod tests {
             unsafe { CStr::from_ptr(sym_info.name) },
             CStr::from_bytes_with_nul(b"factorial\0").unwrap()
         );
-        assert_eq!(sym_info.addr, 0x2000100);
+        assert_eq!(sym_info.addr, 0x2000200);
 
         let () = unsafe { blaze_inspect_syms_free(result) };
         let () = unsafe { blaze_inspector_free(inspector) };

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -1615,7 +1615,7 @@ mod tests {
             F: FnOnce(*mut blaze_symbolizer, *const Addr, usize) -> *const blaze_syms,
         {
             let symbolizer = blaze_symbolizer_new();
-            let addrs = [0x2000100];
+            let addrs = [0x2000200];
             let result = symbolize(symbolizer, addrs.as_ptr(), addrs.len());
 
             assert!(!result.is_null());
@@ -1632,7 +1632,7 @@ mod tests {
                 sym.reason,
                 blaze_symbolize_reason::BLAZE_SYMBOLIZE_REASON_SUCCESS
             );
-            assert_eq!(sym.addr, 0x2000100);
+            assert_eq!(sym.addr, 0x2000200);
             assert_eq!(sym.offset, 0);
             assert!(sym.size > 0);
 
@@ -2066,7 +2066,7 @@ mod tests {
             debug_syms: true,
             ..Default::default()
         };
-        let addrs = [0x2000100];
+        let addrs = [0x2000200];
         let result = unsafe {
             blaze_symbolize_elf_virt_offsets(symbolizer, &elf_src, addrs.as_ptr(), addrs.len())
         };
@@ -2124,7 +2124,7 @@ mod tests {
             debug_syms: true,
             ..Default::default()
         };
-        let addrs = [0x2000100];
+        let addrs = [0x2000200];
         let result = unsafe {
             blaze_symbolize_elf_virt_offsets(symbolizer, &elf_src, addrs.as_ptr(), addrs.len())
         };

--- a/data/test-stable-addrs.ld
+++ b/data/test-stable-addrs.ld
@@ -2,9 +2,9 @@ SECTIONS {
   .text (0x2000000) : {
     *(.text.main)
     *(.text)
-    . = ABSOLUTE(0x2000100);
-    *(.text.factorial)
     . = ABSOLUTE(0x2000200);
+    *(.text.factorial)
+    . = ABSOLUTE(0x2000300);
     *(.text.inline)
     *(.text.*)
   }

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -521,7 +521,7 @@ mod tests {
         let resolver = DwarfResolver::open(bin_name.as_ref()).unwrap();
 
         let info = resolver
-            .find_sym(0x2000100, &FindSymOpts::CodeInfo)
+            .find_sym(0x2000200, &FindSymOpts::CodeInfo)
             .unwrap()
             .unwrap()
             .code_info
@@ -547,9 +547,9 @@ mod tests {
         let symbols = resolver.find_addr("factorial", &opts).unwrap();
         assert_eq!(symbols.len(), 1);
 
-        // `factorial` resides at address 0x2000100.
+        // `factorial` resides at address 0x2000200.
         let symbol = symbols.first().unwrap();
-        assert_eq!(symbol.addr, 0x2000100);
+        assert_eq!(symbol.addr, 0x2000200);
     }
 
     /// Check that we fail to look up variables.

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -1636,7 +1636,7 @@ mod tests {
             assert_eq!(syms.len(), 1);
             let sym = &syms[0];
             assert_eq!(sym.name, "factorial");
-            assert_eq!(sym.addr, 0x2000100);
+            assert_eq!(sym.addr, 0x2000200);
 
             let syms = parser.find_addr("factorial_wrapper", &opts).unwrap();
             assert_eq!(syms.len(), 2);

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -262,11 +262,11 @@ mod tests {
         gsym_fo.read_to_end(&mut data).unwrap();
         let ctx = GsymContext::parse_header(&data).unwrap();
 
-        let idx = ctx.find_addr(0x0000000002000000).unwrap();
+        let idx = ctx.find_addr(0x2000000).unwrap();
         let addrinfo = ctx.addr_info(idx).unwrap();
         assert_eq!(ctx.get_str(addrinfo.name as usize).unwrap(), "main");
 
-        let idx = ctx.find_addr(0x0000000002000100).unwrap();
+        let idx = ctx.find_addr(0x2000200).unwrap();
         let addrinfo = ctx.addr_info(idx).unwrap();
         assert_eq!(ctx.get_str(addrinfo.name as usize).unwrap(), "factorial");
     }

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -387,10 +387,10 @@ mod tests {
         assert_eq!(info.line, Some(75));
         assert_eq!(info.file, OsStr::new("test-stable-addrs.c"));
 
-        // `factorial` resides at address 0x2000100, and it's located at the
+        // `factorial` resides at address 0x2000200, and it's located at the
         // given line.
         let sym = resolver
-            .find_sym(0x2000100, &FindSymOpts::CodeInfoAndInlined)
+            .find_sym(0x2000200, &FindSymOpts::CodeInfoAndInlined)
             .unwrap()
             .unwrap();
         assert_eq!(sym.name, "factorial");
@@ -403,7 +403,7 @@ mod tests {
         // Address is hopefully sufficiently far into `factorial_inline_test` to
         // always fall into the inlined region, no matter toolchain. If not, add
         // padding bytes/dummy instructions and adjust some more.
-        let addr = 0x200020a;
+        let addr = 0x200030a;
         let sym = resolver
             .find_sym(addr, &FindSymOpts::CodeInfoAndInlined)
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ mod tests {
 
         let resolver = helper::GsymResolver::open(test_gsym).unwrap();
         let sym = resolver
-            .find_sym(0x2000100, &FindSymOpts::Basic)
+            .find_sym(0x2000200, &FindSymOpts::Basic)
             .unwrap()
             .unwrap();
         assert_eq!(sym.name, "factorial");

--- a/tests/suite/inspect.rs
+++ b/tests/suite/inspect.rs
@@ -29,7 +29,7 @@ fn inspect_elf() {
 
         let result = &results[0];
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].addr, 0x2000100);
+        assert_eq!(result[0].addr, 0x2000200);
         assert_eq!(result[0].sym_type, SymType::Function);
         assert_ne!(result[0].file_offset, None);
         assert_eq!(
@@ -102,7 +102,7 @@ fn inspect_breakpad() {
 
     let sym = &results[0];
     assert_eq!(sym.name, "factorial");
-    assert_eq!(sym.addr, 0x100);
+    assert_eq!(sym.addr, 0x200);
     assert_eq!(sym.sym_type, SymType::Function);
     assert_eq!(sym.file_offset, None);
     assert_eq!(sym.obj_file_name, None);

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -80,7 +80,7 @@ fn error_on_non_existent_source() {
 
     for src in srcs {
         let err = symbolizer
-            .symbolize_single(&src, Input::VirtOffset(0x2000100))
+            .symbolize_single(&src, Input::VirtOffset(0x2000200))
             .unwrap_err();
         assert_eq!(err.kind(), ErrorKind::NotFound);
     }
@@ -93,13 +93,13 @@ fn symbolize_elf_dwarf_gsym() {
     fn test(src: Source, has_code_info: bool) {
         let symbolizer = Symbolizer::new();
         let result = symbolizer
-            .symbolize_single(&src, Input::VirtOffset(0x2000100))
+            .symbolize_single(&src, Input::VirtOffset(0x2000200))
             .unwrap()
             .into_sym()
             .unwrap();
 
         assert_eq!(result.name, "factorial");
-        assert_eq!(result.addr, 0x2000100);
+        assert_eq!(result.addr, 0x2000200);
         assert_eq!(result.offset, 0);
 
         if has_code_info {
@@ -119,7 +119,7 @@ fn symbolize_elf_dwarf_gsym() {
         let offsets = (1..size).collect::<Vec<_>>();
         let addrs = offsets
             .iter()
-            .map(|offset| (0x2000100 + offset) as Addr)
+            .map(|offset| (0x2000200 + offset) as Addr)
             .collect::<Vec<_>>();
         let results = symbolizer
             .symbolize(&src, Input::VirtOffset(&addrs))
@@ -131,7 +131,7 @@ fn symbolize_elf_dwarf_gsym() {
         for (i, symbolized) in results.into_iter().enumerate() {
             let result = symbolized.into_sym().unwrap();
             assert_eq!(result.name, "factorial");
-            assert_eq!(result.addr, 0x2000100);
+            assert_eq!(result.addr, 0x2000200);
             assert_eq!(result.offset, offsets[i]);
 
             if has_code_info {
@@ -187,7 +187,7 @@ fn symbolize_no_permission_impl(path: &Path) {
     let src = Source::Elf(Elf::new(path));
     let symbolizer = Symbolizer::new();
     let err = symbolizer
-        .symbolize_single(&src, Input::VirtOffset(0x2000100))
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
         .unwrap_err();
     assert_eq!(err.kind(), ErrorKind::PermissionDenied);
 }
@@ -277,13 +277,13 @@ fn symbolize_breakpad() {
     let src = Source::Breakpad(Breakpad::new(path));
     let symbolizer = Symbolizer::new();
     let result = symbolizer
-        .symbolize_single(&src, Input::FileOffset(0x100))
+        .symbolize_single(&src, Input::FileOffset(0x200))
         .unwrap()
         .into_sym()
         .unwrap();
 
     assert_eq!(result.name, "factorial");
-    assert_eq!(result.addr, 0x100);
+    assert_eq!(result.addr, 0x200);
     assert_eq!(result.offset, 0);
 
     let code_info = result.code_info.as_ref().unwrap();
@@ -297,7 +297,7 @@ fn symbolize_breakpad() {
     let offsets = (1..size).collect::<Vec<_>>();
     let addrs = offsets
         .iter()
-        .map(|offset| (0x100 + offset) as Addr)
+        .map(|offset| (0x200 + offset) as Addr)
         .collect::<Vec<_>>();
     let results = symbolizer
         .symbolize(&src, Input::FileOffset(&addrs))
@@ -309,7 +309,7 @@ fn symbolize_breakpad() {
     for (i, symbolized) in results.into_iter().enumerate() {
         let result = symbolized.into_sym().unwrap();
         assert_eq!(result.name, "factorial");
-        assert_eq!(result.addr, 0x100);
+        assert_eq!(result.addr, 0x200);
         assert_eq!(result.offset, offsets[i]);
 
         let code_info = result.code_info.as_ref().unwrap();
@@ -410,7 +410,7 @@ fn symbolize_elf_stripped() {
     let src = Source::Elf(Elf::new(path));
     let symbolizer = Symbolizer::new();
     let result = symbolizer
-        .symbolize_single(&src, Input::VirtOffset(0x2000100))
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
         .unwrap();
 
     assert_eq!(result, Symbolized::Unknown(Reason::MissingSyms));
@@ -426,7 +426,7 @@ fn symbolize_dwarf_gsym_inlined() {
             .enable_inlined_fns(inlined_fns)
             .build();
         let result = symbolizer
-            .symbolize_single(&src, Input::VirtOffset(0x200020a))
+            .symbolize_single(&src, Input::VirtOffset(0x200030a))
             .unwrap()
             .into_sym()
             .unwrap();
@@ -495,7 +495,7 @@ fn symbolize_dwarf_wrong_debug_link_crc() {
     let src = Source::from(Elf::new(path));
     let symbolizer = Symbolizer::new();
     let err = symbolizer
-        .symbolize_single(&src, Input::VirtOffset(0x2000100))
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
         .unwrap_err();
     assert!(
         err.to_string()
@@ -514,7 +514,7 @@ fn symbolize_dwarf_non_existent_debug_link() {
     let src = Source::from(Elf::new(path));
     let symbolizer = Symbolizer::builder().enable_auto_reload(false).build();
     let result = symbolizer
-        .symbolize_single(&src, Input::VirtOffset(0x2000100))
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
         .unwrap()
         .into_sym();
     // Because the binary is stripped, we don't expect any symbol
@@ -539,7 +539,7 @@ fn symbolize_configurable_debug_dirs() {
         .set_debug_dirs(Option::<[&Path; 0]>::Some([]))
         .build();
     let result = symbolizer
-        .symbolize_single(&src, Input::VirtOffset(0x2000100))
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
         .unwrap()
         .into_sym();
     // Shouldn't symbolize to anything because the debug link target cannot be
@@ -559,7 +559,7 @@ fn symbolize_configurable_debug_dirs() {
         .set_debug_dirs(Some([debug_dir1, debug_dir2]))
         .build();
     let sym = symbolizer
-        .symbolize_single(&src, Input::VirtOffset(0x2000100))
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
         .unwrap()
         .into_sym()
         .unwrap();
@@ -576,7 +576,7 @@ fn symbolize_breakpad_inlined() {
             .enable_inlined_fns(inlined_fns)
             .build();
         let result = symbolizer
-            .symbolize_single(&src, Input::FileOffset(0x20a))
+            .symbolize_single(&src, Input::FileOffset(0x30a))
             .unwrap()
             .into_sym()
             .unwrap();
@@ -1216,11 +1216,11 @@ fn symbolize_kernel_vmlinux() {
         let src = Source::Kernel(kernel);
         let symbolizer = Symbolizer::new();
         let symbolized = symbolizer
-            .symbolize_single(&src, Input::AbsAddr(0x2000100))
+            .symbolize_single(&src, Input::AbsAddr(0x2000200))
             .unwrap();
         let sym = symbolized.into_sym().unwrap();
         assert_eq!(sym.name, "factorial");
-        assert_eq!(sym.addr, 0x2000100);
+        assert_eq!(sym.addr, 0x2000200);
 
         if has_code_info {
             let code_info = sym.code_info.as_ref().unwrap();


### PR DESCRIPTION
When adding more functionality to `test-stable-addrs`, we start running into issues with insufficient space in the `.text` section, causing it to overlap with .text.factorial.
To give us some more room to breath, move `.text.factorial` back by 0x100 bytes.