### PR TITLE
Convert panic to graceful runtime error

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -906,7 +906,7 @@ impl<'elf> BackendImpl<'elf> for &'elf [u8] {
     {
         let value = self
             .get(offset as _..)
-            .unwrap()
+            .ok_or_invalid_data(|| "failed to read slice data: invalid offset")?
             .read_pod_slice_ref::<T>(count)
             .ok_or_invalid_data(|| "failed to read slice from mmap")?;
         Ok(Cow::Borrowed(value))


### PR DESCRIPTION
Our BackendImpl for memory slices unwraps and, hence, may panic in case the slice offset is out of range -- likely due to an oversight. Convert the potential panic to a regular runtime error instead.