### PR TITLE
Collect uncached symbols into boxed slices directly

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -733,8 +733,7 @@ impl Symbolizer {
                                 _non_exhaustive: (),
                             }
                         })
-                        .collect::<Vec<_>>()
-                        .into_boxed_slice();
+                        .collect::<Box<[_]>>();
 
                     (name, module, addr, size, code_info, inlined)
                 }


### PR DESCRIPTION
In `Symbolizer::symbolize_with_resolver()` we first collect uncached symbolized symbols into a Vec, just to transform that into a boxed slice. Collect into a boxed slice directly, in order to cut down on unnecessary allocations and/or copies.