### PR TITLE
Add CI test for cargo-c packaging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -405,7 +405,7 @@ jobs:
     - run: cargo run --example inspect-mangled
     - run: cargo run --example normalize-virt-offset
     - run: cargo run --package gsym-in-apk
-  c-header:
+  c-lib:
     name: Check generated C header
     runs-on: ubuntu-latest
     steps:
@@ -415,6 +415,30 @@ jobs:
     - name: Check that C header is up-to-date
       run: git diff --exit-code ||
              (echo "!!!! CHECKED IN C HEADER IS OUTDATED !!!!" && false)
+    - uses: actions/cache/restore@v4
+      id: restore-cargo-c
+      with:
+        path: cargo-c/
+        key: cargo-c
+    - if: steps.restore-cargo-c.outputs.cache-hit != 'true'
+      name: Install cargo-c
+      # TODO: We will never upgrade the program unless the cache gets
+      #       purged.
+      run: cargo install cargo-c --features=vendored-openssl --root cargo-c
+    - if: steps.restore-cargo-c.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: cargo-c/
+        key: cargo-c
+    - name: Run cargo-c
+      run: |
+        cargo-c/bin/cargo-cinstall cinstall --package blazesym-c --prefix / --destdir ./blazesym-c
+        tree ./blazesym-c || true
+        # We could do more sanity checking here, but we mostly care
+        # that cargo-c succeeded and on top of just checking for
+        # command success also check for existence of generated
+        # pkg-config file.
+        test -f ./blazesym-c/lib/x86_64-linux-gnu/pkgconfig/blazesym_c.pc
   bench:
     # Only run benchmarks on the final push. They are generally only
     # informative because the GitHub Runners do not provide a stable
@@ -486,7 +510,7 @@ jobs:
       test-release,
       test-miri,
       test-examples,
-      c-header,
+      c-lib,
       clippy,
       rustfmt,
       cargo-doc,


### PR DESCRIPTION
Add a test that dry-runs the packaging procedure using cargo-c in CI. We could do more on this front (such as actually linking against the library using the package config), but this should be sufficient to have some confidence that we won't break the workflow.