### PR TITLE
Fix unsoundness in `InsertMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Unreleased
 - Moved symbolization and inspection sources into `source` sub-module
 - Moved `normalize::Apk` behind existing `apk` feature
 - Changed `inspect::SymInfo::size` to be an `Option`
+- Fixed unsoundness in internally used `InsertMap` type
 - Bumped minimum supported Rust version to `1.70`
 
 


### PR DESCRIPTION
Our InsertMap type is not working correctly in the presence of reallocations of the internally used hash map. Specifically, because our insertion does not require a mutable reference, users may hold references to entries across insertions. If the hash map were to reallocate as part of the insertion, the references would effectively be dangling, which is undefined behavior.
Fix the problem by heap allocating all values in the hash map.