### PR TITLE
capi: add capi feature & configuration to enable building with cargo-c

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -36,6 +36,8 @@ crate-type = ["cdylib", "staticlib", "lib"]
 default = [
   "dwarf",
 ]
+# Required by cargo-c
+capi = []
 # Check C code documentation snippets.
 check-doc-snippets = []
 # Enable this feature to enable blazesym's DWARF support.
@@ -45,6 +47,15 @@ dwarf = ["blazesym/dwarf"]
 # include/ directory, so this feature is only necessary when APIs are
 # changed.
 generate-c-header = ["dep:cbindgen", "dep:which"]
+
+# cargo-c configuration:
+# skip header generation
+[package.metadata.capi.header]
+generation = false
+subdirectory = false
+# use the existing header for installation
+[package.metadata.capi.install.include]
+asset = [{ from="include/blazesym.h" }]
 
 [[bench]]
 name = "capi"


### PR DESCRIPTION
As explored in #1096 

We disable generating the header since it already exists, and more importantly because we cannot run the required custom cbindgen extension from cargo-c (at least not until the custom rename rule has been merged upstream into cbindgen).
The configuration bits alone should not disturb existing builds in any way, but are necessary for building with e.g. `cargo cbuild`. A sample configuration/invocation can be found in the prototypical [Gentoo ebuild](https://github.com/hhoffstaette/gentoo/tree/blazesym/dev-libs/blazesym_c). Basically a packager needs to pass e.g. `--prefix`, `--destdir` etc. depending on their target environment, and as documented by cargo-c.
