### PR TITLE
Revert "Report symbolic paths as module for APK process symbolization"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@ Unreleased
 ----------
 - Adjusted debug link resolution to handle self-referential debug links
   more gracefully
-- Report "symbolic" path in `symbolize::Sym::module` when using process
-  symbolization on APKs with `map_files` set to `true`
 
 
 0.2.0-rc.3

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -38,8 +38,6 @@ use crate::mmap::Mmap;
 use crate::normalize;
 use crate::normalize::normalize_sorted_user_addrs_with_entries;
 use crate::normalize::Handler as _;
-#[cfg(feature = "apk")]
-use crate::pathlike::PathLike;
 use crate::perf_map::PerfMap;
 use crate::symbolize::InlinedFn;
 use crate::symbolize::Resolve;
@@ -438,16 +436,16 @@ struct SymbolizeHandler<'sym> {
 impl SymbolizeHandler<'_> {
     #[cfg(feature = "apk")]
     fn handle_apk_addr(&mut self, addr: Addr, file_off: u64, entry_path: &EntryPath) -> Result<()> {
-        let result = if self.map_files {
-            self.symbolizer
-                .apk_resolver(entry_path, file_off, self.debug_syms)?
+        let apk_path = if self.map_files {
+            &entry_path.maps_file
         } else {
-            let path = entry_path.symbolic_path.as_path();
-            self.symbolizer
-                .apk_resolver(path, file_off, self.debug_syms)?
+            &entry_path.symbolic_path
         };
 
-        match result {
+        match self
+            .symbolizer
+            .apk_resolver(apk_path, file_off, self.debug_syms)?
+        {
             Some((elf_resolver, elf_addr)) => {
                 let symbol = self.symbolizer.symbolize_with_resolver(
                     elf_addr,
@@ -818,19 +816,15 @@ impl Symbolizer {
         Ok(None)
     }
 
+    // TODO: Should likely require a `PathLike` as input, similar to
+    //       `FileCache<ElfResolverData>::elf_resolver`.
     #[cfg(feature = "apk")]
-    fn apk_resolver<'slf, P>(
+    fn apk_resolver<'slf>(
         &'slf self,
-        path: &P,
+        path: &Path,
         file_off: u64,
         debug_syms: bool,
-    ) -> Result<Option<(&'slf dyn Resolve, Addr)>>
-    where
-        P: ?Sized + PathLike,
-    {
-        let path = path.represented_path();
-        dbg!(path);
-
+    ) -> Result<Option<(&'slf dyn Resolve, Addr)>> {
         let (file, cell) = self.apk_cache.entry(path)?;
         let (apk, resolvers) = cell.get_or_try_init(|| {
             let mmap = Mmap::builder()
@@ -1156,15 +1150,15 @@ impl Symbolizer {
                 }
                 Input::FileOffset(offsets) => offsets
                     .iter()
-                    .map(|offset| {
-                        match self.apk_resolver(path.as_path(), *offset, *debug_syms)? {
+                    .map(
+                        |offset| match self.apk_resolver(path, *offset, *debug_syms)? {
                             Some((elf_resolver, elf_addr)) => self.symbolize_with_resolver(
                                 elf_addr,
                                 &Resolver::Cached(elf_resolver.as_symbolize()),
                             ),
                             None => Ok(Symbolized::Unknown(Reason::InvalidFileOffset)),
-                        }
-                    })
+                        },
+                    )
                     .collect(),
             },
             #[cfg(feature = "breakpad")]
@@ -1344,15 +1338,13 @@ impl Symbolizer {
                         "APK symbolization does not support absolute address inputs",
                     ))
                 }
-                Input::FileOffset(offset) => {
-                    match self.apk_resolver(path.as_path(), offset, *debug_syms)? {
-                        Some((elf_resolver, elf_addr)) => self.symbolize_with_resolver(
-                            elf_addr,
-                            &Resolver::Cached(elf_resolver.as_symbolize()),
-                        ),
-                        None => return Ok(Symbolized::Unknown(Reason::InvalidFileOffset)),
-                    }
-                }
+                Input::FileOffset(offset) => match self.apk_resolver(path, offset, *debug_syms)? {
+                    Some((elf_resolver, elf_addr)) => self.symbolize_with_resolver(
+                        elf_addr,
+                        &Resolver::Cached(elf_resolver.as_symbolize()),
+                    ),
+                    None => return Ok(Symbolized::Unknown(Reason::InvalidFileOffset)),
+                },
             },
             #[cfg(feature = "breakpad")]
             Source::Breakpad(Breakpad {

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -928,37 +928,34 @@ fn symbolize_process_exited_cached_vmas() {
 /// Check that we can symbolize an address residing in a zip archive.
 #[test]
 fn symbolize_process_zip() {
-    fn test(map_files: bool) {
-        let test_zip = Path::new(&env!("CARGO_MANIFEST_DIR"))
-            .join("data")
-            .join("test.zip");
+    let test_zip = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test.zip");
 
-        let mmap = Mmap::builder().exec().open(&test_zip).unwrap();
-        let (sym, the_answer_addr) = find_the_answer_fn_in_zip(&mmap);
+    let mmap = Mmap::builder().exec().open(test_zip).unwrap();
+    let (sym, the_answer_addr) = find_the_answer_fn_in_zip(&mmap);
 
-        // Symbolize the address we just looked up. It should be correctly
-        // mapped to the `the_answer` function within our process.
-        let mut process = Process::new(Pid::Slf);
-        process.map_files = map_files;
-        let src = Source::Process(process);
-        let symbolizer = Symbolizer::new();
-        let result = symbolizer
-            .symbolize_single(&src, Input::AbsAddr(the_answer_addr))
-            .unwrap()
-            .into_sym()
-            .unwrap();
+    // Symbolize the address we just looked up. It should be correctly
+    // mapped to the `the_answer` function within our process.
+    let src = Source::Process(Process::new(Pid::Slf));
+    let symbolizer = Symbolizer::new();
+    let result = symbolizer
+        .symbolize_single(&src, Input::AbsAddr(the_answer_addr))
+        .unwrap()
+        .into_sym()
+        .unwrap();
 
-        let mut module = test_zip.as_os_str().to_os_string();
-        let () = module.push("!/libtest-so.so");
-
-        assert_eq!(result.name, "the_answer");
-        assert_eq!(result.module.as_deref(), Some(module.as_os_str()));
-        assert_eq!(result.addr, sym.addr);
-    }
-
-    for map_files in [false, true] {
-        let () = test(map_files);
-    }
+    assert_eq!(result.name, "the_answer");
+    assert!(
+        result
+            .module
+            .as_deref()
+            .map(|module| module.to_string_lossy().ends_with("!/libtest-so.so"))
+            .unwrap_or(false),
+        "{:?}",
+        result.module
+    );
+    assert_eq!(result.addr, sym.addr);
 }
 
 /// Test that we can use a custom dispatch function when symbolizing addresses


### PR DESCRIPTION
The change shouldn't have gone in in its current form, it wasn't finished.

This reverts commit 3e544840c8c5c6df8a0370269ee5bd40cc089b08.