### PR TITLE
Improve documentation surrounding "code info" and inlined functions

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -563,7 +563,7 @@ typedef struct blaze_symbolizer_opts {
    */
   const char *const *debug_dirs;
   /**
-   * The number of array elements in `debug_dirs`.
+   * The number of array elements in [`debug_dirs`][Self::debug_dirs].
    */
   size_t debug_dirs_len;
   /**
@@ -576,13 +576,16 @@ typedef struct blaze_symbolizer_opts {
    * Whether to attempt to gather source code location information.
    *
    * This option only has an effect if `debug_syms` of the particular
-   * symbol source is set to `true`.
+   * symbol source is set to `true`. Furthermore, it is a necessary
+   * prerequisite for retrieving inlined function information (see
+   * [`inlined_fns`][Self::inlined_fns]).
    */
   bool code_info;
   /**
    * Whether to report inlined functions as part of symbolization.
    *
-   * This option only has an effect if `code_info` is `true`.
+   * This option only has an effect if [`code_info`][Self::code_info]
+   * is `true`.
    */
   bool inlined_fns;
   /**

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -659,7 +659,7 @@ pub struct blaze_symbolizer_opts {
     /// Note that the directory containing a symbolization source is always an
     /// implicit candidate target directory of the highest precedence.
     pub debug_dirs: *const *const c_char,
-    /// The number of array elements in `debug_dirs`.
+    /// The number of array elements in [`debug_dirs`][Self::debug_dirs].
     pub debug_dirs_len: usize,
     /// Whether or not to automatically reload file system based
     /// symbolization sources that were updated since the last
@@ -668,11 +668,14 @@ pub struct blaze_symbolizer_opts {
     /// Whether to attempt to gather source code location information.
     ///
     /// This option only has an effect if `debug_syms` of the particular
-    /// symbol source is set to `true`.
+    /// symbol source is set to `true`. Furthermore, it is a necessary
+    /// prerequisite for retrieving inlined function information (see
+    /// [`inlined_fns`][Self::inlined_fns]).
     pub code_info: bool,
     /// Whether to report inlined functions as part of symbolization.
     ///
-    /// This option only has an effect if `code_info` is `true`.
+    /// This option only has an effect if [`code_info`][Self::code_info]
+    /// is `true`.
     pub inlined_fns: bool,
     /// Whether or not to transparently demangle symbols.
     ///

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -276,7 +276,9 @@ impl Builder {
     /// file names etc.).
     ///
     /// This option only has an effect if `debug_syms` of the particular
-    /// symbol source is set to `true`.
+    /// symbol source is set to `true`. Furthermore, it is a necessary
+    /// prerequisite for retrieving inlined function information (see
+    /// [`Self::enable_inlined_fns`]).
     pub fn enable_code_info(mut self, enable: bool) -> Self {
         self.code_info = enable;
         self


### PR DESCRIPTION
Improve the documentation surrounding the "code info" setting on the `Symbolizer` `Builder` by clarifying that the setting is a prerequisite for inlined function reporting.