### PR TITLE
Fix reading of unaligned compression headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
   more gracefully
 - Report "symbolic" path in `symbolize::Sym::module` when using process
   symbolization on APKs with `map_files` set to `true`
+- Fixed reading of compressed ELF section data with unaligned
+  compression headers
 
 
 0.2.0-rc.3

--- a/dev/build.rs
+++ b/dev/build.rs
@@ -429,7 +429,7 @@ fn prepare_test_files() {
             "-C",
             "debuginfo=2",
             // Note that despite us specifying the name mangling scheme
-            // here, because we want a stable mangled name the source
+            // here, because we want a stable mangled name, the source
             // actually uses a fixed "export name", which really is what
             // is used for the function in question.
             "-C",


### PR DESCRIPTION
The ELF compression header resides inside an ELF section's actual data. As such, it may not be aligned correctly. Switch over to reading it using read_pod() to make sure that we are able to read it even if unaligned.
This is a respin of commit 3e8ef1b54f45 ("Use read_pod() for reading compression header"), which somehow managed to get lost.

Closes: #1105