### PR TITLE
Overhaul and reuse workspace-wide Rust lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,37 @@ license = "BSD-3-Clause"
 repository = "https://github.com/libbpf/blazesym"
 homepage = "https://github.com/libbpf/blazesym"
 
+[workspace.lints.rust]
+deprecated-safe = "warn"
+future-incompatible = "warn"
+keyword-idents = "warn"
+let-underscore = "warn"
+missing-debug-implementations = "warn"
+missing-docs = "warn"
+trivial-numeric-casts = "warn"
+unexpected_cfgs = {level = "warn", check-cfg = ['cfg(has_procmap_query_ioctl)', 'cfg(has_large_test_files)']}
+unsafe-op-in-unsafe-fn = "warn"
+unused = "warn"
+
+[workspace.lints.clippy]
+collapsible-else-if = "allow"
+collapsible-if = "allow"
+fn-to-numeric-cast = "allow"
+let-and-return = "allow"
+let-unit-value = "allow"
+module-inception = "allow"
+type-complexity = "allow"
+absolute-paths = "warn"
+allow-attributes = "warn"
+clone-on-ref-ptr = "warn"
+dbg-macro = "warn"
+doc-markdown = "warn"
+join-absolute-paths = "warn"
+large-enum-variant = "warn"
+redundant-closure-for-method-calls = "warn"
+unchecked-duration-subtraction = "warn"
+uninlined-format-args = "warn"
+
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
@@ -171,5 +202,5 @@ features = ["apk", "backtrace", "breakpad", "demangle", "dwarf", "gsym"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]
 
-[lints.rust]
-unexpected_cfgs = {level = "warn", check-cfg = ['cfg(has_procmap_query_ioctl)', 'cfg(has_large_test_files)']}
+[lints]
+workspace = true

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,8 +1,6 @@
-#![allow(
-    clippy::incompatible_msrv,
-    clippy::let_and_return,
-    clippy::let_unit_value
-)]
+//! Benchmarks for `blazesym`.
+
+#![allow(missing_docs)]
 
 macro_rules! bench_fn {
     ($group:expr, $bench_fn:ident) => {

--- a/benches/normalize.rs
+++ b/benches/normalize.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::fn_to_numeric_cast)]
-
 use std::hint::black_box;
 
 use blazesym::normalize::NormalizeOpts;

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::fn_to_numeric_cast)]
-
 use std::hint::black_box;
 use std::path::Path;
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+//! Build script for `blazesym`.
+
 use std::env;
 
 

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -89,3 +89,6 @@ criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e2
 tempfile = "3.19"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
 test-tag = "0.1"
+
+[lints]
+workspace = true

--- a/capi/benches/capi.rs
+++ b/capi/benches/capi.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_and_return, clippy::let_unit_value)]
+#![allow(missing_docs)]
 
 macro_rules! bench_fn {
     ($group:expr, $bench_fn:ident) => {

--- a/capi/benches/normalize.rs
+++ b/capi/benches/normalize.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::fn_to_numeric_cast, clippy::incompatible_msrv)]
-
 use std::hint::black_box;
 use std::ptr;
 

--- a/capi/build.rs
+++ b/capi/build.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_unit_value)]
+//! Build script for `blazesym-c`.
 
 use std::env;
 use std::ffi::OsStr;

--- a/capi/src/error.rs
+++ b/capi/src/error.rs
@@ -77,7 +77,7 @@ thread_local! {
 /// Retrieve the error reported by the last fallible API function invoked.
 #[no_mangle]
 pub extern "C" fn blaze_err_last() -> blaze_err {
-    LAST_ERR.with(|cell| cell.get())
+    LAST_ERR.with(Cell::get)
 }
 
 /// Retrieve the error reported by the last fallible API function invoked.

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,14 +29,7 @@
 #![doc = include_str!("../examples/input-struct-init.c")]
 //! ```
 
-#![allow(
-    non_camel_case_types,
-    clippy::collapsible_if,
-    clippy::fn_to_numeric_cast,
-    clippy::let_and_return,
-    clippy::let_unit_value,
-    clippy::manual_non_exhaustive
-)]
+#![allow(non_camel_case_types, clippy::manual_non_exhaustive)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -967,7 +967,7 @@ mod tests {
     fn normalize_user_addrs() {
         fn test(normalizer: *const blaze_normalizer) {
             let addrs = [
-                0x0 as Addr,
+                0x0,
                 libc::atexit as Addr,
                 libc::chdir as Addr,
                 libc::fopen as Addr,
@@ -1205,7 +1205,7 @@ mod tests {
         let normalizer = blaze_normalizer_new();
         assert!(!normalizer.is_null());
 
-        let addrs = [the_answer_addr as Addr];
+        let addrs = [the_answer_addr];
         let opts = blaze_normalize_opts {
             apk_to_elf: true,
             ..Default::default()

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -1974,8 +1974,7 @@ mod tests {
             let name = unsafe { CStr::from_ptr(sym.name) };
             assert!(
                 name.to_str().unwrap().contains("test13test_function"),
-                "{:?}",
-                name
+                "{name:?}"
             );
 
             if sym.inlined_cnt == 0 {
@@ -1988,8 +1987,7 @@ mod tests {
             let name = unsafe { CStr::from_ptr((*sym.inlined).name) };
             assert!(
                 name.to_str().unwrap().contains("test12inlined_call"),
-                "{:?}",
-                name
+                "{name:?}"
             );
 
             let () = unsafe { blaze_syms_free(result) };

--- a/capi/tests/trace.rs
+++ b/capi/tests/trace.rs
@@ -6,7 +6,6 @@ use std::ffi::c_char;
 use std::ffi::CStr;
 use std::sync::Mutex;
 
-use blazesym::Addr;
 use blazesym_c::blaze_err;
 use blazesym_c::blaze_err_last;
 use blazesym_c::blaze_symbolize_process_abs_addrs;
@@ -39,7 +38,7 @@ fn trace_callbacks() {
             ..Default::default()
         };
         let symbolizer = blaze_symbolizer_new();
-        let addrs = [0x0 as Addr];
+        let addrs = [0x0];
         let result = unsafe {
             blaze_symbolize_process_abs_addrs(symbolizer, &process_src, addrs.as_ptr(), addrs.len())
         };

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -48,3 +48,6 @@ tracing-subscriber = {version = "0.3", features = ["ansi", "env-filter", "fmt"]}
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 blazesym = {version = "=0.2.0-rc.3", path = "../", features = ["bpf"]}
+
+[lints]
+workspace = true

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,3 +1,5 @@
+//! Build script for `blazecli`.
+
 use std::env;
 
 use anyhow::Result;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_and_return, clippy::let_unit_value)]
+//! A command line utility for the `blazesym` library.
 
 mod args;
 mod trace;
@@ -96,7 +96,7 @@ fn inspect(inspect: args::inspect::Inspect) -> Result<()> {
                 }
             };
 
-            let names = names.iter().map(|s| s.as_ref()).collect::<Vec<&str>>();
+            let names = names.iter().map(AsRef::as_ref).collect::<Vec<&str>>();
             let result = inspector.lookup(&src, &names)?;
             let sym_infos = result
                 .into_iter()
@@ -208,20 +208,18 @@ fn print_frame(
     if let Some((input_addr, addr, offset)) = addr_info {
         // If we have various address information bits we have a new symbol.
         println!(
-            "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
-            code_info = code_info.as_deref().unwrap_or(""),
-            width = ADDR_WIDTH
+            "{input_addr:#0ADDR_WIDTH$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            code_info = code_info.as_deref().unwrap_or("")
         )
     } else {
         // Otherwise we are dealing with an inlined call.
         println!(
-            "{:width$}  {name}{code_info} [inlined]",
+            "{:ADDR_WIDTH$}  {name}{code_info} [inlined]",
             " ",
             code_info = code_info
                 .map(|info| format!(" @{info}"))
                 .as_deref()
-                .unwrap_or(""),
-            width = ADDR_WIDTH
+                .unwrap_or("")
         )
     }
 }
@@ -326,7 +324,7 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
                 }
             }
             symbolize::Symbolized::Unknown(..) => {
-                println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
+                println!("{input_addr:#0ADDR_WIDTH$x}: <no-symbol>")
             }
         }
     }

--- a/cli/var/shell-complete.rs
+++ b/cli/var/shell-complete.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::let_unit_value)]
-
 use std::io::stdout;
 
 use clap::CommandFactory as _;

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -51,3 +51,6 @@ libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = "0.24"
+
+[lints]
+workspace = true

--- a/dev/build.rs
+++ b/dev/build.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_unit_value)]
+//! Build script for `blazesym-dev`.
 
 use std::env;
 use std::env::consts::ARCH;
@@ -181,6 +181,7 @@ where
         }
     };
 
+    #[allow(clippy::redundant_closure_for_method_calls)]
     let () = run(
         tool,
         options

--- a/dev/lib.rs
+++ b/dev/lib.rs
@@ -1,13 +1,4 @@
-#![allow(
-    clippy::clone_on_ref_ptr,
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::fn_to_numeric_cast,
-    clippy::let_and_return,
-    clippy::let_unit_value
-)]
-#![deny(unsafe_op_in_unsafe_fn)]
-
+//! Supporting dev-only functionality for `blazesym`.
 
 #[cfg(linux)]
 mod bpf {
@@ -44,6 +35,8 @@ mod bpf {
         obj
     }
 
+    /// Find and open the BPF object corresponding to the provided file
+    /// name.
     #[track_caller]
     pub fn test_object(filename: &str) -> Object {
         open_test_object(filename)

--- a/examples/addr2ln.rs
+++ b/examples/addr2ln.rs
@@ -1,3 +1,6 @@
+//! Example illustrating symbolization of an address in an ELF file,
+//! similar to `addr2line`.
+
 use std::env;
 
 use anyhow::bail;
@@ -31,20 +34,18 @@ fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &O
     if let Some((input_addr, addr, offset)) = addr_info {
         // If we have various address information bits we have a new symbol.
         println!(
-            "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
-            code_info = code_info.as_deref().unwrap_or(""),
-            width = ADDR_WIDTH
+            "{input_addr:#0ADDR_WIDTH$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            code_info = code_info.as_deref().unwrap_or("")
         )
     } else {
         // Otherwise we are dealing with an inlined call.
         println!(
-            "{:width$}  {name}{code_info} [inlined]",
+            "{:ADDR_WIDTH$}  {name}{code_info} [inlined]",
             " ",
             code_info = code_info
                 .map(|info| format!(" @{info}"))
                 .as_deref()
-                .unwrap_or(""),
-            width = ADDR_WIDTH
+                .unwrap_or("")
         )
     }
 }
@@ -89,7 +90,7 @@ fn main() -> Result<()> {
                 }
             }
             Symbolized::Unknown(..) => {
-                println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
+                println!("{input_addr:#0ADDR_WIDTH$x}: <no-symbol>")
             }
         }
     }

--- a/examples/addr2ln_pid.rs
+++ b/examples/addr2ln_pid.rs
@@ -1,3 +1,5 @@
+//! Example illustrating how to symbolize an address in a progress.
+
 use std::env;
 
 use anyhow::bail;
@@ -31,20 +33,18 @@ fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &O
     if let Some((input_addr, addr, offset)) = addr_info {
         // If we have various address information bits we have a new symbol.
         println!(
-            "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
-            code_info = code_info.as_deref().unwrap_or(""),
-            width = ADDR_WIDTH
+            "{input_addr:#0ADDR_WIDTH$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            code_info = code_info.as_deref().unwrap_or("")
         )
     } else {
         // Otherwise we are dealing with an inlined call.
         println!(
-            "{:width$}  {name}{code_info} [inlined]",
+            "{:ADDR_WIDTH$}  {name}{code_info} [inlined]",
             " ",
             code_info = code_info
                 .map(|info| format!(" @{info}"))
                 .as_deref()
-                .unwrap_or(""),
-            width = ADDR_WIDTH
+                .unwrap_or("")
         )
     }
 }
@@ -92,7 +92,7 @@ print its symbol, the file name of the source, and the line number.",
                 }
             }
             Symbolized::Unknown(..) => {
-                println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
+                println!("{input_addr:#0ADDR_WIDTH$x}: <no-symbol>")
             }
         }
     }

--- a/examples/backtrace.rs
+++ b/examples/backtrace.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_unit_value)]
+//! Example illustrating backtrace symbolization.
 
 use std::cmp::min;
 use std::mem::size_of;
@@ -33,20 +33,18 @@ fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &O
     if let Some((input_addr, addr, offset)) = addr_info {
         // If we have various address information bits we have a new symbol.
         println!(
-            "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
-            code_info = code_info.as_deref().unwrap_or(""),
-            width = ADDR_WIDTH
+            "{input_addr:#0ADDR_WIDTH$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            code_info = code_info.as_deref().unwrap_or("")
         )
     } else {
         // Otherwise we are dealing with an inlined call.
         println!(
-            "{:width$}  {name}{code_info} [inlined]",
+            "{:ADDR_WIDTH$}  {name}{code_info} [inlined]",
             " ",
             code_info = code_info
                 .map(|info| format!(" @{info}"))
                 .as_deref()
-                .unwrap_or(""),
-            width = ADDR_WIDTH
+                .unwrap_or("")
         )
     }
 }
@@ -90,7 +88,7 @@ fn symbolize_current_bt() {
                 }
             }
             Symbolized::Unknown(..) => {
-                println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
+                println!("{input_addr:#0ADDR_WIDTH$x}: <no-symbol>")
             }
         }
     }

--- a/examples/gsym-in-apk/Cargo.toml
+++ b/examples/gsym-in-apk/Cargo.toml
@@ -18,3 +18,6 @@ blazesym = {version = "=0.2.0-rc.3", path = "../..", default-features = false, f
 blazesym-dev = {path = "../../dev", features = ["generate-unit-test-files"]}
 goblin = {version = "0.9", default-features = false, features = ["elf32", "elf64", "std"]}
 zip = {version = "2.6", default-features = false}
+
+[lints]
+workspace = true

--- a/examples/gsym-in-apk/main.rs
+++ b/examples/gsym-in-apk/main.rs
@@ -3,8 +3,6 @@
 //! to symbolize addresses, as opposed to the default one that only looks
 //! directly at members and their ELF/DWARF symbols.
 
-#![allow(clippy::collapsible_if)]
-
 use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
@@ -61,7 +59,7 @@ impl TranslateFileOffset for CustomApkResolver {
         let addr = phdrs.iter().find_map(|phdr| {
             if phdr.p_type == elf64::program_header::PT_LOAD {
                 if (phdr.p_offset..phdr.p_offset + phdr.p_filesz).contains(&file_offset) {
-                    return Some((file_offset - phdr.p_offset + phdr.p_vaddr) as Addr)
+                    return Some(file_offset - phdr.p_offset + phdr.p_vaddr)
                 }
             }
             None

--- a/examples/normalize-virt-offset.rs
+++ b/examples/normalize-virt-offset.rs
@@ -2,8 +2,6 @@
 //! opposed to file offsets from the normalization step by applying some
 //! post-processing.
 
-#![allow(clippy::fn_to_numeric_cast)]
-
 use blazesym::helper::ElfResolver;
 use blazesym::normalize::Normalizer;
 use blazesym::symbolize::source::Elf;

--- a/examples/sym-debuginfod/Cargo.toml
+++ b/examples/sym-debuginfod/Cargo.toml
@@ -17,3 +17,6 @@ clap = {version = "4.5", features = ["derive", "string"]}
 debuginfod = {version = "0.2.0", features = ["fs-cache", "tracing"]}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["ansi", "env-filter", "fmt"]}
+
+[lints]
+workspace = true

--- a/examples/sym-debuginfod/main.rs
+++ b/examples/sym-debuginfod/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::collapsible_if)]
+//! Example illustrating `debuginfod` based symbolization.
 
 use anyhow::Context as _;
 use anyhow::Error;
@@ -70,20 +70,18 @@ fn print_frame(name: &str, addr_info: Option<(Addr, Addr, usize)>, code_info: &O
     if let Some((input_addr, addr, offset)) = addr_info {
         // If we have various address information bits we have a new symbol.
         println!(
-            "{input_addr:#0width$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
+            "{input_addr:#0ADDR_WIDTH$x}: {name} @ {addr:#x}+{offset:#x}{code_info}",
             code_info = code_info.as_deref().unwrap_or(""),
-            width = ADDR_WIDTH
         )
     } else {
         // Otherwise we are dealing with an inlined call.
         println!(
-            "{:width$}  {name}{code_info} [inlined]",
+            "{:ADDR_WIDTH$}  {name}{code_info} [inlined]",
             " ",
             code_info = code_info
                 .map(|info| format!(" @{info}"))
                 .as_deref()
-                .unwrap_or(""),
-            width = ADDR_WIDTH
+                .unwrap_or("")
         )
     }
 }
@@ -108,7 +106,7 @@ where
                 }
             }
             Symbolized::Unknown(..) => {
-                println!("{input_addr:#0width$x}: <no-symbol>", width = ADDR_WIDTH)
+                println!("{input_addr:#0ADDR_WIDTH$x}: <no-symbol>")
             }
         }
     }

--- a/src/breakpad/parser.rs
+++ b/src/breakpad/parser.rs
@@ -78,13 +78,13 @@ fn stringify_error(input: &[u8], e: VerboseError<&[u8]>) -> String {
         if input.is_empty() {
             match kind {
                 VerboseErrorKind::Char(c) => {
-                    write!(&mut result, "{}: expected '{}', got empty input\n\n", i, c)
+                    write!(&mut result, "{i}: expected '{c}', got empty input\n\n")
                 }
                 VerboseErrorKind::Context(s) => {
-                    write!(&mut result, "{}: in {}, got empty input\n\n", i, s)
+                    write!(&mut result, "{i}: in {s}, got empty input\n\n")
                 }
                 VerboseErrorKind::Nom(e) => {
-                    write!(&mut result, "{}: in {:?}, got empty input\n\n", i, e)
+                    write!(&mut result, "{i}: in {e:?}, got empty input\n\n")
                 }
             }
         } else {
@@ -345,7 +345,7 @@ fn file_line(input: &[u8]) -> IResult<&[u8], (u32, String), VerboseError<&[u8]>>
     Ok((input, (id, filename.to_string())))
 }
 
-/// Matches an INLINE_ORIGIN record.
+/// Matches an `INLINE_ORIGIN` record.
 fn inline_origin_line(input: &[u8]) -> IResult<&[u8], (u32, String), VerboseError<&[u8]>> {
     let (input, _) = terminated(tag("INLINE_ORIGIN"), space1)(input)?;
     let (input, (id, function)) = cut(tuple((
@@ -661,7 +661,7 @@ impl SymbolParser {
         Ok((input, ()))
     }
 
-    /// Finish processing an item (cur_item) which had sublines.
+    /// Finish processing an item (`cur_item`) which had sublines.
     /// We now have all the sublines, so it's complete.
     fn finish_item(&mut self, item: Line) {
         match item {
@@ -774,7 +774,7 @@ foo bar baz
         assert_eq!(module_line(line), Ok((rest, OsStr::new("firefox x y z"))));
     }
 
-    /// Sometimes dump_syms on Windows does weird things and produces multiple
+    /// Sometimes `dump_syms` on Windows does weird things and produces multiple
     /// carriage returns before the line feed.
     #[test]
     fn parse_module_line_crcrlf() {

--- a/src/breakpad/resolver.rs
+++ b/src/breakpad/resolver.rs
@@ -79,13 +79,14 @@ impl BreakpadResolver {
     }
 
     fn find_source_location(&self, file: u32) -> Result<(Option<&Path>, &OsStr)> {
-        let path = self.symbol_file.files.get(&file).ok_or_invalid_input(|| {
-            format!("failed to retrieve source file {}: not found", file)
-        })?;
+        let path =
+            self.symbol_file.files.get(&file).ok_or_invalid_input(|| {
+                format!("failed to retrieve source file {file}: not found")
+            })?;
         let mut comps = Path::new(path).components();
         let file = comps
             .next_back()
-            .ok_or_invalid_input(|| format!("source file {} does not contain a valid path", file))?
+            .ok_or_invalid_input(|| format!("source file {file} does not contain a valid path"))?
             .as_os_str();
         let dir = comps.as_path();
 
@@ -103,10 +104,7 @@ impl BreakpadResolver {
             .inline_origins
             .get(&origin_id)
             .ok_or_invalid_input(|| {
-                format!(
-                    "failed to retrieve inlinee origin with {}: not found",
-                    origin_id
-                )
+                format!("failed to retrieve inlinee origin with {origin_id}: not found")
             })?;
 
         Ok(name)

--- a/src/dwarf/debug_link.rs
+++ b/src/dwarf/debug_link.rs
@@ -3,7 +3,7 @@
 //! From <https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html>:
 //!
 //! A debug link is a special section of the executable file named
-//! .gnu_debuglink. The section must contain:
+//! .`gnu_debuglink`. The section must contain:
 //! - A filename, with any leading directory components removed, followed by a
 //!   zero byte,
 //! - zero to three bytes of padding, as needed to reach the next four-byte

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -148,7 +148,7 @@ fn try_deref_debug_link(
 }
 
 
-/// DwarfResolver provides abilities to query DWARF information of binaries.
+/// `DwarfResolver` provides abilities to query DWARF information of binaries.
 pub(crate) struct DwarfResolver {
     /// The lazily parsed compilation units of the DWARF file.
     // SAFETY: We must not hand out references with a 'static lifetime to
@@ -230,7 +230,7 @@ impl DwarfResolver {
         let addr = function
             .range
             .as_ref()
-            .map(|range| range.begin as Addr)
+            .map(|range| range.begin)
             .unwrap_or(0);
         let size = function
             .range

--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -155,7 +155,7 @@ impl<'dwarf> Unit<'dwarf> {
         let functions = self.parse_functions_dwarf_and_unit(unit, units)?;
         for func in functions.functions.iter() {
             let name = Some(name.as_bytes());
-            if func.name.as_ref().map(|r| r.slice()) == name {
+            if func.name.as_ref().map(gimli::EndianSlice::slice) == name {
                 return Ok(Some(func))
             }
         }

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -64,7 +64,7 @@ impl FileCache<ElfResolverData> {
                     //         present and given that we are
                     //         initializing the `dwarf` part of it, the
                     //         `elf` part *must* be present.
-                    let parser = data.elf.get().unwrap().parser().clone();
+                    let parser = Rc::clone(data.elf.get().unwrap().parser());
                     let resolver = ElfResolver::from_parser(parser, debug_dirs)?;
                     let resolver = Rc::new(resolver);
                     Result::<_, Error>::Ok(resolver)
@@ -75,7 +75,7 @@ impl FileCache<ElfResolverData> {
                     //         present and given that we are
                     //         initializing the `elf` part of it, the
                     //         `dwarf` part *must* be present.
-                    let parser = data.dwarf.get().unwrap().parser().clone();
+                    let parser = Rc::clone(data.dwarf.get().unwrap().parser());
                     let resolver = ElfResolver::from_parser(parser, debug_dirs)?;
                     let resolver = Rc::new(resolver);
                     Result::<_, Error>::Ok(resolver)
@@ -236,7 +236,7 @@ mod tests {
             .join("test-stable-addrs.bin");
 
         let parser = Rc::new(ElfParser::open(path.as_path()).unwrap());
-        let resolver = ElfResolver::from_parser(parser.clone(), None).unwrap();
+        let resolver = ElfResolver::from_parser(Rc::clone(&parser), None).unwrap();
         let dbg = format!("{resolver:?}");
         assert!(dbg.starts_with("ElfParser("), "{dbg}");
         assert!(dbg.ends_with("test-stable-addrs.bin\")"), "{dbg}");

--- a/src/error.rs
+++ b/src/error.rs
@@ -906,7 +906,7 @@ Caused by:
         }
 
         // Ensure that we capture a backtrace.
-        let () = env::set_var("RUST_LIB_BACKTRACE", "1");
+        let () = unsafe { env::set_var("RUST_LIB_BACKTRACE", "1") };
 
         let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");
         let err = Error::from(err);
@@ -921,8 +921,8 @@ Caused by:
     /// the `RUST_LIB_BACKTRACE` environment variable is not present.
     #[forked_test]
     fn error_no_backtrace1() {
-        let () = env::remove_var("RUST_BACKTRACE");
-        let () = env::remove_var("RUST_LIB_BACKTRACE");
+        let () = unsafe { env::remove_var("RUST_BACKTRACE") };
+        let () = unsafe { env::remove_var("RUST_LIB_BACKTRACE") };
 
         let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");
         let err = Error::from(err);
@@ -935,8 +935,8 @@ Caused by:
     /// the `RUST_LIB_BACKTRACE` environment variable is "0".
     #[forked_test]
     fn error_no_backtrace2() {
-        let () = env::remove_var("RUST_BACKTRACE");
-        let () = env::set_var("RUST_LIB_BACKTRACE", "0");
+        let () = unsafe { env::remove_var("RUST_BACKTRACE") };
+        let () = unsafe { env::set_var("RUST_LIB_BACKTRACE", "0") };
 
         let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");
         let err = Error::from(err);

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -28,6 +28,7 @@ impl From<&libc::stat> for FileMeta {
     fn from(other: &libc::stat) -> Self {
         // Casts are necessary because on Android some libc types do not
         // use proper typedefs. https://github.com/rust-lang/libc/issues/3285
+        #[allow(trivial_numeric_casts)]
         Self {
             dev: other.st_dev as _,
             inode: other.st_ino as _,

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -114,7 +114,7 @@ pub(crate) fn run_op(
         }
         ADVANCE_PC => {
             let adv = ops.read_u64_leb128()?;
-            row.addr += adv as Addr;
+            row.addr += adv;
             Some(RunResult::NewRow)
         }
         ADVANCE_LINE => {

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -26,9 +26,9 @@
 //! corresponding entry at the same offset in the other table.  The
 //! entries in the Address Data Offset Table are always 32bits
 //! (4bytes.)  It is the file offset to the respective Address
-//! Data. (AddrInfo actually)
+//! Data. (`AddrInfo` actually)
 //!
-//! An AddrInfo comprises the size and name of a symbol.  The name
+//! An `AddrInfo` comprises the size and name of a symbol.  The name
 //! is an offset in the string table.  You will find a null terminated
 //! C string at the give offset.  The size is the number of bytes of
 //! the respective object; ex, a function or variable.
@@ -58,8 +58,8 @@ use super::types::INFO_TYPE_END_OF_LIST;
 
 /// Hold the major parts of a standalone GSYM file.
 ///
-/// GsymContext provides functions to access major entities in GSYM.
-/// GsymContext can find respective AddrInfo for an address. But,
+/// `GsymContext` provides functions to access major entities in GSYM.
+/// `GsymContext` can find respective `AddrInfo` for an address. But,
 /// it doesn't parse [`AddrData`] to get line numbers.
 ///
 /// The developers should use [`parse_address_data()`],
@@ -81,7 +81,7 @@ impl GsymContext<'_> {
     ///
     /// * `data` - is the content of a standalone GSYM.
     ///
-    /// Returns a GsymContext, which includes the Header and other important
+    /// Returns a `GsymContext`, which includes the Header and other important
     /// tables.
     pub(crate) fn parse_header(data: &[u8]) -> Result<GsymContext> {
         fn parse_header_impl(mut data: &[u8]) -> Option<Result<GsymContext>> {
@@ -154,7 +154,7 @@ impl GsymContext<'_> {
         }
 
 
-        let relative_addr = addr.checked_sub(self.header.base_address as Addr)?;
+        let relative_addr = addr.checked_sub(self.header.base_address)?;
         let num_addrs = self.header.num_addrs as usize;
 
         match self.header.addr_off_size {
@@ -174,13 +174,13 @@ impl GsymContext<'_> {
             1 => data.read_u8()?.into(),
             2 => data.read_u16()?.into(),
             4 => data.read_u32()? as Addr,
-            8 => data.read_u64()? as Addr,
+            8 => data.read_u64()?,
             _ => return None,
         };
-        (self.header.base_address as Addr).checked_add(addr)
+        (self.header.base_address).checked_add(addr)
     }
 
-    /// Get the AddrInfo of an address given by an index.
+    /// Get the `AddrInfo` of an address given by an index.
     pub(crate) fn addr_info(&self, idx: usize) -> Option<AddrInfo> {
         let offset = *self.addr_data_off_tab.get(idx)?;
         let mut data = self.raw_data.get(offset as usize..)?;
@@ -213,7 +213,7 @@ impl GsymContext<'_> {
 ///
 /// # Arguments
 ///
-/// * `data` - is the slice from AddrInfo::data.
+/// * `data` - is the slice from `AddrInfo::data`.
 pub(crate) fn parse_address_data(mut data: &[u8]) -> impl Iterator<Item = AddrData> {
     iter::from_fn(move || {
         let typ = data.read_u32()?;

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -98,7 +98,7 @@ impl<'dat> GsymResolver<'dat> {
         let finfo = self
             .ctx
             .file_info(file_idx as usize)
-            .ok_or_invalid_data(|| format!("failed to retrieve file info data @ {}", file_idx))?;
+            .ok_or_invalid_data(|| format!("failed to retrieve file info data @ {file_idx}"))?;
         let dir = self
             .ctx
             .get_str(finfo.directory as usize)

--- a/src/kernel/kaslr.rs
+++ b/src/kernel/kaslr.rs
@@ -21,7 +21,7 @@ use crate::Result;
 const PROC_KCORE: &str = "/proc/kcore";
 /// The name of the `VMCOREINFO` ELF note.
 ///
-/// See https://www.kernel.org/doc/html/latest/admin-guide/kdump/vmcoreinfo.html
+/// See <https://www.kernel.org/doc/html/latest/admin-guide/kdump/vmcoreinfo.html>
 const VMCOREINFO_NAME: &[u8] = b"VMCOREINFO\0";
 
 

--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -222,7 +222,7 @@ impl KsymResolver {
             }
         }
 
-        let () = syms.sort_by_key(|a| a.addr());
+        let () = syms.sort_by_key(Ksym::addr);
 
         let slf = Self {
             syms: syms.into_boxed_slice(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,22 +30,6 @@
 //!
 //! [tracing.rs]: https://tracing.rs
 
-#![allow(
-    clippy::clone_on_ref_ptr,
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::fn_to_numeric_cast,
-    clippy::let_and_return,
-    clippy::let_unit_value,
-    clippy::type_complexity
-)]
-#![deny(unsafe_op_in_unsafe_fn)]
-#![warn(
-    missing_debug_implementations,
-    missing_docs,
-    clippy::absolute_paths,
-    rustdoc::broken_intra_doc_links
-)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "nightly", feature(test))]
 #![cfg_attr(

--- a/src/normalize/ioctl.rs
+++ b/src/normalize/ioctl.rs
@@ -293,7 +293,7 @@ mod tests {
     }
 
     /// Check that we can query an invalid VMA region using the
-    /// PROCMAP_QUERY ioctl.
+    /// `PROCMAP_QUERY` ioctl.
     #[test]
     #[ignore = "test requires PROCMAP_QUERY ioctl kernel support"]
     fn invalid_vma_querying_ioctl() {
@@ -306,7 +306,7 @@ mod tests {
     }
 
     /// Check that we can query a valid VMA region using the
-    /// PROCMAP_QUERY ioctl.
+    /// `PROCMAP_QUERY` ioctl.
     #[test]
     #[ignore = "test requires PROCMAP_QUERY ioctl kernel support"]
     fn valid_vma_querying_ioctl() {
@@ -349,7 +349,7 @@ mod tests {
     }
 
     /// Check that we see the same number of VMAs reported when using
-    /// `/proc/self/maps` parsing versus the PROCMAP_QUERY ioctl.
+    /// `/proc/self/maps` parsing versus the `PROCMAP_QUERY` ioctl.
     #[test]
     #[ignore = "test requires PROCMAP_QUERY ioctl kernel support"]
     fn vma_comparison() {

--- a/src/normalize/user.rs
+++ b/src/normalize/user.rs
@@ -348,7 +348,7 @@ mod tests {
 "#;
 
             let pid = Pid::Slf;
-            let addrs = [unknown_addr as Addr];
+            let addrs = [unknown_addr];
 
             let mut entry_iter = maps::parse_file(maps.as_bytes(), pid)
                 .filter(|result| result.as_ref().map(maps::filter_relevant).unwrap_or(true));

--- a/src/once.rs
+++ b/src/once.rs
@@ -1,4 +1,4 @@
-//! A copy of std::once::OnceCell.
+//! A copy of `std::once::OnceCell`.
 // TODO: Remove this module once our minimum supported Rust version is greater
 //       1.70 and/or `OnceCell::get_or_try_init` is stable.
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -872,6 +872,7 @@ mod tests {
     /// Check that we can read various integers from a slice.
     #[tag(miri)]
     #[test]
+    #[expect(trivial_numeric_casts)]
     fn pod_reading() {
         macro_rules! test {
             ($type:ty) => {{

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -1,5 +1,5 @@
 /// Specification of ZIP file format can be found here:
-/// https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+/// <https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT>
 /// For a high level overview of the structure of a ZIP file see
 /// sections 4.3.1 - 4.3.6.
 ///
@@ -33,7 +33,7 @@ const FLAG_HAS_DATA_DESCRIPTOR: u16 = 1 << 3;
 #[derive(Clone, Debug)]
 #[repr(C, packed)]
 struct EndOfCdRecord {
-    /// Magic value equal to END_OF_CD_RECORD_MAGIC.
+    /// Magic value equal to `END_OF_CD_RECORD_MAGIC`.
     magic: u32,
     /// Number of the file containing this structure or 0xFFFF if ZIP64 archive.
     /// Zip archive might span multiple files (disks).
@@ -66,7 +66,7 @@ unsafe impl Pod for EndOfCdRecord {}
 #[derive(Clone, Debug)]
 #[repr(C, packed)]
 struct CdFileHeader {
-    /// Magic value equal to CD_FILE_HEADER_MAGIC.
+    /// Magic value equal to `CD_FILE_HEADER_MAGIC`.
     magic: u32,
     version: u16,
     /// Minimum zip version needed to extract the file.
@@ -98,7 +98,7 @@ unsafe impl Pod for CdFileHeader {}
 #[derive(Clone, Debug)]
 #[repr(C, packed)]
 struct LocalFileHeader {
-    /// Magic value equal to LOCAL_FILE_HEADER_MAGIC.
+    /// Magic value equal to `LOCAL_FILE_HEADER_MAGIC`.
     magic: u32,
     /// Minimum zip version needed to extract the file.
     min_version: u16,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,10 +1,5 @@
 //! Integration tests for blazesym.
 
-#![allow(
-    clippy::fn_to_numeric_cast,
-    clippy::let_and_return,
-    clippy::let_unit_value
-)]
 #![cfg_attr(not(linux), allow(dead_code, unused_imports))]
 
 mod suite;

--- a/tests/suite/common/mod.rs
+++ b/tests/suite/common/mod.rs
@@ -1,9 +1,3 @@
-#![allow(
-    clippy::fn_to_numeric_cast,
-    clippy::let_and_return,
-    clippy::let_unit_value
-)]
-
 use std::env::current_exe;
 use std::ffi::OsStr;
 use std::ffi::OsString;

--- a/tests/suite/normalize.rs
+++ b/tests/suite/normalize.rs
@@ -55,8 +55,7 @@ fn normalize_unsorted_err() {
 fn normalize_unknown_addrs() {
     // The very first page of the address space should never be
     // mapped, so use addresses from there.
-    let addrs = [0x500 as Addr, 0x600 as Addr];
-
+    let addrs = [0x500, 0x600];
     let normalizer = Normalizer::new();
     let normalized = normalizer
         .normalize_user_addrs(Pid::Slf, addrs.as_slice())
@@ -202,7 +201,7 @@ fn normalize_custom_so() {
 
     let normalizer = Normalizer::new();
     let normalized = normalizer
-        .normalize_user_addrs(Pid::Slf, [the_answer_addr as Addr].as_slice())
+        .normalize_user_addrs(Pid::Slf, [the_answer_addr].as_slice())
         .unwrap();
     assert_eq!(normalized.outputs.len(), 1);
     assert_eq!(normalized.meta.len(), 1);
@@ -253,7 +252,7 @@ fn normalize_custom_so_in_zip() {
             .enable_build_id_caching(cache_build_ids)
             .build();
         let normalized = normalizer
-            .normalize_user_addrs_opts(Pid::Slf, [the_answer_addr as Addr].as_slice(), &opts)
+            .normalize_user_addrs_opts(Pid::Slf, [the_answer_addr].as_slice(), &opts)
             .unwrap();
         assert_eq!(normalized.outputs.len(), 1);
         assert_eq!(normalized.meta.len(), 1);
@@ -349,7 +348,7 @@ fn test_normalize_deleted_so(use_procmap_query: bool) {
             .enable_build_id_caching(cache_build_ids)
             .build();
         let normalized = normalizer
-            .normalize_user_addrs_opts(Pid::Slf, [the_answer_addr as Addr].as_slice(), &opts)
+            .normalize_user_addrs_opts(Pid::Slf, [the_answer_addr].as_slice(), &opts)
             .unwrap();
         assert_eq!(normalized.outputs.len(), 1);
         assert_eq!(normalized.meta.len(), 1);

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -1239,7 +1239,7 @@ fn symbolize_zip_with_custom_dispatch() {
         let src = Source::Process(Process::new(Pid::Slf));
         let symbolizer = Symbolizer::builder().set_apk_dispatcher(dispatcher).build();
         let result = symbolizer
-            .symbolize_single(&src, Input::AbsAddr(the_answer_addr as Addr))
+            .symbolize_single(&src, Input::AbsAddr(the_answer_addr))
             .unwrap()
             .into_sym()
             .unwrap();
@@ -1300,7 +1300,7 @@ fn symbolize_zip_with_custom_dispatch_errors() {
         let src = Source::Process(Process::new(Pid::Slf));
         let symbolizer = Symbolizer::builder().set_apk_dispatcher(dispatcher).build();
         let err = symbolizer
-            .symbolize_single(&src, Input::AbsAddr(the_answer_addr as Addr))
+            .symbolize_single(&src, Input::AbsAddr(the_answer_addr))
             .unwrap_err();
 
         assert_eq!(err.to_string(), "induced error");


### PR DESCRIPTION
Overhaul the set of Rust lints in use and make them apply in a workspace-wide manner. Fix everything new that is being flagged.