### PR TITLE
Switch back to using cbindgen main crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
  "bindgen",
  "blazesym",
  "blazesym-c",
- "cbindgen-assoc-const",
+ "cbindgen",
  "criterion",
  "libc",
  "memoffset",
@@ -348,13 +348,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cbindgen-assoc-const"
-version = "0.28.0"
+name = "cbindgen"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81326c7316397debae08f23dfb4b00c71243292122e59c4a50d7a969a8ee83b7"
+checksum = "975982cdb7ad6a142be15bdf84aea7ec6a9e5d4d797c004d43185b24cfe4e684"
 dependencies = [
  "clap",
- "heck 0.4.1",
+ "heck",
  "indexmap",
  "log",
  "proc-macro2",
@@ -473,7 +473,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1063,12 +1063,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -63,7 +63,7 @@ path = "benches/capi.rs"
 harness = false
 
 [build-dependencies]
-cbindgen = {package = "cbindgen-assoc-const", version = "0.28", optional = true}
+cbindgen = {version = "0.29", optional = true}
 which = {version = "7.0.0", optional = true}
 
 [dependencies]


### PR DESCRIPTION
In the past we required a custom fork of the `cbindgen` crate in order to the `struct.rename_associated_constant` support that we require for authoring the header. This functionality is now included in version `0.29` of the crate, so switch over to using it.