### PR TITLE
cli: Make sure to properly truncate trace messages

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 - Added `--no-debug-syms` option to `inspect dump elf` sub-command
 - Added `--kallsyms` and `--vmlinux` options to `symbolize-kernel
   sub-command
+- Fixed truncation of overly long tracing lines
 
 
 0.1.8


### PR DESCRIPTION
Our tracing logic doesn't handle overly long lines properly: when a line is longer than 256 bytes it will be discarded in its entirety. What we really want is to truncate it silently. Adjust the logic accordingly.