### PR TITLE
capi: Bump version to `0.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "blazesym-c"
-version = "0.1.0-rc.2"
+version = "0.1.0"
 dependencies = [
  "bindgen",
  "blazesym",

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.0
+-----
 - Introduced `blaze_trace` function for tapping into the library's
   tracing functionality
 - Added `apk_to_elf` attribute to `blaze_normalize_opts`

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym-c"
 description = "C bindings for blazesym"
-version = "0.1.0-rc.2"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Daniel Müller <deso@posteo.net>"]

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1,7 +1,7 @@
 /*
  * Please refer to the documentation hosted at
  *
- *   https://docs.rs/blazesym-c/0.1.0-rc.2
+ *   https://docs.rs/blazesym-c/0.1.0
  */
 
 


### PR DESCRIPTION
This change bumps the blazesym-c's version to 0.1.0. The following notable changes have been made since 0.1.0:
- Introduced blaze_trace function for tapping into the library's tracing functionality
- Added apk_to_elf attribute to blaze_normalize_opts
- Added size and module attributes to blaze_sym type
- Added additional reserved bytes to various types
- Adjusted various enum types to be mere typedefs
- Changed size attribute of blaze_sym_info to be signed
- Changed blaze_user_meta_kind to be represented as uint8_t
- Renamed kernel_image member of blaze_symbolize_src_kernel to vmlinux
- Renamed obj_file_name member of blaze_sym_info to module
- Renamed map_files member of blaze_symbolize_src_process to no_map_files and inverted its meaning
- Added support for disabling kallsyms and vmlinux to blaze_symbolize_src_kernel
- Added blaze_symbolize_cache_elf for caching of ELF data
- Added blaze_symbolize_cache_process for caching of process VMA metadata
- Bumped blazesym dependency to 0.2.0-rc.3