### PR TITLE
cli: Bump version to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blazecli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "blazesym",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,9 +1,9 @@
-Unreleased
-----------
+0.1.9
+-----
 - Added `--debug-dirs` and `--no-debug-syms` options to `symbolize
   process` sub-command
 - Added `--no-debug-syms` option to `inspect dump elf` sub-command
-- Added `--kallsyms` and `--vmlinux` options to `symbolize-kernel
+- Added `--kallsyms` and `--vmlinux` options to `symbolize kernel`
   sub-command
 - Fixed truncation of overly long tracing lines
 - Bumped `blazesym` dependency to `0.2.0-rc.3`

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazecli"
 description = "A command line utility for the blazesym library."
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 rust-version.workspace = true
 default-run = "blazecli"


### PR DESCRIPTION
This change bumps blazecli's version to 0.1.9. The following notable changes have been made since 0.1.8:
- Added --debug-dirs and --no-debug-syms options to 'symbolize process' sub-command
- Added --no-debug-syms option to 'inspect dump elf' sub-command
- Added --kallsyms and --vmlinux options to 'symbolize kernel' sub-command
- Fixed truncation of overly long tracing lines
- Bumped blazesym dependency to 0.2.0-rc.3