### PR TITLE
Enable Rust artifact caching for test-32bit CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,6 +378,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         targets: "i686-unknown-linux-gnu"
+    - uses: Swatinem/rust-cache@v2
     - run: cargo check --target x86_64-unknown-linux-gnu --package=blazesym-dev --features=generate-unit-test-files
     - name: Install development dependencies
       run: |


### PR DESCRIPTION
Enable caching of Rust build artifacts for the test-32bit CI job. It seems one of the slower jobs now, given that most others already use caching.