### PR TITLE
Rename `FindAddrOpts::offset_in_file` attribute

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -317,7 +317,7 @@ impl Inspect for DwarfResolver {
                         //         name attribute set. `function_to_sym_info`
                         //         only returns `None` if no name is present.
                         let info = self
-                            .function_to_sym_info(function, opts.offset_in_file)?
+                            .function_to_sym_info(function, opts.file_offset)?
                             .unwrap();
                         Ok(info)
                     }
@@ -341,7 +341,7 @@ impl Inspect for DwarfResolver {
 
         let mut overall_result = Ok(());
         let () = self.units.for_each_function(|func| {
-            let result = self.function_to_sym_info(func, opts.offset_in_file);
+            let result = self.function_to_sym_info(func, opts.file_offset);
             match result {
                 Ok(Some(sym_info)) => f(&sym_info),
                 Ok(None) => ControlFlow::Continue(()),
@@ -547,7 +547,7 @@ mod tests {
             .join("data")
             .join("test-stable-addrs-stripped-elf-with-dwarf.bin");
         let opts = FindAddrOpts {
-            offset_in_file: false,
+            file_offset: false,
             sym_type: SymType::Function,
         };
         let resolver = DwarfResolver::open(test_dwarf.as_ref()).unwrap();
@@ -567,7 +567,7 @@ mod tests {
             .join("data")
             .join("test-stable-addrs-stripped-elf-with-dwarf.bin");
         let opts = FindAddrOpts {
-            offset_in_file: false,
+            file_offset: false,
             sym_type: SymType::Variable,
         };
         let resolver = DwarfResolver::open(test_dwarf.as_ref()).unwrap();

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -1104,7 +1104,7 @@ where
                             //         succeed.
                             sym_type: SymType::try_from(&sym).unwrap(),
                             file_offset: opts
-                                .offset_in_file
+                                .file_offset
                                 .then(|| file_offset(shdrs, &sym))
                                 .transpose()?
                                 .flatten(),
@@ -1167,7 +1167,7 @@ where
                     //         succeed.
                     sym_type: SymType::try_from(&sym).unwrap(),
                     file_offset: opts
-                        .offset_in_file
+                        .file_offset
                         .then(|| file_offset(shdrs, &sym))
                         .transpose()?
                         .flatten(),
@@ -1579,7 +1579,7 @@ mod tests {
     fn file_offset_calculation() {
         fn test(path: &Path) {
             let opts = FindAddrOpts {
-                offset_in_file: true,
+                file_offset: true,
                 sym_type: SymType::Function,
             };
             let parser = ElfParser::open(path).unwrap();

--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -94,7 +94,7 @@ impl Inspector {
         names: &[&str],
     ) -> Result<Vec<Vec<SymInfo<'slf>>>> {
         let opts = FindAddrOpts {
-            offset_in_file: true,
+            file_offset: true,
             sym_type: SymType::Undefined,
         };
 
@@ -179,7 +179,7 @@ impl Inspector {
                 }) => {
                     let opts = FindAddrOpts {
                         // Breakpad logic doesn't support file offsets.
-                        offset_in_file: false,
+                        file_offset: false,
                         sym_type: SymType::Undefined,
                     };
                     let resolver = slf.breakpad_resolver(path)?;
@@ -191,7 +191,7 @@ impl Inspector {
                     _non_exhaustive: (),
                 }) => {
                     let opts = FindAddrOpts {
-                        offset_in_file: true,
+                        file_offset: true,
                         sym_type: SymType::Undefined,
                     };
                     let debug_dirs;

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -81,10 +81,13 @@ impl SymInfo<'_> {
 /// This type passes additional parameters to resolvers.
 #[derive(Debug, Default)]
 pub(crate) struct FindAddrOpts {
-    /// Return the offset of the symbol from the first byte of the
-    /// object file if it is true. (False by default)
-    pub offset_in_file: bool,
+    /// Whether or not to return file offsets by attempting to populate
+    /// the [`SymInfo::file_offset`] attribute.
+    ///
+    /// This options default to `false`.
+    pub file_offset: bool,
     /// Return the symbol(s) matching a given type.
+    ///
     /// [`Undefined`][SymType::Undefined] indicates that all supported
     /// symbols are of interest.
     pub sym_type: SymType,

--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -433,7 +433,7 @@ ffffffffc212d000 t ftrace_trampoline    [__builtin__ftrace]
 
         let ensure_addr_for_name = |name, addr| {
             let opts = FindAddrOpts {
-                offset_in_file: false,
+                file_offset: false,
                 sym_type: SymType::Function,
             };
             let found = resolver.find_addr(name, &opts).unwrap();

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -21,7 +21,7 @@ pub fn find_the_answer_fn(mmap: &Mmap) -> (inspect::SymInfo<'static>, Addr) {
     // object.
     let elf_parser = ElfParser::from_mmap(mmap.clone(), Some(OsString::from("libtest-so.so")));
     let opts = inspect::FindAddrOpts {
-        offset_in_file: true,
+        file_offset: true,
         sym_type: SymType::Function,
     };
     let syms = elf_parser.find_addr("the_answer", &opts).unwrap();


### PR DESCRIPTION
Rename the `FindAddrOpts::offset_in_file` attribute to file_offset. The former just feels too cumbersome to spell out. There is admittedly some potential for confusion between `FindAddrOpts::file_offset` (a boolean) and `SymInfo::file_offset` (an integer), but really the context should make it obvious which one is which.