### PR TITLE
Add support for symbolizing addresses in a vDSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added support for symbolizing addresses in a vDSO
+  - Added `vdso` attribute to `symbolize::Process` type
 - Adjusted debug link resolution to handle self-referential debug links
   more gracefully
 - Report "symbolic" path in `symbolize::Sym::module` when using process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+- Added support for symbolizing addresses in a vDSO
 - Adjusted debug link resolution to handle self-referential debug links
   more gracefully
 - Report "symbolic" path in `symbolize::Sym::module` when using process

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -850,10 +850,20 @@ typedef struct blaze_symbolize_src_process {
    */
   bool no_map_files;
   /**
+   * Whether or not to symbolize addresses in a vDSO (virtual dynamic
+   * shared object).
+   *
+   * The main reason to disable vDSO symbolization is in cases of
+   * unpriviledged symbolization. Symbolizing vDSO data from a
+   * different process requires reading memory from another process,
+   * which is privileged.
+   */
+  bool no_vdso;
+  /**
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[17];
+  uint8_t reserved[16];
 } blaze_symbolize_src_process;
 
 /**

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -346,6 +346,8 @@ impl From<blaze_symbolize_src_process> for Process {
             debug_syms,
             perf_map,
             map_files: !no_map_files,
+            // TODO: Hook up vDSO usage.
+            vdso: false,
             _non_exhaustive: (),
         }
     }

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -397,15 +397,7 @@ pub(crate) fn filter_relevant(entry: &MapsEntry) -> bool {
     // Only readable (r---) or executable (--x-) entries are of relevance.
     // NB: Please keep this logic in sync with flags being used by
     //     `procmap_query`.
-    if (entry.perm & (Perm::R | Perm::X)) == Perm::default() {
-        return false
-    }
-
-    match entry.path_name {
-        Some(PathName::Path(..)) => true,
-        Some(PathName::Component(..)) => false,
-        None => true,
-    }
+    (entry.perm & (Perm::R | Perm::X)) != Perm::default()
 }
 
 /// Parse the maps file for the process with the given PID and make sure

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -278,6 +278,20 @@ pub struct Process {
     /// However, by using symbolic paths the need for requiring the
     /// `SYS_ADMIN` capability is eliminated.
     pub map_files: bool,
+    /// Whether or not to symbolize addresses in a vDSO (virtual dynamic
+    /// shared object).
+    ///
+    /// The main reason to disable vDSO symbolization is in cases of
+    /// unpriviledged symbolization. Symbolizing vDSO data from a
+    /// different process requires reading memory from another process,
+    /// which is privileged.
+    // TODO: Think about making this a tri-state of sorts and allowing
+    //       for direct usage of the current process' vDSO (which is
+    //       *likely* the same one used in other processes). This would
+    //       allow for unprivileged vDSO symbolization (but should be
+    //       opt-in, because it *could* result in wrong symbolization if
+    //       a process uses a custom vDSO).
+    pub vdso: bool,
     /// The struct is non-exhaustive and open to extension.
     #[doc(hidden)]
     pub _non_exhaustive: (),
@@ -286,8 +300,8 @@ pub struct Process {
 impl Process {
     /// Create a new [`Process`] object using the provided `pid`.
     ///
-    /// `debug_syms` and `perf_map` default to `true` when using this
-    /// constructor.
+    /// `debug_syms`, `perf_map`, `map_files`, and `vdso` default to
+    /// `true` when using this constructor.
     #[inline]
     pub fn new(pid: Pid) -> Self {
         Self {
@@ -295,6 +309,7 @@ impl Process {
             debug_syms: true,
             perf_map: true,
             map_files: true,
+            vdso: true,
             _non_exhaustive: (),
         }
     }
@@ -307,6 +322,7 @@ impl Debug for Process {
             debug_syms: _,
             perf_map: _,
             map_files: _,
+            vdso: _,
             _non_exhaustive: (),
         } = self;
 

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -1009,6 +1009,36 @@ fn symbolize_process_with_custom_dispatch() {
     test(process_no_dispatch);
 }
 
+/// Test that we symbolize addresses in a vDSO.
+#[cfg(linux)]
+#[test]
+fn symbolize_process_vdso() {
+    use libc::clock_gettime;
+    use libc::gettimeofday;
+
+    let src = Source::Process(Process::new(Pid::Slf));
+    // Both functions are typically provided by the vDSO, though there
+    // is no guarantee of that.
+    let addrs = [gettimeofday as Addr, clock_gettime as Addr];
+    let symbolizer = Symbolizer::new();
+
+    // Symbolize twice, to exercise both cache population and cache
+    // usage paths.
+    for _ in [0, 1] {
+        let results = symbolizer
+            .symbolize(&src, Input::AbsAddr(&addrs))
+            .unwrap()
+            .into_iter()
+            .collect::<Vec<_>>();
+        assert_eq!(results.len(), 2);
+        // Given that we can't guarantee that these symbols are in a vDSO,
+        // it's hard for us to assert anything more than the name.
+        let sym1 = results[0].as_sym().unwrap();
+        assert!(sym1.name.ends_with("gettimeofday"), "{sym1:?}");
+        let sym2 = results[1].as_sym().unwrap();
+        assert!(sym2.name.contains("clock_gettime"), "{sym2:?}");
+    }
+}
 
 /// Make sure that we do not fail symbolization when an empty perf
 /// map is present.


### PR DESCRIPTION
Add support for symbolizing addresses residing in a vDSO (virtual dynamic shared object). vDSO calls are system calls that don't have to enter the kernel but just read memory shared with it (and mapped into the application). As such, they are much faster than regular system calls.
From a symbolization perspective, the vDSO is a memory region that is actually nothing more than a regular ELF object. For symbolization purposes, we grab that region (potentially reading it from another process), write it into a file, and then use the regular ELF symbolization logic. We could opt to do this completely in-memory and without file system involvement, however due to the way things are structured it gets a bit more involved, because a new ElfParser backend has to be introduced, alongside accompanying infrastructure (e.g., for managing page aligned buffers). Using a regular file we get the benefit that handling is extremely similar to other paths, we use regular memory mapping which means that the kernel can opt to page out our cached data, and in general this seems like the less invasive approach.