### PR TITLE
Rename ElfParser::open_*() constructors

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -923,7 +923,9 @@ where
 }
 
 impl ElfParser<File> {
-    fn open_file_io<P>(file: File, path: P) -> Self
+    /// Create an `ElfParser` that uses regular file I/O on the provided
+    /// file.
+    fn from_file_io<P>(file: File, path: P) -> Self
     where
         P: Into<PathBuf>,
     {
@@ -938,15 +940,16 @@ impl ElfParser<File> {
         parser
     }
 
-    /// Create an `ElfParser` from an open file.
-    pub(crate) fn open_non_mmap<P>(path: P) -> Result<Self>
+    /// Create an `ElfParser` employing regular file I/O, opening the
+    /// file at `path`.
+    pub(crate) fn open_file_io<P>(path: P) -> Result<Self>
     where
         P: Into<PathBuf>,
     {
         let path = path.into();
         let file =
             File::open(&path).with_context(|| format!("failed to open `{}`", path.display()))?;
-        let slf = Self::open_file_io(file, path);
+        let slf = Self::from_file_io(file, path);
         Ok(slf)
     }
 
@@ -958,7 +961,7 @@ impl ElfParser<File> {
 
 impl ElfParser<Mmap> {
     /// Create an `ElfParser` from an open file.
-    pub(crate) fn open_file<P>(file: &File, path: P) -> Result<Self>
+    pub(crate) fn from_file<P>(file: &File, path: P) -> Result<Self>
     where
         P: Into<PathBuf>,
     {
@@ -987,7 +990,7 @@ impl ElfParser<Mmap> {
     pub(crate) fn open(path: &Path) -> Result<ElfParser> {
         let file =
             File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
-        Self::open_file(&file, path)
+        Self::from_file(&file, path)
     }
 }
 
@@ -1434,10 +1437,10 @@ mod tests {
         }
 
         let path = file.path().to_path_buf();
-        let parser_mmap = ElfParser::open_file(file.as_file(), &path).unwrap();
+        let parser_mmap = ElfParser::from_file(file.as_file(), &path).unwrap();
         let () = test(parser_mmap);
 
-        let parser_io = ElfParser::open_file_io(file.into_file(), &path);
+        let parser_io = ElfParser::from_file_io(file.into_file(), &path);
         let () = test(parser_io);
     }
 
@@ -1502,10 +1505,10 @@ mod tests {
         }
 
         let path = file.path().to_path_buf();
-        let parser_mmap = ElfParser::open_file(file.as_file(), &path).unwrap();
+        let parser_mmap = ElfParser::from_file(file.as_file(), &path).unwrap();
         let () = test(parser_mmap);
 
-        let parser_io = ElfParser::open_file_io(file.into_file(), &path);
+        let parser_io = ElfParser::from_file_io(file.into_file(), &path);
         let () = test(parser_io);
     }
 
@@ -1708,10 +1711,10 @@ mod tests {
         }
 
         let path = file.path().to_path_buf();
-        let parser_mmap = ElfParser::open_file(file.as_file(), &path).unwrap();
+        let parser_mmap = ElfParser::from_file(file.as_file(), &path).unwrap();
         let () = test(parser_mmap);
 
-        let parser_io = ElfParser::open_file_io(file.into_file(), &path);
+        let parser_io = ElfParser::from_file_io(file.into_file(), &path);
         let () = test(parser_io);
     }
 

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -82,7 +82,7 @@ impl FileCache<ElfResolverData> {
             };
             Rc::clone(resolver)
         } else {
-            let parser = Rc::new(ElfParser::open_file(file, path)?);
+            let parser = Rc::new(ElfParser::from_file(file, path)?);
             let resolver = ElfResolver::from_parser(parser, debug_dirs)?;
             Rc::new(resolver)
         };

--- a/src/kernel/kaslr.rs
+++ b/src/kernel/kaslr.rs
@@ -98,7 +98,7 @@ fn find_kcore_kaslr_offset() -> Result<Option<u64>> {
     // Note that we cannot use the regular mmap based ELF parser
     // backend for this file, as it cannot be mmap'ed. We have to
     // fall back to using regular I/O instead.
-    let parser = match ElfParser::open_non_mmap(PROC_KCORE) {
+    let parser = match ElfParser::open_file_io(PROC_KCORE) {
         Ok(parser) => parser,
         Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
         Err(err) => return Err(err),

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -346,7 +346,7 @@ impl Normalizer {
             if self.cache_build_ids {
                 let (file, cell) = self.build_id_cache.entry(path)?;
                 cell.get_or_try_init(|| {
-                    let parser = ElfParser::open_file(file, path)?;
+                    let parser = ElfParser::from_file(file, path)?;
                     let build_id =
                         read_build_id(&parser)?.map(|build_id| Cow::Owned(build_id.to_vec()));
                     Result::<_, Error>::Ok(build_id)

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -472,7 +472,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         let () = file.write_all(entry.data).unwrap();
 
-        let elf = ElfParser::open_file(file.as_file(), file.path()).unwrap();
+        let elf = ElfParser::from_file(file.as_file(), file.path()).unwrap();
         assert!(elf.find_section(".text").is_ok());
     }
 


### PR DESCRIPTION
Using the "open" terminology in some of the `ElfParser::open_*()` constructors doesn't really make sense. We are not opening a file, because an already opened file gets passed in. Rename the constructors to something using `from_file*()` instead.