### PR TITLE
Update criterion dependency to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
  "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -551,22 +551,21 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
-source = "git+https://github.com/bheisler/criterion.rs.git?rev=b913e232edd98780961ecfbae836ec77ede49259#b913e232edd98780961ecfbae836ec77ede49259"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -575,10 +574,11 @@ dependencies = [
 [[package]]
 name = "criterion-plot"
 version = "0.5.0"
-source = "git+https://github.com/bheisler/criterion.rs.git?rev=b913e232edd98780961ecfbae836ec77ede49259#b913e232edd98780961ecfbae836ec77ede49259"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1367,9 +1367,27 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,8 +182,7 @@ zstd = {version = "0.13.3", default-features = false, optional = true}
 addr2line = "=0.24.2"
 anyhow = "1.0.98"
 blazesym-dev = {path = "dev", features = ["generate-unit-test-files"]}
-# TODO: Use 0.5.2 once released.
-criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}
+criterion = {version = "0.6", default-features = false, features = ["rayon", "cargo_bench_support"]}
 rand = {version = "0.9", default-features = false, features = ["std", "thread_rng"]}
 scopeguard = "1.2"
 stats_alloc = {version = "0.1.1", features = ["nightly"]}

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -84,8 +84,7 @@ blazesym = {version = "=0.2.0-rc.3", path = "../", features = ["bpf"]}
 blazesym = {version = "=0.2.0-rc.3", path = "../", features = ["test"]}
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}
 bindgen = {version = "0.71", default-features = false, features = ["runtime"]}
-# TODO: Use 0.5.2 once released.
-criterion = {git = "https://github.com/bheisler/criterion.rs.git", rev = "b913e232edd98780961ecfbae836ec77ede49259", default-features = false, features = ["rayon", "cargo_bench_support"]}
+criterion = {version = "0.6", default-features = false, features = ["rayon", "cargo_bench_support"]}
 tempfile = "3.20"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
 test-tag = "0.1"


### PR DESCRIPTION
Update the criterion dependency to 0.6 now that it has been released, so that we can finally stop depending on a Git snapshot.