### PR TITLE
Update test-log dev-dependency to 0.2.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
 dependencies = [
  "test-log-macros",
  "tracing-subscriber",
@@ -2775,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ scopeguard = "1.2"
 stats_alloc = {version = "0.1.1", features = ["nightly"]}
 tempfile = "3.20"
 test-fork = "0.1"
-test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
+test-log = {version = "0.2.18", default-features = false, features = ["trace"]}
 test-tag = "0.1.3"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -731,7 +731,7 @@ mod tests {
     use std::env;
     use std::mem::size_of;
 
-    use test_fork::test as forked_test;
+    use test_fork::fork;
     use test_log::test;
     use test_tag::tag;
 
@@ -868,7 +868,8 @@ Caused by:
     /// that the file name is contained in the backtrace. For that reason we
     /// only run it on debug builds (represented by the `debug_assertions`
     /// proxy cfg).
-    #[forked_test]
+    #[fork]
+    #[test]
     fn error_backtrace() {
         if !cfg!(debug_assertions) {
             return
@@ -888,7 +889,8 @@ Caused by:
 
     /// Make sure that we do not emit backtraces in errors when
     /// the `RUST_LIB_BACKTRACE` environment variable is not present.
-    #[forked_test]
+    #[fork]
+    #[test]
     fn error_no_backtrace1() {
         let () = unsafe { env::remove_var("RUST_BACKTRACE") };
         let () = unsafe { env::remove_var("RUST_LIB_BACKTRACE") };
@@ -902,7 +904,8 @@ Caused by:
 
     /// Make sure that we do not emit backtraces in errors when
     /// the `RUST_LIB_BACKTRACE` environment variable is "0".
-    #[forked_test]
+    #[fork]
+    #[test]
     fn error_no_backtrace2() {
         let () = unsafe { env::remove_var("RUST_BACKTRACE") };
         let () = unsafe { env::set_var("RUST_LIB_BACKTRACE", "0") };

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1560,7 +1560,7 @@ mod tests {
 
     use std::env::current_exe;
 
-    use test_fork::test as forked_test;
+    use test_fork::fork;
     use test_log::test;
 
     use crate::maps::Perm;
@@ -1763,7 +1763,8 @@ mod tests {
     /// parsing over and over, but it peeks at implementation details.
     // Run in separate process to make sure that VMAs are not influenced
     // by tests running concurrently.
-    #[forked_test]
+    #[fork]
+    #[test]
     fn resolver_instantiation() {
         let exe = current_exe().unwrap();
         let addrs = maps::parse(Pid::Slf)

--- a/tests/suite/normalize.rs
+++ b/tests/suite/normalize.rs
@@ -24,7 +24,7 @@ use scopeguard::defer;
 
 use tempfile::tempdir;
 
-use test_fork::test as forked_test;
+use test_fork::fork;
 use test_log::test;
 
 use crate::suite::common::run_unprivileged_process_test;
@@ -492,7 +492,8 @@ fn normalize_permissionless_impl(pid: Pid, addr: Addr, test_lib: &Path) {
 /// Check that we can normalize an address in a process using only
 /// symbolic paths.
 #[cfg(linux)]
-#[forked_test]
+#[fork]
+#[test]
 fn normalize_process_symbolic_paths() {
     run_unprivileged_process_test(normalize_permissionless_impl)
 }

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -60,7 +60,7 @@ use scopeguard::defer;
 use tempfile::tempdir;
 use tempfile::NamedTempFile;
 
-use test_fork::test as forked_test;
+use test_fork::fork;
 use test_log::test;
 use test_tag::tag;
 
@@ -201,7 +201,8 @@ fn symbolize_no_permission_impl(path: &Path) {
 /// Check that we fail symbolization as expected when we don't have the
 /// permission to open the symbolization source.
 #[cfg(linux)]
-#[forked_test]
+#[fork]
+#[test]
 fn symbolize_elf_no_permission() {
     use libc::getresuid;
     use std::os::unix::fs::PermissionsExt as _;
@@ -1066,7 +1067,8 @@ fn symbolize_remote_process_vdso() {
 
 /// Make sure that we do not fail symbolization when an empty perf
 /// map is present.
-#[forked_test]
+#[fork]
+#[test]
 fn symbolize_with_empty_perf_map() {
     let heap = vec![0; 4096];
     let path = format!("/tmp/perf-{}.map", process::id());
@@ -1094,7 +1096,8 @@ fn symbolize_with_empty_perf_map() {
 
 /// Check that we can symbolize an address using a perf map.
 #[cfg(linux)]
-#[forked_test]
+#[fork]
+#[test]
 #[ignore = "test requires python 3.12 or higher"]
 fn symbolize_process_perf_map() {
     use std::ffi::OsString;
@@ -1178,7 +1181,8 @@ fn symbolize_permissionless_impl(pid: Pid, addr: Addr, _test_lib: &Path) {
 /// Check that we can symbolize an address in a process using only
 /// symbolic paths.
 #[cfg(linux)]
-#[forked_test]
+#[fork]
+#[test]
 fn symbolize_process_symbolic_paths() {
     run_unprivileged_process_test(symbolize_permissionless_impl)
 }


### PR DESCRIPTION
Update the `test-log` dev-dependency to 0.2.18, which now allows for proper stacking of `#[test]` attributes, making it compose more nicely with the `test-fork` crate.