### PR TITLE
Allow extern 'test' crate for benchmarking purposes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 
 
 #[cfg(feature = "nightly")]
+#[allow(unused_extern_crates)]
 extern crate test;
 
 #[macro_use]


### PR DESCRIPTION
For running "unit benches", we rely on the nightly 'test' crate. In recent versions of Rust, we are now seeing a warning emitted for the corresponding extern declaration, for no obvious reason. Silence it.