### PR TITLE
capi: Make sure to generate unit test files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -368,7 +368,7 @@ jobs:
       run: cargo miri test --workspace --features=blazesym-dev/dont-generate-unit-test-files -- ":miri:"
   test-32bit:
     name: Test 32bit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "bindgen",
  "blazesym",
  "blazesym-c",
+ "blazesym-dev",
  "cbindgen-assoc-const",
  "criterion",
  "libc",

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -83,6 +83,7 @@ blazesym = {version = "=0.2.0-rc.3", path = "../", features = ["bpf"]}
 [dev-dependencies]
 blazesym = {version = "=0.2.0-rc.3", path = "../", features = ["test"]}
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}
+blazesym-dev = {path = "../dev", features = ["generate-unit-test-files"]}
 bindgen = {version = "0.71", default-features = false, features = ["runtime"]}
 # TODO: Use 0.5.2 once released.
 criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}


### PR DESCRIPTION
Make sure to generate unit test files when running the `blazesym-c` test suite, not just when testing the main crate.