### PR TITLE
Improve documentation surrounding `code_info` & `inlined_fns` flags

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -575,11 +575,14 @@ typedef struct blaze_symbolizer_opts {
   /**
    * Whether to attempt to gather source code location information.
    *
-   * This setting implies `debug_syms` (and forces it to `true`).
+   * This option only has an effect if `debug_syms` of the particular
+   * symbol source is set to `true`.
    */
   bool code_info;
   /**
    * Whether to report inlined functions as part of symbolization.
+   *
+   * This option only has an effect if `code_info` is `true`.
    */
   bool inlined_fns;
   /**

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -672,9 +672,12 @@ pub struct blaze_symbolizer_opts {
     pub auto_reload: bool,
     /// Whether to attempt to gather source code location information.
     ///
-    /// This setting implies `debug_syms` (and forces it to `true`).
+    /// This option only has an effect if `debug_syms` of the particular
+    /// symbol source is set to `true`.
     pub code_info: bool,
     /// Whether to report inlined functions as part of symbolization.
+    ///
+    /// This option only has an effect if `code_info` is `true`.
     pub inlined_fns: bool,
     /// Whether or not to transparently demangle symbols.
     ///

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -279,6 +279,9 @@ impl Builder {
 
     /// Enable/disable source code location information (line numbers,
     /// file names etc.).
+    ///
+    /// This option only has an effect if `debug_syms` of the particular
+    /// symbol source is set to `true`.
     pub fn enable_code_info(mut self, enable: bool) -> Self {
         self.code_info = enable;
         self


### PR DESCRIPTION
The documentation surrounding the `code_info` and `inlined_fns` flags is somewhat lacking and partly incorrect. Both flags require `debug_syms` of the particular source to be enabled in order to have an effect. State that explicitly.