### PR TITLE
capi: Lower MSRV to 1.70

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,7 @@ jobs:
           toolchain: 1.70.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --features="apk,backtrace,bpf,demangle,dwarf,gsym,tracing"
+      - run: cargo build --package=blazesym-c
   nop-rebuilds:
     name: No-op rebuilds
     runs-on: ubuntu-24.04

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Lowered minimum supported Rust version to `1.70`
+
+
 0.1.0
 -----
 - Introduced `blaze_trace` function for tapping into the library's

--- a/capi/src/error.rs
+++ b/capi/src/error.rs
@@ -8,7 +8,7 @@ use blazesym::ErrorKind;
 ///
 /// C ABI compatible version of [`blazesym::ErrorKind`].
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct blaze_err(i16);
 
 impl blaze_err {

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -276,7 +276,7 @@ impl From<(u64, usize)> for blaze_normalized_output {
 
 /// The valid variant kind in [`blaze_user_meta`].
 #[repr(transparent)]
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct blaze_user_meta_kind(u8);
 
 impl blaze_user_meta_kind {
@@ -412,7 +412,7 @@ impl blaze_user_meta_elf {
 /// over time and, hence, should not be relied upon for the correctness of the
 /// application.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct blaze_normalize_reason(u8);
 
 impl blaze_normalize_reason {

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -451,7 +451,7 @@ pub type blaze_symbolizer = Symbolizer;
 /// change over time and, hence, should not be relied upon for the
 /// correctness of the application.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct blaze_symbolize_reason(u8);
 
 impl blaze_symbolize_reason {

--- a/capi/src/trace.rs
+++ b/capi/src/trace.rs
@@ -19,7 +19,7 @@ use crate::set_last_err;
 
 /// The level at which to emit traces.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct blaze_trace_lvl(u8);
 
 impl blaze_trace_lvl {


### PR DESCRIPTION
As it turns out only recent versions of Rust seem to support matches on constants of types not implementing Eq. As a result, the library actually does not build on Rust 1.70 as advertised. Add the necessary derive implementations and make sure to enforce MSRV checks even for blazesym-c.