### PR TITLE
Adjust BPF program symbols to preserve kernel name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Unreleased
   symbolization on APKs with `map_files` set to `true`
 - Fixed reading of compressed ELF section data with unaligned
   compression headers
+- Adjusted symbol names reported for BPF programs to contain `bpf_prog_`
+  prefix and program tag
 
 
 0.2.0-rc.3

--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -402,7 +402,7 @@ ffffffffc212d000 t ftrace_trampoline    [__builtin__ftrace]
 
             let prog = resolver.syms[1].as_bpf_prog().unwrap();
             assert_eq!(prog.addr(), 0xffffffffc003e9c8);
-            assert_eq!(prog.name(), "kprobe__cap_capable");
+            assert_eq!(prog.name(), "bpf_prog_30304e82b4033ea3_kprobe__cap_capable");
             assert_eq!(
                 prog.tag(),
                 BpfTag::from([0x30, 0x30, 0x4e, 0x82, 0xb4, 0x03, 0x3e, 0xa3])

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -1560,7 +1560,11 @@ fn symbolize_kernel_bpf_program() {
             .symbolize(&src, Input::AbsAddr(&[handle_getpid, subprogram]))
             .unwrap();
         let handle_getpid_sym = result[0].as_sym().unwrap();
-        assert_eq!(handle_getpid_sym.name, "handle__getpid");
+        assert!(
+            handle_getpid_sym.name.ends_with("handle__getpid"),
+            "{}",
+            handle_getpid_sym.name
+        );
         let code_info = handle_getpid_sym.code_info.as_ref().unwrap();
         assert_eq!(code_info.dir, None);
         assert_eq!(
@@ -1571,7 +1575,11 @@ fn symbolize_kernel_bpf_program() {
         assert_ne!(code_info.column, None);
 
         let subprogram_sym = result[1].as_sym().unwrap();
-        assert_eq!(subprogram_sym.name, "subprogram");
+        assert!(
+            subprogram_sym.name.ends_with("subprogram"),
+            "{}",
+            subprogram_sym.name
+        );
         let code_info = subprogram_sym.code_info.as_ref().unwrap();
         assert_eq!(code_info.dir, None);
         assert_eq!(


### PR DESCRIPTION
Currently we report only the "core" name of the BPF program when symbolizing the corresponding address. However, to make them easier distinguishable from regular kernel functions, it can make sense for us to preserve the 'bpf_prog_' prefix. So do just that. Furthermore, keep the tag in there as well, which can be helpful when comparing potentially different versions of the program.