### PR TITLE
Relax Cargo test runner constraint

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.x86_64-unknown-linux-gnu]
+[target.'cfg(target_os= "linux")']
 runner = "sudo --preserve-env .cargo/runner.sh"


### PR DESCRIPTION
We have to use a custom test runner in order to run privileged tests. Currently we only do so for the `x86_64-unknown-linux-gnu` target, but that is unnecessarily restrictive.
Relax the constraint to use the test runner on any Linux target.