### PR TITLE
Work more with PathLike trait objects

### DIFF
--- a/src/inspect/inspector.rs
+++ b/src/inspect/inspector.rs
@@ -114,7 +114,7 @@ impl Inspector {
             }) => {
                 let debug_dirs;
                 let resolver = self.elf_cache.elf_resolver(
-                    path.as_path(),
+                    path,
                     if *debug_syms {
                         debug_dirs = DEFAULT_DEBUG_DIRS
                             .iter()
@@ -196,7 +196,7 @@ impl Inspector {
                     };
                     let debug_dirs;
                     let resolver = slf.elf_cache.elf_resolver(
-                        path.as_path(),
+                        path,
                         if *debug_syms {
                             debug_dirs = DEFAULT_DEBUG_DIRS
                                 .iter()

--- a/src/pathlike.rs
+++ b/src/pathlike.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::path::PathBuf;
 
 
 pub(crate) trait PathLike {
@@ -24,5 +25,15 @@ impl PathLike for Path {
 
     fn represented_path(&self) -> &Path {
         self
+    }
+}
+
+impl PathLike for PathBuf {
+    fn actual_path(&self) -> &Path {
+        self.as_path()
+    }
+
+    fn represented_path(&self) -> &Path {
+        self.as_path()
     }
 }

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -465,7 +465,7 @@ impl SymbolizeHandler<'_> {
                 self.symbolizer.maybe_debug_dirs(self.debug_syms),
             )
         } else {
-            let path = entry_path.symbolic_path.as_path();
+            let path = &entry_path.symbolic_path;
             self.symbolizer
                 .elf_cache
                 .elf_resolver(path, self.symbolizer.maybe_debug_dirs(self.debug_syms))
@@ -994,7 +994,7 @@ impl Symbolizer {
             MaybeDefault::Some(vmlinux) => {
                 let resolver = self
                     .elf_cache
-                    .elf_resolver(vmlinux.as_path(), self.maybe_debug_dirs(*debug_syms))?;
+                    .elf_resolver(vmlinux, self.maybe_debug_dirs(*debug_syms))?;
                 Some(resolver)
             }
             MaybeDefault::Default => {
@@ -1012,7 +1012,7 @@ impl Symbolizer {
                 if let Some(vmlinux) = vmlinux {
                     let result = self
                         .elf_cache
-                        .elf_resolver(vmlinux.as_path(), self.maybe_debug_dirs(*debug_syms));
+                        .elf_resolver(&vmlinux, self.maybe_debug_dirs(*debug_syms));
                     match result {
                         Ok(resolver) => {
                             log::debug!("found suitable vmlinux file `{}`", vmlinux.display());
@@ -1068,7 +1068,7 @@ impl Symbolizer {
                 let _unpinned = self.elf_cache.unpin(path);
                 let result = self
                     .elf_cache
-                    .elf_resolver(path.as_path(), self.maybe_debug_dirs(false));
+                    .elf_resolver(path, self.maybe_debug_dirs(false));
                 // Make sure to always pin the entry, even if bailing
                 // due to a retrieval error. Basically, the semantics we
                 // want to have is that if caching new data fails the
@@ -1191,7 +1191,7 @@ impl Symbolizer {
             }) => {
                 let resolver = self
                     .elf_cache
-                    .elf_resolver(path.as_path(), self.maybe_debug_dirs(*debug_syms))?;
+                    .elf_resolver(path, self.maybe_debug_dirs(*debug_syms))?;
                 match input {
                     Input::VirtOffset(addrs) => addrs
                         .iter()
@@ -1375,7 +1375,7 @@ impl Symbolizer {
             }) => {
                 let resolver = self
                     .elf_cache
-                    .elf_resolver(path.as_path(), self.maybe_debug_dirs(*debug_syms))?;
+                    .elf_resolver(path, self.maybe_debug_dirs(*debug_syms))?;
                 let addr = match input {
                     Input::VirtOffset(addr) => addr,
                     Input::AbsAddr(..) => {


### PR DESCRIPTION
With upcoming changes we are going to use the PathLike trait on the APK symbolization paths as well. These paths are arguably more involved than the ELF bits and monomorphizing everything there will lead to binary bloat.
As such, we have to switch over to using trait objects when working with PathLike objects in more places. Do so for the `elf_resolver()` method already to set proper precedent.