### PR TITLE
Merged normalize::Reason and symbolize::Reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Unreleased
 - Adjusted symbol names reported for BPF programs to contain `bpf_prog_`
   prefix and program tag
 - Made `inspect::SymInfo` type non-exhaustive
+- Merged `normalize::Reason` and `symbolize::Reason`
 - Changed `CodeInfo::to_owned` to `into_owned`
 - Bumped minimum supported Rust version to `1.75`
 

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -122,7 +122,6 @@ pub(crate) use symbolizer::Resolver;
 pub use crate::maps::EntryPath as ProcessMemberPath;
 pub use crate::maps::PathName as ProcessMemberType;
 
-use crate::normalize;
 use crate::Addr;
 use crate::Result;
 
@@ -491,17 +490,6 @@ impl Display for Reason {
     }
 }
 
-impl From<normalize::Reason> for Reason {
-    #[inline]
-    fn from(reason: normalize::Reason) -> Self {
-        match reason {
-            normalize::Reason::Unmapped => Self::Unmapped,
-            normalize::Reason::MissingComponent => Self::MissingComponent,
-            normalize::Reason::Unsupported => Self::Unsupported,
-        }
-    }
-}
-
 
 /// An enumeration used as reporting vehicle for address symbolization.
 // We keep this enum as exhaustive because additions to it, should they occur,
@@ -685,21 +673,6 @@ mod tests {
         for variant in [Input::AbsAddr, Input::VirtOffset, Input::FileOffset] {
             let () = test(variant);
         }
-    }
-
-    /// Check that we can convert `normalize::Reason` objects into
-    /// `symbolize::Reason` objects.
-    #[test]
-    fn reason_conversion() {
-        assert_eq!(Reason::from(normalize::Reason::Unmapped), Reason::Unmapped);
-        assert_eq!(
-            Reason::from(normalize::Reason::MissingComponent),
-            Reason::MissingComponent
-        );
-        assert_eq!(
-            Reason::from(normalize::Reason::Unsupported),
-            Reason::Unsupported
-        );
     }
 
     /// Test the `Symbolized::*_sym()` conversion methods for the `Unknown`


### PR DESCRIPTION
Merged the normalize::Reason and symbolize::Reason enums into a single one. Given that with commit 83eae8353321 ("Add support for normalizing vDSO addresses") we already started using actual symbolization as part of the normalization process, it seems only consequent to unify these two reason. This way, we can actually report the symbolization reason and don't have to translate it in a lossy manner. Furthermore, having a single enum removes a bunch of interop plumbing.
We re-export symbolize::Reason from the normalize module, because for all intents and purposes the Reason is a first class member of the API. That is a little bit different from symbolize::Sym (which is not re-export through the normalize module), for which we want to make it clear that it is absolutely the fully blown symbol as would be returned from the symbolization APIs.