### PR TITLE
Ignore self-referential debug links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Adjusted debug link resolution to handle self-referential debug links
+  more gracefully
+
+
 0.2.0-rc.3
 ----------
 - Added support for 32 bit ELF binaries

--- a/dev/build.rs
+++ b/dev/build.rs
@@ -580,6 +580,14 @@ fn prepare_test_files() {
     );
     let () = remove_file(&dbg).unwrap();
 
+    let name = "test-stable-addrs-with-link-to-self.bin";
+    let link = data_dir.join(name);
+    objcopy(
+        &src,
+        name,
+        &[&format!("--add-gnu-debuglink={}", link.display())],
+    );
+
     let src = data_dir.join("kallsyms.xz");
     unpack_xz(&src, &change_ext(&src, ""));
 

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -575,6 +575,25 @@ fn symbolize_dwarf_non_existent_debug_link() {
     assert_eq!(result, None);
 }
 
+/// Check that we don't error out due to checksum mismatch on
+/// self-referential debug link.
+#[tag(other_os)]
+#[test]
+fn symbolize_dwarf_self_referential_debug_link() {
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-with-link-to-self.bin");
+    let src = Source::from(Elf::new(path));
+    let symbolizer = Symbolizer::builder().enable_auto_reload(false).build();
+    let result = symbolizer
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
+        .unwrap()
+        .into_sym()
+        .unwrap();
+    assert_eq!(result.name, "factorial");
+    assert_eq!(result.addr, 0x2000200);
+}
+
 /// Check that we honor configured debug directories as one would expect.
 #[tag(other_os)]
 #[test]


### PR DESCRIPTION
It is possible to set a DWARF file's debug link to the file itself, i.e., creating a self-referential entity. One could come up with a rational for that, or it could just be a bug. Our debug link resolution logic currently follows the link, but given that the link's expected checksum seems to be written before adjustment of the link, the checksum would never check out, causing us to report an error. From a logical point of view, it makes no sense to even consider the case where we resolve the debug link to the linker itself. As such, with this change we check to make sure that we do not report the linker itself, just moving on if we would. In so doing we actually support the case where the linkee is a file of the same name as the linker, and that could actually be found in a different directory than the linker.