### PR TITLE
cli: Replace `StackWriter` type with `bufio::Writer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ version = "0.1.8"
 dependencies = [
  "anyhow",
  "blazesym",
+ "bufio",
  "clap",
  "clap_complete",
  "grev",
@@ -284,6 +285,12 @@ checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "bufio"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b244dd1077dbff58a5433175ad9c91d9b8a85af8e3b9a0af29e25974e892cb"
 
 [[package]]
 name = "bumpalo"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,6 +37,7 @@ grev = "0.1.3"
 
 [dependencies]
 anyhow = "1.0.97"
+bufio = "0.1"
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
 blazesym = {version = "=0.2.0-rc.2", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}


### PR DESCRIPTION
Replace our custom `StackWriter` type with the Writer type from the `bufio` crate.