### PR TITLE
Use file size in gsym-in-apk example

### DIFF
--- a/examples/gsym-in-apk/main.rs
+++ b/examples/gsym-in-apk/main.rs
@@ -60,7 +60,7 @@ impl TranslateFileOffset for CustomApkResolver {
         );
         let addr = phdrs.iter().find_map(|phdr| {
             if phdr.p_type == elf64::program_header::PT_LOAD {
-                if (phdr.p_offset..phdr.p_offset + phdr.p_memsz).contains(&file_offset) {
+                if (phdr.p_offset..phdr.p_offset + phdr.p_filesz).contains(&file_offset) {
                     return Some((file_offset - phdr.p_offset + phdr.p_vaddr) as Addr)
                 }
             }


### PR DESCRIPTION
The gsym-in-apk example still uses the memory size in the file offse to virtual offset translation. Similar to what we did in commit 1a4e10740652 ("Use file size in file offset -> virtual offset translation") switch to using the file size instead.