### PR TITLE
Remove lifetime from `symbolize::cache::Cache` enum

### DIFF
--- a/src/symbolize/cache.rs
+++ b/src/symbolize/cache.rs
@@ -64,7 +64,7 @@ impl Debug for Process {
     }
 }
 
-impl From<Process> for Cache<'static> {
+impl From<Process> for Cache {
     #[inline]
     fn from(process: Process) -> Self {
         Self::Process(process)
@@ -76,18 +76,15 @@ impl From<Process> for Cache<'static> {
 /// subsequent symbolization requests can be satisfied quicker.
 #[derive(Clone)]
 #[non_exhaustive]
-pub enum Cache<'dat> {
+pub enum Cache {
     /// Information about a process.
     Process(Process),
-    #[doc(hidden)]
-    Phantom(&'dat ()),
 }
 
-impl Debug for Cache<'_> {
+impl Debug for Cache {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::Process(process) => Debug::fmt(process, f),
-            Self::Phantom(()) => unreachable!(),
         }
     }
 }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1059,7 +1059,6 @@ impl Symbolizer {
                     let _prev = self.process_vma_cache.borrow_mut().insert(*pid, parsed);
                 }
             }
-            Cache::Phantom(()) => unreachable!(),
         }
         Ok(())
     }


### PR DESCRIPTION
We introduced the `symbolize::cache::Cache` with a lifetime argument to mirror what we have for `symbolize::source::Source`. However, whereas it may make sense for a symbolization source to be in-memory, that (at least currently) does not for caching: caching only makes sense if the data can subsequently be passed to symbolization APIs. However, there is no way to name this data, as its just a blob of bytes. To that end, remove the lifetime parameter from the Cache enum.