### PR TITLE
Add note about test artifact generation for capi tests

### DIFF
--- a/README-devel.md
+++ b/README-devel.md
@@ -23,6 +23,13 @@ transparently created as long as the `generate-unit-test-files` feature for the
 `blazesym-dev` package is active, which is enabled by default for
 testing.
 
+Note that if you explicitly and *only* run the test suite for the C API
+bindings (`blazesym-c`), you will have to explicitly have to generate test
+artifacts before the first test run, via:
+```sh
+cargo check --package blazesym-dev --features=generate-unit-test-files
+```
+
 ### Running Miri
 [Miri][miri] is used for testing the crate for any undefined behavior.
 The interpreter is restricted to functionality that does not cross FFI


### PR DESCRIPTION
When *only* running the capi test suite and never having run the overall blazesym one, we end up not generating test artifacts. The fix isn't trivial, unfortunately, and given that this is a very unlikely pattern, let's just fudge this case with documentation.

Refs: #1103