### PR TITLE
cli: Add --debug-dirs & --no-debug-syms options to 'symbolize process…

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 ----------
+- Added `--debug-dirs` and `--no-debug-syms` options to `symbolize
+  process` sub-command
 - Added `--no-debug-syms` option to `inspect dump elf` sub-command
 - Added `--kallsyms` and `--vmlinux` options to `symbolize-kernel
   sub-command

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -246,6 +246,8 @@ pub mod symbolize {
         /// The PID of the process the provided addresses belong to.
         #[arg(short, long, value_parser = parse_pid)]
         pub pid: Pid,
+        #[command(flatten)]
+        pub debug_args: DebugArgs,
         /// The addresses to symbolize.
         #[arg(value_parser = parse_addr)]
         pub addrs: Vec<Addr>,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -262,10 +262,18 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
         }
         args::symbolize::Symbolize::Process(args::symbolize::Process {
             pid,
+            debug_args:
+                args::symbolize::DebugArgs {
+                    debug_dirs,
+                    no_debug_syms,
+                },
             ref addrs,
             no_map_files,
         }) => {
+            builder = builder.set_debug_dirs(debug_dirs);
+
             let mut process = symbolize::source::Process::new(pid);
+            process.debug_syms = !no_debug_syms;
             process.map_files = !no_map_files;
             let src = symbolize::source::Source::from(process);
             let addrs = addrs.as_slice();


### PR DESCRIPTION
…' sub-command

Add support for the --debug-dirs and --no-debug-syms options to the 'symbolize process' sub-command. These mirror functionality that we already provide for the 'symbolize elf' sub-command.