### PR TITLE
Rename `inspect::SymInfo::obj_file_name` to `module`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
   addresses mapping to APKs to the contained ELF file
 - Added `symbolize::Sym::module` attribute
 - Renamed `symbolize::Source::kernel_image` to `vmlinux`
+- Renamed `inspect::SymInfo::obj_file_name` to `module`
 - Adjusted kernel symbolization logic to give preference to `vmlinux`
   file, if present
 - Changed `symbolize::Kernel::{kallsyms,kernel_image}` to support

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 - Changed `size` attribute of `blaze_sym_info` to be signed
 - Renamed `kernel_image` member of `blaze_symbolize_src_kernel` to
   `vmlinux`
+- Renamed `obj_file_name` member of `blaze_sym_info` to `module`
 - Added support for disabling `kallsyms` and `vmlinux` to
   `blaze_symbolize_src_kernel`
 - Added `blaze_symbolize_cache_elf` for caching of ELF data

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -264,9 +264,9 @@ typedef struct blaze_sym_info {
    */
   uint64_t file_offset;
   /**
-   * See [`inspect::SymInfo::obj_file_name`].
+   * See [`inspect::SymInfo::module`].
    */
-  const char *obj_file_name;
+  const char *module;
   /**
    * See [`inspect::SymInfo::sym_type`].
    */

--- a/src/breakpad/resolver.rs
+++ b/src/breakpad/resolver.rs
@@ -41,7 +41,7 @@ impl<'func> From<&'func Function> for SymInfo<'func> {
             size: Some(func.size as _),
             sym_type: SymType::Function,
             file_offset: None,
-            obj_file_name: None,
+            module: None,
         }
     }
 }

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -244,7 +244,7 @@ impl DwarfResolver {
                 .then(|| self.parser.find_file_offset(addr))
                 .transpose()?
                 .flatten(),
-            obj_file_name: self.parser.path().map(Cow::Borrowed),
+            module: self.parser.path().map(Cow::Borrowed),
         };
         Ok(Some(info))
     }

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -1094,7 +1094,7 @@ where
                                 .then(|| file_offset(shdrs, &sym))
                                 .transpose()?
                                 .flatten(),
-                            obj_file_name: self.path().map(Cow::Borrowed),
+                            module: self.path().map(Cow::Borrowed),
                         });
                     }
                 }
@@ -1157,7 +1157,7 @@ where
                         .then(|| file_offset(shdrs, &sym))
                         .transpose()?
                         .flatten(),
-                    obj_file_name: None,
+                    module: None,
                 };
                 if let ControlFlow::Break(()) = f(&sym_info) {
                     return Ok(())

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -52,8 +52,8 @@ pub struct SymInfo<'src> {
     pub sym_type: SymType,
     /// The offset in the object file.
     pub file_offset: Option<u64>,
-    /// The file name of the shared object.
-    pub obj_file_name: Option<Cow<'src, Path>>,
+    /// The path to or name of the module containing the symbol.
+    pub module: Option<Cow<'src, Path>>,
 }
 
 impl SymInfo<'_> {
@@ -67,8 +67,8 @@ impl SymInfo<'_> {
             size: self.size,
             sym_type: self.sym_type,
             file_offset: self.file_offset,
-            obj_file_name: self
-                .obj_file_name
+            module: self
+                .module
                 .as_deref()
                 .map(|path| Cow::Owned(path.to_path_buf())),
         }

--- a/src/kernel/bpf/prog.rs
+++ b/src/kernel/bpf/prog.rs
@@ -410,7 +410,7 @@ impl<'prog> TryFrom<&'prog BpfProg> for SymInfo<'prog> {
             size: None,
             sym_type: SymType::Function,
             file_offset: None,
-            obj_file_name: None,
+            module: None,
         };
         Ok(sym)
     }

--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -161,7 +161,7 @@ impl<'kfunc> TryFrom<&'kfunc Kfunc> for SymInfo<'kfunc> {
             size: None,
             sym_type: SymType::Function,
             file_offset: None,
-            obj_file_name: None,
+            module: None,
         };
         Ok(sym)
     }

--- a/tests/suite/inspect.rs
+++ b/tests/suite/inspect.rs
@@ -32,10 +32,7 @@ fn inspect_elf() {
         assert_eq!(result[0].addr, 0x2000200);
         assert_eq!(result[0].sym_type, SymType::Function);
         assert_ne!(result[0].file_offset, None);
-        assert_eq!(
-            result[0].obj_file_name.as_deref().unwrap(),
-            src.path().unwrap()
-        );
+        assert_eq!(result[0].module.as_deref().unwrap(), src.path().unwrap());
 
         let result = &results[1];
         if no_vars {
@@ -45,10 +42,7 @@ fn inspect_elf() {
             assert_eq!(result[0].addr, 0x4001100);
             assert_eq!(result[0].sym_type, SymType::Variable);
             assert_ne!(result[0].file_offset, None);
-            assert_eq!(
-                result[0].obj_file_name.as_deref().unwrap(),
-                src.path().unwrap()
-            );
+            assert_eq!(result[0].module.as_deref().unwrap(), src.path().unwrap());
         }
     }
 
@@ -105,7 +99,7 @@ fn inspect_breakpad() {
     assert_eq!(sym.addr, 0x200);
     assert_eq!(sym.sym_type, SymType::Function);
     assert_eq!(sym.file_offset, None);
-    assert_eq!(sym.obj_file_name, None);
+    assert_eq!(sym.module, None);
 }
 
 


### PR DESCRIPTION
Rename the `inspect::SymInfo::obj_file_name` attribute to `module`. In so doing we establish similarity with `symbolize::Sym::module`, which has been introduced earlier. The new name is shorter and arguably more telling.