### PR TITLE
Fix warnings emitted by recent versions of Rust

### DIFF
--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -83,8 +83,8 @@ impl GsymContext<'_> {
     ///
     /// Returns a `GsymContext`, which includes the Header and other important
     /// tables.
-    pub(crate) fn parse_header(data: &[u8]) -> Result<GsymContext> {
-        fn parse_header_impl(mut data: &[u8]) -> Option<Result<GsymContext>> {
+    pub(crate) fn parse_header(data: &[u8]) -> Result<GsymContext<'_>> {
+        fn parse_header_impl(mut data: &[u8]) -> Option<Result<GsymContext<'_>>> {
             let head = data;
             let magic = data.read_u32()?;
             if magic != GSYM_MAGIC {
@@ -181,7 +181,7 @@ impl GsymContext<'_> {
     }
 
     /// Get the `AddrInfo` of an address given by an index.
-    pub(crate) fn addr_info(&self, idx: usize) -> Option<AddrInfo> {
+    pub(crate) fn addr_info(&self, idx: usize) -> Option<AddrInfo<'_>> {
         let offset = *self.addr_data_off_tab.get(idx)?;
         let mut data = self.raw_data.get(offset as usize..)?;
         let size = data.read_u32()?;
@@ -214,7 +214,7 @@ impl GsymContext<'_> {
 /// # Arguments
 ///
 /// * `data` - is the slice from `AddrInfo::data`.
-pub(crate) fn parse_address_data(mut data: &[u8]) -> impl Iterator<Item = AddrData> {
+pub(crate) fn parse_address_data(mut data: &[u8]) -> impl Iterator<Item = AddrData<'_>> {
     iter::from_fn(move || {
         let typ = data.read_u32()?;
         if typ == INFO_TYPE_END_OF_LIST {

--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -251,7 +251,7 @@ impl Normalizer {
         addrs: A,
         pid: Pid,
         opts: &NormalizeOpts,
-    ) -> Result<UserOutput>
+    ) -> Result<UserOutput<'_>>
     where
         A: ExactSizeIterator<Item = Addr> + Clone,
     {
@@ -326,7 +326,7 @@ impl Normalizer {
         pid: Pid,
         addrs: &[Addr],
         opts: &NormalizeOpts,
-    ) -> Result<UserOutput> {
+    ) -> Result<UserOutput<'_>> {
         if opts.sorted_addrs {
             self.normalize_user_addrs_iter(addrs.iter().copied(), pid, opts)
         } else {
@@ -342,7 +342,7 @@ impl Normalizer {
     ///
     /// A convenience wrapper around [`Normalizer::normalize_user_addrs_opts`][]
     /// that uses the default normalization options.
-    pub fn normalize_user_addrs(&self, pid: Pid, addrs: &[Addr]) -> Result<UserOutput> {
+    pub fn normalize_user_addrs(&self, pid: Pid, addrs: &[Addr]) -> Result<UserOutput<'_>> {
         self.normalize_user_addrs_opts(pid, addrs, &NormalizeOpts::default())
     }
 

--- a/src/perf_map.rs
+++ b/src/perf_map.rs
@@ -102,7 +102,7 @@ fn parse_perf_map_line<'line>(line: &'line [u8]) -> Result<Function<'line>> {
 }
 
 
-fn parse_perf_map(data: &[u8]) -> Result<Vec<Function>> {
+fn parse_perf_map(data: &[u8]) -> Result<Vec<Function<'_>>> {
     let mut functions = data
         .split(|&b| b == b'\n' || b == b'\r')
         .filter(|line| !line.is_empty())

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -943,7 +943,7 @@ impl Symbolizer {
         perf_map: bool,
         map_files: bool,
         vdso: bool,
-    ) -> Result<Vec<Symbolized>> {
+    ) -> Result<Vec<Symbolized<'_>>> {
         let mut handler = SymbolizeHandler {
             symbolizer: self,
             pid,


### PR DESCRIPTION
Fix warnings emitted by recent versions of Rust, complaining about a mismatch in lifetime syntaxes.