### PR TITLE
Relax libc version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ codegen-units = 256
 [dependencies]
 cpp_demangle = {version = "0.4", optional = true}
 gimli = {version = "0.31", optional = true}
-libc = "0.2.172"
+libc = "0.2"
 memmap2 = {version = "0.9", default-features = false}
 miniz_oxide = {version = "0.8", default-features = false, features = ["simd", "with-alloc"], optional = true}
 nom = {version = "7", optional = true}

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -71,7 +71,7 @@ which = {version = "7.0.0", optional = true}
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
 blazesym = {version = "=0.2.0-rc.3", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
-libc = "0.2.172"
+libc = "0.2"
 # TODO: Remove dependency once MSRV is 1.77.
 memoffset = "0.9"
 tracing = "0.1"


### PR DESCRIPTION
Relax the libc version requirement. Not sure why we'd need 0.2.172.