### PR TITLE
Rework various resolver Debug impls

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -354,7 +354,11 @@ impl Inspect for DwarfResolver {
 
 impl Debug for DwarfResolver {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str(stringify!(DwarfResolver))
+        let path = self
+            .parser()
+            .path()
+            .unwrap_or_else(|| Path::new("<unknown-path>"));
+        write!(f, "DwarfResolver(\"{}\")", path.display())
     }
 }
 

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -906,7 +906,6 @@ impl<'elf> BackendImpl<'elf> for &File {
 
 
 /// A parser for ELF64 files.
-#[derive(Debug)]
 pub(crate) struct ElfParser<B = Mmap>
 where
     B: Backend,
@@ -1094,7 +1093,7 @@ where
                                 .then(|| file_offset(shdrs, &sym))
                                 .transpose()?
                                 .flatten(),
-                            module: self.path().map(Cow::Borrowed),
+                            module: self.path.as_deref().map(Cow::Borrowed),
                         });
                     }
                 }
@@ -1289,6 +1288,16 @@ where
     #[inline]
     pub(crate) fn path(&self) -> Option<&Path> {
         self.path.as_deref()
+    }
+}
+
+impl Debug for ElfParser {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let path = self
+            .path
+            .as_deref()
+            .unwrap_or_else(|| Path::new("<unknown-path>"));
+        write!(f, "ElfParser(\"{}\")", path.display())
     }
 }
 

--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -277,11 +277,6 @@ impl KsymResolver {
 
         by_name_idx
     }
-
-    /// Retrieve the path to the kallsyms file used by this resolver.
-    pub(crate) fn file_name(&self) -> &Path {
-        &self.file_name
-    }
 }
 
 impl Symbolize for KsymResolver {
@@ -336,7 +331,7 @@ impl Inspect for KsymResolver {
 
 impl Debug for KsymResolver {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "KsymResolver")
+        write!(f, "KsymResolver(\"{}\")", self.file_name.display())
     }
 }
 

--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
-use std::path::Path;
 use std::rc::Rc;
 
 use crate::elf::ElfResolver;
@@ -91,17 +90,8 @@ impl Debug for KernelResolver {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(
             f,
-            "KernelResolver {} {}",
-            self.ksym_resolver
-                .as_ref()
-                .map(|resolver| resolver.file_name())
-                .unwrap_or_else(|| Path::new(""))
-                .display(),
-            self.elf_resolver
-                .as_ref()
-                .and_then(|resolver| resolver.path())
-                .unwrap_or_else(|| Path::new(""))
-                .display(),
+            "KernelResolver({:?} {:?})",
+            self.ksym_resolver, self.elf_resolver,
         )
     }
 }
@@ -110,6 +100,8 @@ impl Debug for KernelResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::path::Path;
 
     use crate::kernel::KALLSYMS;
 


### PR DESCRIPTION
Rework `Debug` impls of a few resolvers/parsers in a way that allows us to remove the `KsymResolver::file_name()` as well as `ElfResolver::path()` methods. We want to minimize exposure of "paths" pertaining resolvers between individual modules of the crate.