### PR TITLE
cli: Bump version to 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blazecli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "blazesym",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.10
+------
 - Bumped `blazesym` dependency to `0.2.0-rc.4`
 
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazecli"
 description = "A command line utility for the blazesym library."
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 rust-version.workspace = true
 default-run = "blazecli"


### PR DESCRIPTION
This change bumps blazecli's version to 0.1.10. The following notable changes have been made since 0.1.9:
- Bumped blazesym dependency to 0.2.0-rc.4