### PR TITLE
Make `inspect::SymInfo` enum non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Unreleased
   compression headers
 - Adjusted symbol names reported for BPF programs to contain `bpf_prog_`
   prefix and program tag
+- Made `inspect::SymInfo` type non-exhaustive
 - Changed `CodeInfo::to_owned` to `into_owned`
 - Bumped minimum supported Rust version to `1.75`
 

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -211,6 +211,7 @@ fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_s
             sym_type,
             file_offset,
             module,
+            _non_exhaustive: (),
         } in syms
         {
             let name_ptr = str_ptr.cast();
@@ -535,6 +536,7 @@ mod tests {
             sym_type: SymType::Function,
             file_offset: Some(1337),
             module: Some(OsStr::new("/tmp/foobar.so").into()),
+            _non_exhaustive: (),
         }]];
         test(syms);
 
@@ -547,6 +549,7 @@ mod tests {
                 sym_type: SymType::Function,
                 file_offset: Some(1337),
                 module: Some(OsStr::new("/tmp/foobar.so").into()),
+                _non_exhaustive: (),
             },
             SymInfo {
                 name: "sym2".into(),
@@ -555,6 +558,7 @@ mod tests {
                 sym_type: SymType::Undefined,
                 file_offset: Some(1338),
                 module: Some(OsStr::new("other.so").into()),
+                _non_exhaustive: (),
             },
         ]];
         test(syms);
@@ -568,6 +572,7 @@ mod tests {
                 sym_type: SymType::Function,
                 file_offset: Some(1337),
                 module: Some(OsStr::new("/tmp/foobar.so").into()),
+                _non_exhaustive: (),
             }],
             vec![SymInfo {
                 name: "sym2".into(),
@@ -576,6 +581,7 @@ mod tests {
                 sym_type: SymType::Undefined,
                 file_offset: Some(1338),
                 module: Some(OsStr::new("other.so").into()),
+                _non_exhaustive: (),
             }],
         ];
         test(syms);
@@ -588,6 +594,7 @@ mod tests {
             sym_type: SymType::Function,
             file_offset: Some(1337),
             module: Some(OsStr::new("/tmp/foobar.so").into()),
+            _non_exhaustive: (),
         };
         let syms = vec![(0..200).map(|_| sym.clone()).collect()];
         test(syms);

--- a/capi/src/util.rs
+++ b/capi/src/util.rs
@@ -127,6 +127,7 @@ impl DynSize for SymInfo<'_> {
             sym_type: _,
             file_offset: _,
             module,
+            _non_exhaustive: (),
         } = self;
 
         name.c_str_size() + module.c_str_size()

--- a/src/breakpad/resolver.rs
+++ b/src/breakpad/resolver.rs
@@ -42,6 +42,7 @@ impl<'func> From<&'func Function> for SymInfo<'func> {
             sym_type: SymType::Function,
             file_offset: None,
             module: None,
+            _non_exhaustive: (),
         }
     }
 }

--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -248,6 +248,7 @@ impl DwarfResolver {
                 .transpose()?
                 .flatten(),
             module: self.parser.module().map(Cow::Borrowed),
+            _non_exhaustive: (),
         };
         Ok(Some(info))
     }

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -1114,6 +1114,7 @@ where
                                 .transpose()?
                                 .flatten(),
                             module: self.module.as_deref().map(Cow::Borrowed),
+                            _non_exhaustive: (),
                         });
                     }
                 }
@@ -1177,6 +1178,7 @@ where
                         .transpose()?
                         .flatten(),
                     module: None,
+                    _non_exhaustive: (),
                 };
                 if let ControlFlow::Break(()) = f(&sym_info) {
                     return Ok(())

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -54,6 +54,9 @@ pub struct SymInfo<'src> {
     pub file_offset: Option<u64>,
     /// The path to or name of the module containing the symbol.
     pub module: Option<Cow<'src, OsStr>>,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
 }
 
 impl SymInfo<'_> {
@@ -71,6 +74,7 @@ impl SymInfo<'_> {
                 .module
                 .as_deref()
                 .map(|path| Cow::Owned(path.to_os_string())),
+            _non_exhaustive: (),
         }
     }
 }

--- a/src/kernel/bpf/prog.rs
+++ b/src/kernel/bpf/prog.rs
@@ -410,6 +410,7 @@ impl<'prog> TryFrom<&'prog BpfProg> for SymInfo<'prog> {
             sym_type: SymType::Function,
             file_offset: None,
             module: None,
+            _non_exhaustive: (),
         };
         Ok(sym)
     }

--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -162,6 +162,7 @@ impl<'kfunc> TryFrom<&'kfunc Kfunc> for SymInfo<'kfunc> {
             sym_type: SymType::Function,
             file_offset: None,
             module: None,
+            _non_exhaustive: (),
         };
         Ok(sym)
     }


### PR DESCRIPTION
We want to leave open the options of adding additional variants to the `inspect::SymInfo` enum down the line without breaking backwards compatibility.
Mark the type as non-exhaustive to make sure that this is a possibility.