### PR TITLE
Don't run self-referential debug link test on other OSs

### DIFF
--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -577,7 +577,6 @@ fn symbolize_dwarf_non_existent_debug_link() {
 
 /// Check that we don't error out due to checksum mismatch on
 /// self-referential debug link.
-#[tag(other_os)]
 #[test]
 fn symbolize_dwarf_self_referential_debug_link() {
     let path = Path::new(&env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
The test fails on Windows, presumably because of their weird path handling. It doesn't seem worth it to spent the time to look into that for this corner case until this becomes more than a hypothetical issue, so stop running the test on anything but Linux.