### PR TITLE
capi: Fix documentation for blaze_symbolize_cache_process

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1255,8 +1255,7 @@ void blaze_symbolizer_free(blaze_symbolizer *symbolizer);
  *
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
- * - `src` needs to point to a valid [`blaze_symbolize_src_process`] object
- * - `abs_addrs` point to an array of `abs_addr_cnt` addresses
+ * - `cache` needs to point to a valid [`blaze_cache_src_process`] object
  */
 void blaze_symbolize_cache_process(blaze_symbolizer *symbolizer,
                                    const struct blaze_cache_src_process *cache);

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -767,8 +767,7 @@ pub unsafe extern "C" fn blaze_symbolizer_free(symbolizer: *mut blaze_symbolizer
 ///
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
-/// - `src` needs to point to a valid [`blaze_symbolize_src_process`] object
-/// - `abs_addrs` point to an array of `abs_addr_cnt` addresses
+/// - `cache` needs to point to a valid [`blaze_cache_src_process`] object
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_cache_process(
     symbolizer: *mut blaze_symbolizer,


### PR DESCRIPTION
The documentation of the blaze_symbolize_cache_process() function references non-existing inputs arguments. Fix it up.