### PR TITLE
Make normalization APK exports conditional on 'apk' feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
   into account system KASLR state
   - Added `kaslr_offset` member to `symbolize::Kernel`
 - Moved symbolization and inspection sources into `source` sub-module
+- Moved `normalize::Apk` behind existing `apk` feature
 - Changed `inspect::SymInfo::size` to be an `Option`
 
 

--- a/src/normalize/meta.rs
+++ b/src/normalize/meta.rs
@@ -4,6 +4,7 @@ use super::buildid::BuildId;
 use super::Reason;
 
 
+cfg_apk! {
 /// Meta information about an APK.
 ///
 /// This type is used in the [`UserMeta::Apk`] variant.
@@ -44,6 +45,7 @@ pub struct Apk {
     /// The struct is non-exhaustive and open to extension.
     #[doc(hidden)]
     pub _non_exhaustive: (),
+}
 }
 
 
@@ -103,6 +105,8 @@ impl From<Unknown> for UserMeta<'_> {
 #[non_exhaustive]
 pub enum UserMeta<'src> {
     /// The address belongs to an APK file.
+    #[cfg(feature = "apk")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "apk")))]
     Apk(Apk),
     /// The address belongs to an ELF file.
     Elf(Elf<'src>),
@@ -112,6 +116,8 @@ pub enum UserMeta<'src> {
 
 impl<'src> UserMeta<'src> {
     /// Retrieve the [`Apk`] of this enum, if this variant is active.
+    #[cfg(feature = "apk")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "apk")))]
     #[inline]
     pub fn as_apk(&self) -> Option<&Apk> {
         match self {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -53,7 +53,9 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::str;
 
+cfg_apk! {
 pub use meta::Apk;
+}
 pub use meta::Elf;
 pub use meta::Unknown;
 pub use meta::UserMeta;

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -14,6 +14,7 @@ use crate::Error;
 use crate::Result;
 
 use super::buildid::BuildIdReader;
+#[cfg(feature = "apk")]
 use super::meta::Apk;
 use super::meta::Elf;
 use super::meta::Unknown;


### PR DESCRIPTION
We use the 'apk' feature in the symbolization part of the crate to guard inclusion of everything and anything APK related. However, for the normalization APIs we only really exclude the actual implementation (i.e., creation of APK meta entries). That seems to be a bit confusing. Make sure to guard the APK meta data types of the normalization bits by the 'apk' feature as well.