### PR TITLE
Bump MSRV to 1.75

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,6 +1,6 @@
 # For general information about this file, check
 # https://doc.rust-lang.org/stable/clippy/configuration.html
 
-msrv = "1.70"
+msrv = "1.75"
 
 absolute-paths-allowed-crates = [ "gimli" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           # Please adjust README, `rust-version` field in Cargo.toml,
           # and `msrv` in .clippy.toml when bumping version.
-          toolchain: 1.70.0
+          toolchain: 1.75.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --features="apk,backtrace,bpf,demangle,dwarf,gsym,tracing"
       - run: cargo build --package=blazesym-c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
 - Adjusted symbol names reported for BPF programs to contain `bpf_prog_`
   prefix and program tag
 - Changed `CodeInfo::to_owned` to `into_owned`
+- Bumped minimum supported Rust version to `1.75`
 
 
 0.2.0-rc.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = ["."]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.75"
 license = "BSD-3-Clause"
 repository = "https://github.com/libbpf/blazesym"
 homepage = "https://github.com/libbpf/blazesym"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![coverage](https://codecov.io/gh/libbpf/blazesym/branch/main/graph/badge.svg)](https://codecov.io/gh/libbpf/blazesym)
 [![crates.io](https://img.shields.io/crates/v/blazesym.svg)](https://crates.io/crates/blazesym)
 [![Docs](https://docs.rs/blazesym/badge.svg)](https://docs.rs/blazesym)
-[![rustc](https://img.shields.io/badge/rustc-1.70+-blue.svg)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.75+-blue.svg)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0/)
 
 # blazesym
 

--- a/capi/README.md
+++ b/capi/README.md
@@ -1,6 +1,6 @@
 [![pipeline](https://github.com/libbpf/blazesym/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/libbpf/blazesym/actions/workflows/test.yml)
 [![crates.io](https://img.shields.io/crates/v/blazesym-c.svg)](https://crates.io/crates/blazesym-c)
-[![rustc](https://img.shields.io/badge/rustc-1.70+-blue.svg)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.75+-blue.svg)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0/)
 
 blazesym-c
 ==========

--- a/capi/build.rs
+++ b/capi/build.rs
@@ -3,7 +3,6 @@
 use std::env;
 use std::ffi::OsStr;
 use std::io::Error;
-use std::io::ErrorKind;
 use std::io::Result;
 use std::ops::Deref as _;
 use std::path::Path;
@@ -44,13 +43,10 @@ where
         .args(args.clone())
         .output()
         .map_err(|err| {
-            Error::new(
-                ErrorKind::Other,
-                format!(
-                    "failed to run `{}`: {err}",
-                    format_command(command.as_ref(), args.clone())
-                ),
-            )
+            Error::other(format!(
+                "failed to run `{}`: {err}",
+                format_command(command.as_ref(), args.clone())
+            ))
         })?;
 
     if !instance.status.success() {
@@ -68,13 +64,10 @@ where
             String::new()
         };
 
-        Err(Error::new(
-            ErrorKind::Other,
-            format!(
-                "`{}` reported non-zero exit-status{code}{stderr}",
-                format_command(command, args)
-            ),
-        ))
+        Err(Error::other(format!(
+            "`{}` reported non-zero exit-status{code}{stderr}",
+            format_command(command, args)
+        )))
     } else {
         Ok(())
     }
@@ -90,7 +83,7 @@ fn adjust_mtime(path: &Path) -> Result<()> {
     // don't rely on it for anything essential.
     let output = Path::new(&out_dir)
         .parent()
-        .ok_or_else(|| Error::new(ErrorKind::Other, "OUT_DIR has no parent"))?
+        .ok_or_else(|| Error::other("OUT_DIR has no parent"))?
         .join("output");
 
     if !output.exists() {

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -195,8 +195,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
         }
     }
 
-    let array_sz = (mem::size_of::<*const u64>() * syms_list.len() + mem::size_of::<u64>() - 1)
-        / mem::size_of::<u64>()
+    let array_sz = (mem::size_of::<*const u64>() * syms_list.len()).div_ceil(mem::size_of::<u64>())
         * mem::size_of::<u64>();
     let sym_buf_sz = mem::size_of::<blaze_sym_info>() * sym_cnt;
     let buf_size = mem::size_of::<u64>() + array_sz + sym_buf_sz + str_buf_sz;

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 [![pipeline](https://github.com/libbpf/blazesym/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/libbpf/blazesym/actions/workflows/test.yml)
 [![crates.io](https://img.shields.io/crates/v/blazecli.svg)](https://crates.io/crates/blazecli)
-[![rustc](https://img.shields.io/badge/rustc-1.70+-blue.svg)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.75+-blue.svg)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0/)
 
 blazecli
 ========

--- a/dev/build.rs
+++ b/dev/build.rs
@@ -37,10 +37,10 @@ fn page_size() -> Result<usize> {
     // SAFETY: `sysconf` is always safe to call.
     let rc = unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) };
     if rc < 0 {
-        return Err(Error::new(
-            ErrorKind::Other,
-            format!("failed to retrieve page size: {}", Error::last_os_error()),
-        ))
+        return Err(Error::other(format!(
+            "failed to retrieve page size: {}",
+            Error::last_os_error()
+        )))
     }
     Ok(usize::try_from(rc).unwrap())
 }
@@ -83,13 +83,10 @@ where
         .args(args.clone())
         .output()
         .map_err(|err| {
-            Error::new(
-                ErrorKind::Other,
-                format!(
-                    "failed to run `{}`: {err}",
-                    format_command(command.as_ref(), args.clone())
-                ),
-            )
+            Error::other(format!(
+                "failed to run `{}`: {err}",
+                format_command(command.as_ref(), args.clone())
+            ))
         })?;
 
     if !instance.status.success() {
@@ -107,13 +104,10 @@ where
             String::new()
         };
 
-        Err(Error::new(
-            ErrorKind::Other,
-            format!(
-                "`{}` reported non-zero exit-status{code}{stderr}",
-                format_command(command, args)
-            ),
-        ))
+        Err(Error::other(format!(
+            "`{}` reported non-zero exit-status{code}{stderr}",
+            format_command(command, args)
+        )))
     } else {
         Ok(())
     }
@@ -129,7 +123,7 @@ fn adjust_mtime(path: &Path) -> Result<()> {
     // don't rely on it for anything essential.
     let output = Path::new(&out_dir)
         .parent()
-        .ok_or_else(|| Error::new(ErrorKind::Other, "OUT_DIR has no parent"))?
+        .ok_or_else(|| Error::other("OUT_DIR has no parent"))?
         .join("output");
 
     if !output.exists() {

--- a/src/once.rs
+++ b/src/once.rs
@@ -1,6 +1,5 @@
 //! A copy of `std::once::OnceCell`.
-// TODO: Remove this module once our minimum supported Rust version is greater
-//       1.70 and/or `OnceCell::get_or_try_init` is stable.
+// TODO: Remove this module once `OnceCell::get_or_try_init` is stable.
 
 use std::cell::UnsafeCell;
 use std::convert::Infallible;


### PR DESCRIPTION
Bump the minimum support Rust version to 1.75, in order to enable usage of recently added stable features. Specifically, `pointer::byte_sub()` is something we intend on using subsequently.