### PR TITLE
Fix build-linux workflow

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -47,7 +47,9 @@ jobs:
           path: linux/
       - if: steps.restore-cached-kernel.outputs.cache-hit != 'true'
         name: Install required tools
-        run: sudo apt-get install --yes --no-install-recommends libelf-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libelf-dev
       - if: steps.restore-cached-kernel.outputs.cache-hit != 'true'
         name: Build kernel
         run: |


### PR DESCRIPTION
Similar to what commit c30b1003d3d6 ("Fix Miri and Clippy CI jobs") did for the main test CI workflow, fix the build-linux workflow by running apt-get update before attempting to install packages.