### PR TITLE
Revert "Work around Miri failures"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -350,12 +350,8 @@ jobs:
     - name: Install development dependencies
       run: sudo apt-get install --yes --no-install-recommends libelf-dev zlib1g-dev
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        # TODO: Recent nightly versions fail with what *seems* to be a
-        #       false positive. Fall back to a known good version. We
-        #       should come back to this eventually.
-        toolchain: nightly-2024-08-06
         components: miri
     # Miri would honor our custom test runner, but doesn't work with it. We
     # could conceivably override that by specifying

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -457,6 +457,7 @@ mod tests {
             debug_syms: bool,
             reserved: [u8; 7],
             foobar: bool,
+            reserved2: [u8; 7],
         }
 
         assert!(mem::size_of::<blaze_inspect_elf_src>() < mem::size_of::<elf_src_with_ext>());
@@ -478,14 +479,17 @@ mod tests {
         assert!(input_zeroed!(src_ptr, blaze_inspect_elf_src));
 
         src.reserved[0] = 1;
+        let src_ptr = addr_of!(src).cast::<blaze_inspect_elf_src>();
         assert!(!input_zeroed!(src_ptr, blaze_inspect_elf_src));
         src.reserved[0] = 0;
 
         src.type_size = mem::size_of::<usize>() - 1;
+        let src_ptr = addr_of!(src).cast::<blaze_inspect_elf_src>();
         assert!(!input_zeroed!(src_ptr, blaze_inspect_elf_src));
         src.type_size = mem::size_of::<elf_src_with_ext>();
 
         src.foobar = true;
+        let src_ptr = addr_of!(src).cast::<blaze_inspect_elf_src>();
         assert!(!input_zeroed!(src_ptr, blaze_inspect_elf_src));
     }
 


### PR DESCRIPTION
With commit cf9a687db372 ("Work around Miri failures") we pinned the Miri version used in CI to a know version, because newer ones were suddenly causing test failures, and the suspicion was that this could be caused by a bug in Miri itself. This is pinning of an old version is now becoming an issue, as it is blocking the update of a dependency [0].

Investigation has now put a light on the actual issue, which is that we are modifying data through a pointer, while an exclusive reference to said data exists, which is -- as Miri reports -- undefined behavior, because we are violating aliasing rules.

With this change we fix this problem and roll back to using more up-to-date versions of Miri.

This reverts commit cf9a687db372fa9ad5694f9c44d7df2aad637a4a.

[0] https://github.com/libbpf/blazesym/pull/1011