### PR TITLE
Make create_apk_elf_path() infallible

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,6 +1,6 @@
 # For general information about this file, check
 # https://doc.rust-lang.org/stable/clippy/configuration.html
 
-msrv = "1.69"
+msrv = "1.70"
 
 absolute-paths-allowed-crates = [ "gimli" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           # Please adjust README, `rust-version` field in Cargo.toml,
           # and `msrv` in .clippy.toml when bumping version.
-          toolchain: 1.69.0
+          toolchain: 1.70.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --features="apk,backtrace,bpf,demangle,dwarf,gsym,tracing"
   nop-rebuilds:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Unreleased
 - Moved symbolization and inspection sources into `source` sub-module
 - Moved `normalize::Apk` behind existing `apk` feature
 - Changed `inspect::SymInfo::size` to be an `Option`
+- Bumped minimum supported Rust version to `1.70`
 
 
 0.2.0-rc.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = ["."]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 license = "BSD-3-Clause"
 repository = "https://github.com/libbpf/blazesym"
 homepage = "https://github.com/libbpf/blazesym"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![coverage](https://codecov.io/gh/libbpf/blazesym/branch/main/graph/badge.svg)](https://codecov.io/gh/libbpf/blazesym)
 [![crates.io](https://img.shields.io/crates/v/blazesym.svg)](https://crates.io/crates/blazesym)
 [![Docs](https://docs.rs/blazesym/badge.svg)](https://docs.rs/blazesym)
-[![rustc](https://img.shields.io/badge/rustc-1.69+-blue.svg)](https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.70+-blue.svg)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
 
 # blazesym
 

--- a/capi/README.md
+++ b/capi/README.md
@@ -1,6 +1,6 @@
 [![pipeline](https://github.com/libbpf/blazesym/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/libbpf/blazesym/actions/workflows/test.yml)
 [![crates.io](https://img.shields.io/crates/v/blazesym-c.svg)](https://crates.io/crates/blazesym-c)
-[![rustc](https://img.shields.io/badge/rustc-1.69+-blue.svg)](https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.70+-blue.svg)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
 
 blazesym-c
 ==========

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 [![pipeline](https://github.com/libbpf/blazesym/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/libbpf/blazesym/actions/workflows/test.yml)
 [![crates.io](https://img.shields.io/crates/v/blazecli.svg)](https://crates.io/crates/blazecli)
-[![rustc](https://img.shields.io/badge/rustc-1.69+-blue.svg)](https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.70+-blue.svg)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
 
 blazecli
 ========

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -201,7 +201,7 @@ fn default_apk_dispatcher(
 ) -> Result<Box<dyn Resolve>> {
     // Create an Android-style binary-in-APK path for
     // reporting purposes.
-    let apk_elf_path = create_apk_elf_path(info.apk_path, info.member_path)?;
+    let apk_elf_path = create_apk_elf_path(info.apk_path, info.member_path);
     let parser = Rc::new(ElfParser::from_mmap(info.member_mmap, Some(apk_elf_path)));
     let resolver = ElfResolver::from_parser(parser, debug_dirs)?;
     let resolver = Box::new(resolver);


### PR DESCRIPTION
It doesn't really make much sense for the create_apk_elf_path() helper to be fallible. Conceptually at least, the algorithm is super straight forward and there is no reason to report an error just because no APK path is present. Yes, it's a logical error of sorts, but it's a logical error everywhere else as well, not just in this function. Adjust the logic to be a bit more robust (or at least easier to grasp) and to not emit any errors.