### PR TITLE
capi: Don't use vmlinux in symbolize_in_kernel() test

### DIFF
--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -1986,6 +1986,7 @@ mod tests {
         let path_c = CString::new(path.to_str().unwrap()).unwrap();
         let src = blaze_symbolize_src_kernel {
             kallsyms: path_c.as_ptr(),
+            vmlinux: b"\0" as *const _ as *const c_char,
             ..Default::default()
         };
 


### PR DESCRIPTION
The `symbolize_in_kernel()` test may inadvertently use a vmlinux file that could be present on the system and that could lead to a wrong symbolization. Given that the test is only meant to work with kallsyms image, disable usage of vmlinux altogether to prevent any interference with system data.