### PR TITLE
Warn on wildcard imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ large-enum-variant = "warn"
 redundant-closure-for-method-calls = "warn"
 unchecked-duration-subtraction = "warn"
 uninlined-format-args = "warn"
+wildcard-imports = "warn"
 
 [package]
 name = "blazesym"

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -62,7 +62,9 @@ pub enum Command {
 
 
 pub mod inspect {
-    use super::*;
+    use super::Arguments;
+    use super::PathBuf;
+    use super::Subcommand;
 
 
     /// A type representing the `inspect` command.
@@ -139,7 +141,12 @@ pub mod inspect {
 
 
 pub mod normalize {
-    use super::*;
+    use super::parse_addr;
+    use super::parse_pid;
+    use super::Addr;
+    use super::Arguments;
+    use super::Pid;
+    use super::Subcommand;
 
 
     /// A type representing the `normalize` command.
@@ -173,7 +180,15 @@ pub mod normalize {
 
 
 pub mod symbolize {
-    use super::*;
+    use super::parse_addr;
+    use super::parse_pid;
+    use super::Addr;
+    use super::Arguments;
+    use super::OsString;
+    use super::PathBuf;
+    use super::Pid;
+    use super::Subcommand;
+    use super::ValueHint;
 
 
     /// A type representing the `symbolize` command.

--- a/src/breakpad/parser.rs
+++ b/src/breakpad/parser.rs
@@ -58,7 +58,11 @@ use nom::IResult;
 use nom::Needed;
 use nom::Offset as _;
 
-use super::types::*;
+use super::types::Function;
+use super::types::Inlinee;
+use super::types::PublicSymbol;
+use super::types::SourceLine;
+use super::types::SymbolFile;
 
 use crate::error::IntoCowStr;
 use crate::once::OnceCell;

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,9 @@ use std::str;
 
 
 mod private {
-    use super::*;
+    use super::io;
+    use super::str;
+    use super::Error;
 
     pub trait Sealed {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,8 @@ impl<T> From<T> for MaybeDefault<T> {
 
 /// Utility functionality not specific to any overarching theme.
 pub mod helper {
-    use super::*;
+    use super::Addr;
+    use super::Result;
 
     pub use crate::normalize::buildid::read_elf_build_id;
     pub use crate::normalize::buildid::read_elf_build_id_from_mmap;


### PR DESCRIPTION
Enable the Clippy lint warning on the usage of wildcard imports. These are generally considered undesirable on many axis and should be avoided. The existing uses are probably fine, but given that rustfix is able to auto-correct them, there is very little harm in preventing such usage from the get go.