### PR TITLE
Remove 'other_os' tag from `symbolize_elf_cached()` test

### DIFF
--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -425,7 +425,6 @@ fn symbolize_elf_stripped() {
 
 /// Check that we can symbolize data in a non-existent ELF binary after
 /// caching it.
-#[tag(other_os)]
 #[test]
 fn symbolize_elf_cached() {
     let dir = tempdir().unwrap();


### PR DESCRIPTION
The `symbolize_elf_cached` test fails on Windows, citing some denied access when removing the file. That being some platform peculiarity, remove this test from the suite run in operating systems other than Linux.