### PR TITLE
Report symbolic paths as module for APK process symbolization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 - Adjusted debug link resolution to handle self-referential debug links
   more gracefully
+- Report "symbolic" path in `symbolize::Sym::module` when using process
+  symbolization on APKs with `map_files` set to `true`
 
 
 0.2.0-rc.3


### PR DESCRIPTION
Commit 7e1d9455db20 ("Introduce PathLike trait") introduced the PathLike trait and adjusted the process symbolization for ELF files to use it in order to report more meaningful Sym::module values. What explicitly was left for later was to apply a similar logic to the APK path. This change addresses this remaining short coming.