### PR TITLE
capi: Add more reserved bytes for future expansion

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -281,7 +281,7 @@ typedef struct blaze_sym_info {
   /**
    * Unused member available for future expansion.
    */
-  uint8_t reserved[15];
+  uint8_t reserved[23];
 } blaze_sym_info;
 
 /**
@@ -315,7 +315,7 @@ typedef struct blaze_inspect_elf_src {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[7];
+  uint8_t reserved[23];
 } blaze_inspect_elf_src;
 
 /**
@@ -381,7 +381,7 @@ typedef struct blaze_normalizer_opts {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[4];
+  uint8_t reserved[20];
 } blaze_normalizer_opts;
 
 /**
@@ -396,7 +396,7 @@ typedef struct blaze_user_meta_apk {
   /**
    * Unused member available for future expansion.
    */
-  uint8_t reserved[8];
+  uint8_t reserved[16];
 } blaze_user_meta_apk;
 
 /**
@@ -424,7 +424,7 @@ typedef struct blaze_user_meta_elf {
   /**
    * Unused member available for future expansion.
    */
-  uint8_t reserved[8];
+  uint8_t reserved[16];
 } blaze_user_meta_elf;
 
 /**
@@ -441,7 +441,7 @@ typedef struct blaze_user_meta_unknown {
   /**
    * Unused member available for future expansion.
    */
-  uint8_t reserved[7];
+  uint8_t reserved[15];
 } blaze_user_meta_unknown;
 
 /**
@@ -521,7 +521,7 @@ typedef struct blaze_normalized_user_output {
   /**
    * Unused member available for future expansion.
    */
-  uint8_t reserved[8];
+  uint8_t reserved[16];
 } blaze_normalized_user_output;
 
 /**
@@ -569,7 +569,7 @@ typedef struct blaze_normalize_opts {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[5];
+  uint8_t reserved[21];
 } blaze_normalize_opts;
 
 /**
@@ -636,7 +636,7 @@ typedef struct blaze_symbolizer_opts {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[4];
+  uint8_t reserved[20];
 } blaze_symbolizer_opts;
 
 /**
@@ -658,7 +658,7 @@ typedef struct blaze_cache_src_elf {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[8];
+  uint8_t reserved[16];
 } blaze_cache_src_elf;
 
 /**
@@ -701,7 +701,7 @@ typedef struct blaze_cache_src_process {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[11];
+  uint8_t reserved[19];
 } blaze_cache_src_process;
 
 /**
@@ -829,7 +829,7 @@ typedef struct blaze_sym {
   /**
    * Unused member available for future expansion.
    */
-  uint8_t reserved[7];
+  uint8_t reserved[15];
 } blaze_sym;
 
 /**
@@ -895,7 +895,7 @@ typedef struct blaze_symbolize_src_process {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[1];
+  uint8_t reserved[17];
 } blaze_symbolize_src_process;
 
 /**
@@ -948,7 +948,7 @@ typedef struct blaze_symbolize_src_kernel {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[7];
+  uint8_t reserved[23];
 } blaze_symbolize_src_kernel;
 
 /**
@@ -983,7 +983,7 @@ typedef struct blaze_symbolize_src_elf {
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[7];
+  uint8_t reserved[23];
 } blaze_symbolize_src_elf;
 
 /**
@@ -1005,6 +1005,11 @@ typedef struct blaze_symbolize_src_gsym_data {
    * The size of the Gsym data.
    */
   size_t data_len;
+  /**
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
+   */
+  uint8_t reserved[16];
 } blaze_symbolize_src_gsym_data;
 
 /**
@@ -1022,6 +1027,11 @@ typedef struct blaze_symbolize_src_gsym_file {
    * The path to a gsym file.
    */
   const char *path;
+  /**
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
+   */
+  uint8_t reserved[16];
 } blaze_symbolize_src_gsym_file;
 
 /**

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -54,7 +54,7 @@ pub struct blaze_inspect_elf_src {
     pub debug_syms: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 7],
+    pub reserved: [u8; 23],
 }
 
 impl Default for blaze_inspect_elf_src {
@@ -63,7 +63,7 @@ impl Default for blaze_inspect_elf_src {
             type_size: mem::size_of::<Self>(),
             path: ptr::null(),
             debug_syms: false,
-            reserved: [0; 7],
+            reserved: [0; 23],
         }
     }
 }
@@ -173,7 +173,7 @@ pub struct blaze_sym_info {
     /// See [`inspect::SymInfo::sym_type`].
     pub sym_type: blaze_sym_type,
     /// Unused member available for future expansion.
-    pub reserved: [u8; 15],
+    pub reserved: [u8; 23],
 }
 
 
@@ -248,7 +248,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
                     sym_type: sym_type.into(),
                     file_offset: file_offset.unwrap_or(0),
                     module,
-                    reserved: [0u8; 15],
+                    reserved: [0; 23],
                 }
             };
             sym_ptr = unsafe { sym_ptr.add(1) };
@@ -261,7 +261,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
                 sym_type: blaze_sym_type::BLAZE_SYM_UNDEF,
                 file_offset: 0,
                 module: ptr::null(),
-                reserved: [0u8; 15],
+                reserved: [0; 23],
             }
         };
         sym_ptr = unsafe { sym_ptr.add(1) };
@@ -411,8 +411,8 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn type_sizes() {
-        assert_eq!(mem::size_of::<blaze_inspect_elf_src>(), 24);
-        assert_eq!(mem::size_of::<blaze_sym_info>(), 56);
+        assert_eq!(mem::size_of::<blaze_inspect_elf_src>(), 40);
+        assert_eq!(mem::size_of::<blaze_sym_info>(), 64);
     }
 
     /// Exercise the `Debug` representation of various types.
@@ -423,11 +423,11 @@ mod tests {
             type_size: 24,
             path: ptr::null(),
             debug_syms: true,
-            reserved: [0; 7],
+            reserved: [0; 23],
         };
         assert_eq!(
             format!("{elf:?}"),
-            "blaze_inspect_elf_src { type_size: 24, path: 0x0, debug_syms: true, reserved: [0, 0, 0, 0, 0, 0, 0] }"
+            "blaze_inspect_elf_src { type_size: 24, path: 0x0, debug_syms: true, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let info = blaze_sym_info {
@@ -437,11 +437,11 @@ mod tests {
             file_offset: 31,
             module: ptr::null(),
             sym_type: blaze_sym_type::BLAZE_SYM_VAR,
-            reserved: [0u8; 15],
+            reserved: [0; 23],
         };
         assert_eq!(
             format!("{info:?}"),
-            "blaze_sym_info { name: 0x0, addr: 42, size: 1337, file_offset: 31, module: 0x0, sym_type: BLAZE_SYM_VAR, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
+            "blaze_sym_info { name: 0x0, addr: 42, size: 1337, file_offset: 31, module: 0x0, sym_type: BLAZE_SYM_VAR, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
     }
 
@@ -455,7 +455,7 @@ mod tests {
             type_size: usize,
             _path: *const c_char,
             debug_syms: bool,
-            reserved: [u8; 7],
+            reserved: [u8; 23],
             foobar: bool,
             reserved2: [u8; 7],
         }

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -79,7 +79,7 @@ pub struct blaze_normalizer_opts {
     pub cache_build_ids: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 4],
+    pub reserved: [u8; 20],
 }
 
 impl Default for blaze_normalizer_opts {
@@ -90,7 +90,7 @@ impl Default for blaze_normalizer_opts {
             cache_vmas: false,
             build_ids: false,
             cache_build_ids: false,
-            reserved: [0; 4],
+            reserved: [0; 20],
         }
     }
 }
@@ -131,7 +131,7 @@ pub struct blaze_normalize_opts {
     pub apk_to_elf: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 5],
+    pub reserved: [u8; 21],
 }
 
 impl Default for blaze_normalize_opts {
@@ -141,7 +141,7 @@ impl Default for blaze_normalize_opts {
             sorted_addrs: false,
             map_files: false,
             apk_to_elf: false,
-            reserved: [0; 5],
+            reserved: [0; 21],
         }
     }
 }
@@ -288,7 +288,7 @@ pub struct blaze_user_meta_apk {
     /// This member is always present.
     pub path: *mut c_char,
     /// Unused member available for future expansion.
-    pub reserved: [u8; 8],
+    pub reserved: [u8; 16],
 }
 
 impl blaze_user_meta_apk {
@@ -302,7 +302,7 @@ impl blaze_user_meta_apk {
             path: CString::new(path.into_os_string().into_vec())
                 .expect("encountered path with NUL bytes")
                 .into_raw(),
-            reserved: [0u8; 8],
+            reserved: [0; 16],
         };
         ManuallyDrop::new(slf)
     }
@@ -337,7 +337,7 @@ pub struct blaze_user_meta_elf {
     /// The optional build ID of the ELF file, if found and readable.
     pub build_id: *mut u8,
     /// Unused member available for future expansion.
-    pub reserved: [u8; 8],
+    pub reserved: [u8; 16],
 }
 
 impl blaze_user_meta_elf {
@@ -368,7 +368,7 @@ impl blaze_user_meta_elf {
                     }
                 })
                 .unwrap_or_else(ptr::null_mut),
-            reserved: [0u8; 8],
+            reserved: [0; 16],
         };
         ManuallyDrop::new(slf)
     }
@@ -459,7 +459,7 @@ pub struct blaze_user_meta_unknown {
     /// prevented the normalization from being successful.
     pub reason: blaze_normalize_reason,
     /// Unused member available for future expansion.
-    pub reserved: [u8; 7],
+    pub reserved: [u8; 15],
 }
 
 impl blaze_user_meta_unknown {
@@ -471,7 +471,7 @@ impl blaze_user_meta_unknown {
 
         let slf = Self {
             reason: reason.into(),
-            reserved: [0u8; 7],
+            reserved: [0; 15],
         };
         ManuallyDrop::new(slf)
     }
@@ -520,21 +520,21 @@ impl blaze_user_meta {
         let slf = match other {
             UserMeta::Apk(apk) => Self {
                 kind: blaze_user_meta_kind::BLAZE_USER_META_APK,
-                unused: [0u8; 7],
+                unused: [0; 7],
                 variant: blaze_user_meta_variant {
                     apk: blaze_user_meta_apk::from(apk),
                 },
             },
             UserMeta::Elf(elf) => Self {
                 kind: blaze_user_meta_kind::BLAZE_USER_META_ELF,
-                unused: [0u8; 7],
+                unused: [0; 7],
                 variant: blaze_user_meta_variant {
                     elf: blaze_user_meta_elf::from(elf),
                 },
             },
             UserMeta::Unknown(unknown) => Self {
                 kind: blaze_user_meta_kind::BLAZE_USER_META_UNKNOWN,
-                unused: [0u8; 7],
+                unused: [0; 7],
                 variant: blaze_user_meta_variant {
                     unknown: blaze_user_meta_unknown::from(unknown),
                 },
@@ -575,7 +575,7 @@ pub struct blaze_normalized_user_output {
     /// An array of `output_cnt` objects.
     pub outputs: *mut blaze_normalized_output,
     /// Unused member available for future expansion.
-    pub reserved: [u8; 8],
+    pub reserved: [u8; 16],
 }
 
 impl blaze_normalized_user_output {
@@ -610,7 +610,7 @@ impl blaze_normalized_user_output {
                 .unwrap()
                 .as_mut_ptr()
             },
-            reserved: [0u8; 8],
+            reserved: [0; 16],
         };
         ManuallyDrop::new(slf)
     }
@@ -775,11 +775,11 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn type_sizes() {
-        assert_eq!(size_of::<blaze_normalizer_opts>(), 16);
-        assert_eq!(size_of::<blaze_normalize_opts>(), 16);
-        assert_eq!(size_of::<blaze_user_meta_apk>(), 16);
-        assert_eq!(size_of::<blaze_user_meta_elf>(), 32);
-        assert_eq!(size_of::<blaze_user_meta_unknown>(), 8);
+        assert_eq!(size_of::<blaze_normalizer_opts>(), 32);
+        assert_eq!(size_of::<blaze_normalize_opts>(), 32);
+        assert_eq!(size_of::<blaze_user_meta_apk>(), 24);
+        assert_eq!(size_of::<blaze_user_meta_elf>(), 40);
+        assert_eq!(size_of::<blaze_user_meta_unknown>(), 16);
     }
 
     /// Exercise the `Debug` representation of various types.
@@ -800,40 +800,40 @@ mod tests {
 
         let apk = blaze_user_meta_apk {
             path: ptr::null_mut(),
-            reserved: [0u8; 8],
+            reserved: [0; 16],
         };
         assert_eq!(
             format!("{apk:?}"),
-            "blaze_user_meta_apk { path: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0] }",
+            "blaze_user_meta_apk { path: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }",
         );
 
         let elf = blaze_user_meta_elf {
             path: ptr::null_mut(),
             build_id_len: 0,
             build_id: ptr::null_mut(),
-            reserved: [0u8; 8],
+            reserved: [0; 16],
         };
         assert_eq!(
             format!("{elf:?}"),
-            "blaze_user_meta_elf { path: 0x0, build_id_len: 0, build_id: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0] }",
+            "blaze_user_meta_elf { path: 0x0, build_id_len: 0, build_id: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }",
         );
 
         let unknown = blaze_user_meta_unknown {
             reason: blaze_normalize_reason::BLAZE_NORMALIZE_REASON_UNMAPPED,
-            reserved: [0u8; 7],
+            reserved: [0; 15],
         };
         assert_eq!(
             format!("{unknown:?}"),
-            "blaze_user_meta_unknown { reason: BLAZE_NORMALIZE_REASON_UNMAPPED, reserved: [0, 0, 0, 0, 0, 0, 0] }",
+            "blaze_user_meta_unknown { reason: BLAZE_NORMALIZE_REASON_UNMAPPED, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }",
         );
 
         let meta = blaze_user_meta {
             kind: blaze_user_meta_kind::BLAZE_USER_META_UNKNOWN,
-            unused: [0u8; 7],
+            unused: [0; 7],
             variant: blaze_user_meta_variant {
                 unknown: ManuallyDrop::new(blaze_user_meta_unknown {
                     reason: blaze_normalize_reason::BLAZE_NORMALIZE_REASON_UNMAPPED,
-                    reserved: [0u8; 7],
+                    reserved: [0; 15],
                 }),
             },
         };
@@ -847,11 +847,11 @@ mod tests {
             metas: ptr::null_mut(),
             output_cnt: 0,
             outputs: ptr::null_mut(),
-            reserved: [0u8; 8],
+            reserved: [0; 16],
         };
         assert_eq!(
             format!("{user_addrs:?}"),
-            "blaze_normalized_user_output { meta_cnt: 0, metas: 0x0, output_cnt: 0, outputs: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0] }",
+            "blaze_normalized_user_output { meta_cnt: 0, metas: 0x0, output_cnt: 0, outputs: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }",
         );
     }
 

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -50,7 +50,7 @@ pub struct blaze_cache_src_elf {
     pub path: *const c_char,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 8],
+    pub reserved: [u8; 16],
 }
 
 impl Default for blaze_cache_src_elf {
@@ -58,7 +58,7 @@ impl Default for blaze_cache_src_elf {
         Self {
             type_size: mem::size_of::<Self>(),
             path: ptr::null(),
-            reserved: [0; 8],
+            reserved: [0; 16],
         }
     }
 }
@@ -110,7 +110,7 @@ pub struct blaze_cache_src_process {
     pub cache_vmas: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 11],
+    pub reserved: [u8; 19],
 }
 
 impl Default for blaze_cache_src_process {
@@ -119,7 +119,7 @@ impl Default for blaze_cache_src_process {
             type_size: mem::size_of::<Self>(),
             pid: 0,
             cache_vmas: false,
-            reserved: [0; 11],
+            reserved: [0; 19],
         }
     }
 }
@@ -165,7 +165,7 @@ pub struct blaze_symbolize_src_elf {
     pub debug_syms: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 7],
+    pub reserved: [u8; 23],
 }
 
 impl Default for blaze_symbolize_src_elf {
@@ -174,7 +174,7 @@ impl Default for blaze_symbolize_src_elf {
             type_size: mem::size_of::<Self>(),
             path: ptr::null(),
             debug_syms: false,
-            reserved: [0; 7],
+            reserved: [0; 23],
         }
     }
 }
@@ -236,7 +236,7 @@ pub struct blaze_symbolize_src_kernel {
     pub debug_syms: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 7],
+    pub reserved: [u8; 23],
 }
 
 impl Default for blaze_symbolize_src_kernel {
@@ -246,7 +246,7 @@ impl Default for blaze_symbolize_src_kernel {
             kallsyms: ptr::null(),
             vmlinux: ptr::null(),
             debug_syms: false,
-            reserved: [0; 7],
+            reserved: [0; 23],
         }
     }
 }
@@ -315,7 +315,7 @@ pub struct blaze_symbolize_src_process {
     pub no_map_files: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 1],
+    pub reserved: [u8; 17],
 }
 
 impl Default for blaze_symbolize_src_process {
@@ -326,7 +326,7 @@ impl Default for blaze_symbolize_src_process {
             debug_syms: false,
             perf_map: false,
             no_map_files: false,
-            reserved: [0; 1],
+            reserved: [0; 17],
         }
     }
 }
@@ -365,8 +365,9 @@ pub struct blaze_symbolize_src_gsym_data {
     pub data: *const u8,
     /// The size of the Gsym data.
     pub data_len: usize,
-    /// Unused member indicating the last field.
-    pub reserved: (),
+    /// Unused member available for future expansion. Must be initialized
+    /// to zero.
+    pub reserved: [u8; 16],
 }
 
 impl Default for blaze_symbolize_src_gsym_data {
@@ -375,7 +376,7 @@ impl Default for blaze_symbolize_src_gsym_data {
             type_size: mem::size_of::<Self>(),
             data: ptr::null(),
             data_len: 0,
-            reserved: (),
+            reserved: [0; 16],
         }
     }
 }
@@ -386,7 +387,7 @@ impl From<blaze_symbolize_src_gsym_data> for GsymData<'_> {
             type_size: _,
             data,
             data_len,
-            reserved: (),
+            reserved: _,
         } = gsym;
         Self {
             data: unsafe { slice_from_aligned_user_array(data, data_len) },
@@ -407,8 +408,9 @@ pub struct blaze_symbolize_src_gsym_file {
     pub type_size: usize,
     /// The path to a gsym file.
     pub path: *const c_char,
-    /// Unused member indicating the last field.
-    pub reserved: (),
+    /// Unused member available for future expansion. Must be initialized
+    /// to zero.
+    pub reserved: [u8; 16],
 }
 
 impl Default for blaze_symbolize_src_gsym_file {
@@ -416,7 +418,7 @@ impl Default for blaze_symbolize_src_gsym_file {
         Self {
             type_size: mem::size_of::<Self>(),
             path: ptr::null(),
-            reserved: (),
+            reserved: [0; 16],
         }
     }
 }
@@ -426,7 +428,7 @@ impl From<blaze_symbolize_src_gsym_file> for GsymFile {
         let blaze_symbolize_src_gsym_file {
             type_size: _,
             path,
-            reserved: (),
+            reserved: _,
         } = gsym;
         Self {
             path: unsafe { from_cstr(path) },
@@ -609,7 +611,7 @@ pub struct blaze_sym {
     /// why symbolization failed.
     pub reason: blaze_symbolize_reason,
     /// Unused member available for future expansion.
-    pub reserved: [u8; 7],
+    pub reserved: [u8; 15],
 }
 
 /// `blaze_syms` is the result of symbolization of a list of addresses.
@@ -680,7 +682,7 @@ pub struct blaze_symbolizer_opts {
     pub demangle: bool,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 4],
+    pub reserved: [u8; 20],
 }
 
 impl Default for blaze_symbolizer_opts {
@@ -693,7 +695,7 @@ impl Default for blaze_symbolizer_opts {
             code_info: false,
             inlined_fns: false,
             demangle: false,
-            reserved: [0; 4],
+            reserved: [0; 20],
         }
     }
 }
@@ -1348,17 +1350,17 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn type_sizes() {
-        assert_eq!(mem::size_of::<blaze_cache_src_elf>(), 24);
-        assert_eq!(mem::size_of::<blaze_cache_src_process>(), 24);
-        assert_eq!(mem::size_of::<blaze_symbolize_src_elf>(), 24);
-        assert_eq!(mem::size_of::<blaze_symbolize_src_kernel>(), 32);
-        assert_eq!(mem::size_of::<blaze_symbolize_src_process>(), 16);
-        assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_data>(), 24);
-        assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_file>(), 16);
-        assert_eq!(mem::size_of::<blaze_symbolizer_opts>(), 32);
+        assert_eq!(mem::size_of::<blaze_cache_src_elf>(), 32);
+        assert_eq!(mem::size_of::<blaze_cache_src_process>(), 32);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_elf>(), 40);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_kernel>(), 48);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_process>(), 32);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_data>(), 40);
+        assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_file>(), 32);
+        assert_eq!(mem::size_of::<blaze_symbolizer_opts>(), 48);
         assert_eq!(mem::size_of::<blaze_symbolize_code_info>(), 32);
         assert_eq!(mem::size_of::<blaze_symbolize_inlined_fn>(), 48);
-        assert_eq!(mem::size_of::<blaze_sym>(), 96);
+        assert_eq!(mem::size_of::<blaze_sym>(), 104);
     }
 
     /// Exercise the `Debug` representation of various types.
@@ -1371,7 +1373,7 @@ mod tests {
         };
         assert_eq!(
             format!("{elf:?}"),
-            "blaze_symbolize_src_elf { type_size: 24, path: 0x0, debug_syms: false, reserved: [0, 0, 0, 0, 0, 0, 0] }"
+            "blaze_symbolize_src_elf { type_size: 24, path: 0x0, debug_syms: false, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let kernel = blaze_symbolize_src_kernel {
@@ -1381,7 +1383,7 @@ mod tests {
         };
         assert_eq!(
             format!("{kernel:?}"),
-            "blaze_symbolize_src_kernel { type_size: 32, kallsyms: 0x0, vmlinux: 0x0, debug_syms: true, reserved: [0, 0, 0, 0, 0, 0, 0] }"
+            "blaze_symbolize_src_kernel { type_size: 32, kallsyms: 0x0, vmlinux: 0x0, debug_syms: true, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let process = blaze_symbolize_src_process {
@@ -1392,28 +1394,28 @@ mod tests {
         };
         assert_eq!(
             format!("{process:?}"),
-            "blaze_symbolize_src_process { type_size: 16, pid: 1337, debug_syms: true, perf_map: false, no_map_files: false, reserved: [0] }"
+            "blaze_symbolize_src_process { type_size: 16, pid: 1337, debug_syms: true, perf_map: false, no_map_files: false, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let gsym_data = blaze_symbolize_src_gsym_data {
             type_size: 24,
             data: ptr::null(),
             data_len: 0,
-            reserved: (),
+            reserved: [0; 16],
         };
         assert_eq!(
             format!("{gsym_data:?}"),
-            "blaze_symbolize_src_gsym_data { type_size: 24, data: 0x0, data_len: 0, reserved: () }"
+            "blaze_symbolize_src_gsym_data { type_size: 24, data: 0x0, data_len: 0, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let gsym_file = blaze_symbolize_src_gsym_file {
             type_size: 16,
             path: ptr::null(),
-            reserved: (),
+            reserved: [0; 16],
         };
         assert_eq!(
             format!("{gsym_file:?}"),
-            "blaze_symbolize_src_gsym_file { type_size: 16, path: 0x0, reserved: () }"
+            "blaze_symbolize_src_gsym_file { type_size: 16, path: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let sym = blaze_sym {
@@ -1427,16 +1429,16 @@ mod tests {
                 file: ptr::null(),
                 line: 42,
                 column: 1,
-                reserved: [0u8; 10],
+                reserved: [0; 10],
             },
             inlined_cnt: 0,
             inlined: ptr::null(),
             reason: blaze_symbolize_reason::BLAZE_SYMBOLIZE_REASON_UNSUPPORTED,
-            reserved: [0u8; 7],
+            reserved: [0; 15],
         };
         assert_eq!(
             format!("{sym:?}"),
-            "blaze_sym { name: 0x0, module: 0x0, addr: 4919, offset: 24, size: 16, code_info: blaze_symbolize_code_info { dir: 0x0, file: 0x0, line: 42, column: 1, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }, inlined_cnt: 0, inlined: 0x0, reason: BLAZE_SYMBOLIZE_REASON_UNSUPPORTED, reserved: [0, 0, 0, 0, 0, 0, 0] }"
+            "blaze_sym { name: 0x0, module: 0x0, addr: 4919, offset: 24, size: 16, code_info: blaze_symbolize_code_info { dir: 0x0, file: 0x0, line: 42, column: 1, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }, inlined_cnt: 0, inlined: 0x0, reason: BLAZE_SYMBOLIZE_REASON_UNSUPPORTED, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
 
         let inlined = blaze_symbolize_inlined_fn {
@@ -1446,9 +1448,9 @@ mod tests {
                 file: ptr::null(),
                 line: 42,
                 column: 1,
-                reserved: [0u8; 10],
+                reserved: [0; 10],
             },
-            reserved: [0u8; 8],
+            reserved: [0; 8],
         };
         assert_eq!(
             format!("{inlined:?}"),
@@ -1465,7 +1467,7 @@ mod tests {
         };
         assert_eq!(
             format!("{opts:?}"),
-            "blaze_symbolizer_opts { type_size: 16, debug_dirs: 0x0, debug_dirs_len: 0, auto_reload: false, code_info: false, inlined_fns: false, demangle: true, reserved: [0, 0, 0, 0] }"
+            "blaze_symbolizer_opts { type_size: 16, debug_dirs: 0x0, debug_dirs_len: 0, auto_reload: false, code_info: false, inlined_fns: false, demangle: true, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
     }
 


### PR DESCRIPTION
Add more reserved bytes to various types to facilitate future expansion. We want to make sure to have at least 16 bytes available on most types. Exceptions are `blaze_sym` as well as the code and info types, which are somewhat performance sensitive as well as less likely to see large extensions due to the nature of what they represent.