### PR TITLE
Document the NormalizeOpts Default impl better

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -72,6 +72,8 @@ pub(crate) use user::Handler;
 
 
 /// Options influencing the address normalization process.
+///
+/// By default all options are disabled.
 #[derive(Clone, Debug, Default)]
 pub struct NormalizeOpts {
     /// Whether or not addresses are sorted (in ascending order) already.

--- a/tests/suite/normalize.rs
+++ b/tests/suite/normalize.rs
@@ -438,12 +438,7 @@ fn normalize_no_self_vma_path_reporting() {
 
 fn normalize_permissionless_impl(pid: Pid, addr: Addr, test_lib: &Path) {
     let normalizer = Normalizer::builder().enable_build_ids(true).build();
-    let opts = NormalizeOpts {
-        sorted_addrs: false,
-        map_files: false,
-        _non_exhaustive: (),
-    };
-
+    let opts = NormalizeOpts::default();
     let normalized = normalizer
         .normalize_user_addrs_opts(pid, &[addr], &opts)
         .unwrap();


### PR DESCRIPTION
Document that the `Default` impl of the `normalize::NormalizeOpts` type disables all options, as it is not obvious how it behaves otherwise.