### PR TITLE
Add test checking Symbolizer size

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1679,6 +1679,15 @@ mod tests {
         });
     }
 
+    /// Test forcing a double check of all `Symbolizer` size changes.
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn symbolizer_size() {
+        // TODO: This size is rather larger and we should look into
+        //       minimizing it.
+        assert_eq!(size_of::<Symbolizer>(), 744);
+    }
+
     /// Check that we can correctly construct the source code path to a symbol.
     #[test]
     fn symbol_source_code_path() {


### PR DESCRIPTION
While there are no hard bounds on the size of a Symbolizer instance, right now it's basically a free for all without any checks. Given that objects may be copied around, we don't want it to balloon too much. Add a test asserting the size of such objects, to introduce a bit more intentionality to changes of said size.