### PR TITLE
Adjust `{Sym,SymInfo}::module` to be an `OsString`

### DIFF
--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -521,16 +521,9 @@ mod tests {
                     assert_eq!(Some(c_sym.file_offset), sym.file_offset);
                     assert_eq!(
                         unsafe { CStr::from_ptr(c_sym.module) }.to_bytes(),
-                        CString::new(
-                            sym.module
-                                .as_deref()
-                                .unwrap()
-                                .as_os_str()
-                                .to_os_string()
-                                .into_vec()
-                        )
-                        .unwrap()
-                        .to_bytes()
+                        CString::new(sym.module.as_deref().unwrap().to_os_string().into_vec())
+                            .unwrap()
+                            .to_bytes()
                     );
                 }
             }
@@ -549,7 +542,7 @@ mod tests {
             size: Some(42),
             sym_type: SymType::Function,
             file_offset: Some(1337),
-            module: Some(Path::new("/tmp/foobar.so").into()),
+            module: Some(OsStr::new("/tmp/foobar.so").into()),
         }]];
         test(syms);
 
@@ -561,7 +554,7 @@ mod tests {
                 size: Some(42),
                 sym_type: SymType::Function,
                 file_offset: Some(1337),
-                module: Some(Path::new("/tmp/foobar.so").into()),
+                module: Some(OsStr::new("/tmp/foobar.so").into()),
             },
             SymInfo {
                 name: "sym2".into(),
@@ -569,7 +562,7 @@ mod tests {
                 size: Some(45),
                 sym_type: SymType::Undefined,
                 file_offset: Some(1338),
-                module: Some(Path::new("other.so").into()),
+                module: Some(OsStr::new("other.so").into()),
             },
         ]];
         test(syms);
@@ -582,7 +575,7 @@ mod tests {
                 size: Some(42),
                 sym_type: SymType::Function,
                 file_offset: Some(1337),
-                module: Some(Path::new("/tmp/foobar.so").into()),
+                module: Some(OsStr::new("/tmp/foobar.so").into()),
             }],
             vec![SymInfo {
                 name: "sym2".into(),
@@ -590,7 +583,7 @@ mod tests {
                 size: Some(45),
                 sym_type: SymType::Undefined,
                 file_offset: Some(1338),
-                module: Some(Path::new("other.so").into()),
+                module: Some(OsStr::new("other.so").into()),
             }],
         ];
         test(syms);
@@ -602,7 +595,7 @@ mod tests {
             size: Some(42),
             sym_type: SymType::Function,
             file_offset: Some(1337),
-            module: Some(Path::new("/tmp/foobar.so").into()),
+            module: Some(OsStr::new("/tmp/foobar.so").into()),
         };
         let syms = vec![(0..200).map(|_| sym.clone()).collect()];
         test(syms);

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -897,7 +897,7 @@ fn sym_strtab_size(sym: &Sym) -> usize {
         + sym
             .module
             .as_deref()
-            .map(|path| path.as_os_str().len() + 1)
+            .map(|module| module.len() + 1)
             .unwrap_or(0)
         + code_info_strtab_size(&sym.code_info)
         + sym
@@ -990,7 +990,7 @@ fn convert_symbolizedresults_to_c(results: Vec<Symbolized>) -> *const blaze_syms
                 let module_ptr = sym
                     .module
                     .as_deref()
-                    .map(|path| make_cstr(path.as_os_str()))
+                    .map(&mut make_cstr)
                     .unwrap_or(ptr::null_mut());
 
                 sym_ref.name = name_ptr;
@@ -1633,7 +1633,7 @@ mod tests {
         // A single symbol with inlined function information.
         let results = vec![Symbolized::Sym(Sym {
             name: "test".into(),
-            module: Some(Cow::from(Path::new("module"))),
+            module: Some(Cow::from(OsStr::new("module"))),
             addr: 0x1337,
             offset: 0x1338,
             size: Some(42),
@@ -1668,7 +1668,7 @@ mod tests {
             Symbolized::Unknown(Reason::UnknownAddr),
             Symbolized::Sym(Sym {
                 name: "test".into(),
-                module: Some(Cow::from(Path::new("module"))),
+                module: Some(Cow::from(OsStr::new("module"))),
                 addr: 0x1337,
                 offset: 0x1338,
                 size: None,

--- a/src/breakpad/types.rs
+++ b/src/breakpad/types.rs
@@ -23,7 +23,7 @@
 // > DEALINGS IN THE SOFTWARE.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::ffi::OsString;
 
 use crate::once::OnceCell;
 use crate::util::find_lowest_match_by_key;
@@ -185,7 +185,7 @@ impl Function {
 #[derive(Debug)]
 pub(crate) struct SymbolFile {
     /// The module represented by this symbol file.
-    pub module: Option<PathBuf>,
+    pub module: Option<OsString>,
     /// The set of source files involved in compilation.
     pub files: HashMap<u32, String>,
     /// Functions, sorted by start address.

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -241,7 +241,7 @@ impl DwarfResolver {
                 .then(|| self.parser.find_file_offset(addr))
                 .transpose()?
                 .flatten(),
-            module: self.parser.path().map(Cow::Borrowed),
+            module: self.parser.path().map(Path::as_os_str).map(Cow::Borrowed),
         };
         Ok(Some(info))
     }
@@ -262,7 +262,7 @@ impl Symbolize for DwarfResolver {
                 .map(|range| usize::try_from(range.end - range.begin).unwrap_or(usize::MAX));
             ResolvedSym {
                 name,
-                module: self.parser.path(),
+                module: self.parser.path().map(Path::as_os_str),
                 addr: fn_addr,
                 size,
                 lang: unit.language().into(),

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -22,9 +22,9 @@ mod inspector;
 pub mod source;
 
 use std::borrow::Cow;
+use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::ops::ControlFlow;
-use std::path::Path;
 
 use crate::Addr;
 use crate::Result;
@@ -53,7 +53,7 @@ pub struct SymInfo<'src> {
     /// The offset in the object file.
     pub file_offset: Option<u64>,
     /// The path to or name of the module containing the symbol.
-    pub module: Option<Cow<'src, Path>>,
+    pub module: Option<Cow<'src, OsStr>>,
 }
 
 impl SymInfo<'_> {
@@ -70,7 +70,7 @@ impl SymInfo<'_> {
             module: self
                 .module
                 .as_deref()
-                .map(|path| Cow::Owned(path.to_path_buf())),
+                .map(|path| Cow::Owned(path.to_os_string())),
         }
     }
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -313,7 +313,7 @@ pub struct ResolvedSym<'src> {
     /// The name of the symbol.
     pub name: &'src str,
     /// The path to or name of the module containing the symbol.
-    pub module: Option<&'src Path>,
+    pub module: Option<&'src OsStr>,
     /// The symbol's normalized address.
     pub addr: Addr,
     /// The symbol's size, if available.
@@ -340,7 +340,7 @@ pub struct Sym<'src> {
     /// case of an ELF file contained inside an APK, this will be an
     /// Android style path of the form `<apk>!<elf-in-apk>`. E.g.,
     /// `/root/test.apk!/lib/libc.so`.
-    pub module: Option<Cow<'src, Path>>,
+    pub module: Option<Cow<'src, OsStr>>,
     /// The address at which the symbol is located (i.e., its "start").
     ///
     /// This is the "normalized" address of the symbol, as present in
@@ -555,7 +555,7 @@ mod tests {
 
         let sym = Sym {
             name: Cow::Borrowed("test"),
-            module: Some(Cow::Borrowed(Path::new("module"))),
+            module: Some(Cow::Borrowed(OsStr::new("module"))),
             addr: 1337,
             offset: 42,
             size: None,

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -669,7 +669,7 @@ impl Symbolizer {
 
                     let name =
                         Cow::Owned(self.maybe_demangle(Cow::Borrowed(name), lang).into_owned());
-                    let module = module.map(|module| Cow::Owned(module.to_path_buf()));
+                    let module = module.map(|module| Cow::Owned(module.to_os_string()));
                     let code_info = code_info.map(|info| info.to_owned());
                     let inlined = Vec::from(inlined)
                         .into_iter()

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -287,7 +287,7 @@ fn symbolize_breakpad() {
     assert_eq!(result.name, "factorial");
     assert_eq!(
         result.module,
-        Some(Cow::Borrowed(Path::new("test-stable-addrs.bin")))
+        Some(Cow::Borrowed(OsStr::new("test-stable-addrs.bin")))
     );
     assert_eq!(result.addr, 0x200);
     assert_eq!(result.offset, 0);
@@ -370,7 +370,7 @@ fn symbolize_elf_variable() {
             .unwrap();
 
         assert_eq!(result.name, "a_variable");
-        assert_eq!(result.module, Some(Cow::Borrowed(path.as_path())));
+        assert_eq!(result.module, Some(Cow::Borrowed(path.as_os_str())));
         assert_eq!(result.addr, 0x4001100);
         assert_eq!(result.offset, 0);
         // Even when using DWARF we don't currently support variable lookup,
@@ -618,7 +618,7 @@ fn symbolize_configurable_debug_dirs() {
     assert_eq!(sym.name, "factorial");
     // The module reported should be the original file and not the
     // linked one.
-    assert_eq!(sym.module, Some(Cow::Owned(path)));
+    assert_eq!(sym.module, Some(Cow::Owned(path.into_os_string())));
 }
 
 /// Make sure that we report (enabled) or don't report (disabled) inlined
@@ -751,7 +751,7 @@ fn symbolize_dwarf_demangle() {
             .unwrap();
 
         assert_eq!(result.name, "test::test_function");
-        assert_eq!(result.module, Some(Cow::Borrowed(test_dwarf)));
+        assert_eq!(result.module, Some(Cow::Borrowed(test_dwarf.as_os_str())));
         assert_eq!(result.inlined.len(), 1, "{:#?}", result.inlined);
         assert_eq!(result.inlined[0].name, "test::inlined_call");
         Ok(())
@@ -923,10 +923,7 @@ fn symbolize_process_zip() {
         result
             .module
             .as_deref()
-            .map(|path| path
-                .as_os_str()
-                .to_string_lossy()
-                .ends_with("!/libtest-so.so"))
+            .map(|module| module.to_string_lossy().ends_with("!/libtest-so.so"))
             .unwrap_or(false),
         "{:?}",
         result.module


### PR DESCRIPTION
It is unlikely that the "module" attribute of the `Sym` and `SymInfo` types will always be a Path. For example, for VDSO data we may want to have a mere string in there. But even for APK contents we may end up with an Android style "virtual" path. Make this somewhat clearer by changing the type from `Path`/`PathBuf` to `OsStr`/`OsString`.