### PR TITLE
capi: Add support for vDSO address normalization

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 ----------
+- Introduced `blaze_user_meta_sym` meta data variant
+  - Added support for normalization of vDSO addresses
 - Added shorter `blaze_user_meta_kind` constants
   - Deprecated `BLAZE_USER_META_KIND_BLAZE_USER_META_*` constants
 

--- a/capi/build.rs
+++ b/capi/build.rs
@@ -129,6 +129,12 @@ fn cc(src: &Path, dst: &str, options: &[&str]) {
 }
 
 fn main() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "linux" || target_os == "android" {
+        println!("cargo:rustc-cfg=linux");
+    }
+    println!("cargo:rustc-check-cfg=cfg(linux)");
+
     let crate_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
 
     #[cfg(feature = "generate-c-header")]

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -919,7 +919,7 @@ fn convert_code_info(
 
 
 /// Convert a [`Sym`] into the `blaze_sym` C correspondent.
-fn convert_sym(
+pub(crate) fn convert_sym(
     sym: &Sym,
     sym_ref: &mut blaze_sym,
     inlined_last: &mut *mut blaze_symbolize_inlined_fn,


### PR DESCRIPTION
Add support for normalization of vDSO addresses. This is the C API counter part to #1158. We introduce a new user meta data variant for representing a fully symbolized entity.

Closes: #1134