### PR TITLE
cli: Loosen clap version requirements

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,8 +40,8 @@ anyhow = "1.0.68"
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
 blazesym = {version = "=0.2.0-rc.2", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
-clap = {version = "4.5.30", features = ["derive"]}
-clap_complete = {version = "4.5.45", optional = true}
+clap = {version = "4.5", features = ["derive"]}
+clap_complete = {version = "4.5", optional = true}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["ansi", "env-filter", "fmt"]}
 


### PR DESCRIPTION
It seems over the top to specify patch versions for clap and that appears to be causing Dependabot to decide to create an update pull request for each patch level release. Just drop the patch bits from the version.