### PR TITLE
Document private items in documentation CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -505,7 +505,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo doc --workspace --exclude=blazesym-dev --exclude=gsym-in-apk --no-deps
+      - run: cargo doc --workspace --exclude=blazesym-dev --exclude=gsym-in-apk --no-deps --document-private-items
 
   required-checks:
     needs: [

--- a/capi/src/inspect.rs
+++ b/capi/src/inspect.rs
@@ -180,8 +180,7 @@ pub struct blaze_sym_info {
 }
 
 
-/// Convert [`SymInfo`] objects as returned by
-/// [`Symbolizer::find_addrs`] to a C array.
+/// Convert [`SymInfo`] objects to a C array.
 fn convert_syms_list_to_c(syms_list: Vec<Vec<SymInfo>>) -> *const *const blaze_sym_info {
     let sym_cnt = syms_list.iter().map(|syms| syms.len() + 1).sum::<usize>();
     let str_buf_sz = syms_list.c_str_size();

--- a/src/breakpad/parser.rs
+++ b/src/breakpad/parser.rs
@@ -420,8 +420,8 @@ fn func_line(input: &[u8]) -> IResult<&[u8], Function, VerboseError<&[u8]>> {
     ))
 }
 
-/// Matches one entry of the form <addr> <size> which is used at the end of
-/// an INLINE record
+/// Matches one entry of the form `<addr> <size>` which is used at the
+/// end of an INLINE record
 fn inline_address_range(input: &[u8]) -> IResult<&[u8], (u64, u32), VerboseError<&[u8]>> {
     tuple((terminated(hex_str::<u64>, space1), hex_str::<u32>))(input)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -383,9 +383,9 @@ impl Display for ErrorKind {
 /// assert!(inner_err.to_string().starts_with("No such file or directory"));
 /// ```
 ///
-/// For convenient reporting, the [`Display`][std::fmt::Display]
-/// representation takes care of reporting the complete error chain when
-/// the alternate flag is set:
+/// For convenient reporting, the [`Display`] representation takes care
+/// of reporting the complete error chain when the alternate flag is
+/// set:
 /// ```
 /// # use std::fs::File;
 /// # use std::error::Error as _;
@@ -397,8 +397,8 @@ impl Display for ErrorKind {
 /// println!("{err:#}");
 /// ```
 ///
-/// The [`Debug`][std::fmt::Debug] representation similarly will print
-/// the entire error chain, but will do so in a multi-line format:
+/// The [`Debug`] representation similarly will print the entire error
+/// chain, but will do so in a multi-line format:
 /// ```
 /// # use std::fs::File;
 /// # use std::error::Error as _;

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -3,6 +3,12 @@
 use crate::util::ReadRaw as _;
 use crate::Addr;
 
+#[cfg(doc)]
+use super::types::AddrData;
+#[cfg(doc)]
+use super::types::INFO_TYPE_LINE_TABLE_INFO;
+
+
 /// End of the line table
 const END_SEQUENCE: u8 = 0x00;
 /// Set [`LineTableRow.file_idx`], don't push a row.
@@ -76,8 +82,7 @@ impl LineTableRow {
     ///
     /// # Arguments
     ///
-    /// * `header` - is a [`LineTableHeader`] returned by
-    ///   [`parse_line_table_header()`].
+    /// * `header` - is a [`LineTableHeader`].
     /// * `symaddr` - the address of the symbol that `header` belongs to.
     pub(crate) fn from_header(header: &LineTableHeader, symaddr: Addr) -> Self {
         Self {

--- a/src/gsym/parser.rs
+++ b/src/gsym/parser.rs
@@ -59,12 +59,7 @@ use super::types::INFO_TYPE_END_OF_LIST;
 /// Hold the major parts of a standalone GSYM file.
 ///
 /// `GsymContext` provides functions to access major entities in GSYM.
-/// `GsymContext` can find respective `AddrInfo` for an address. But,
-/// it doesn't parse [`AddrData`] to get line numbers.
-///
-/// The developers should use [`parse_address_data()`],
-/// [`parse_line_table_header()`], and [`linetab::run_op()`] to get
-/// line number information from [`AddrInfo`].
+/// `GsymContext` can find respective `AddrInfo` for an address.
 pub(crate) struct GsymContext<'a> {
     header: Header,
     addr_tab: &'a [u8],
@@ -207,7 +202,7 @@ impl GsymContext<'_> {
 
 /// Parse [`AddrData`].
 ///
-/// [`AddrData`] objects are items following [`AndressInfo`].
+/// [`AddrData`] objects are items following [`AddrInfo`].
 /// [`GsymContext::addr_info()`] returns the raw data of [`AddrData`] objects as
 /// a slice at [`AddrInfo::data`].
 ///

--- a/src/once.rs
+++ b/src/once.rs
@@ -9,15 +9,10 @@ use std::hint::unreachable_unchecked;
 /// A cell which can be written to only once.
 ///
 /// This allows obtaining a shared `&T` reference to its inner value without
-/// copying or replacing it (unlike [`Cell`]), and without runtime borrow checks
-/// (unlike [`RefCell`]). However, only immutable references can be obtained
-/// unless one has a mutable reference to the cell itself.
-///
-/// For a thread-safe version of this struct, see [`std::sync::OnceLock`].
-///
-/// [`RefCell`]: crate::cell::RefCell
-/// [`Cell`]: crate::cell::Cell
-/// [`std::sync::OnceLock`]: ../../std/sync/struct.OnceLock.html
+/// copying or replacing it (unlike [`Cell`][std::cell::Cell]), and without
+/// runtime borrow checks (unlike [`RefCell`][std::cell::RefCell]). However,
+/// only immutable references can be obtained unless one has a mutable
+/// reference to the cell itself.
 pub struct OnceCell<T> {
     // Invariant: written to at most once.
     inner: UnsafeCell<Option<T>>,

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -160,7 +160,7 @@ fn maybe_demangle(symbol: Cow<'_, str>, language: SrcLang, demangle: bool) -> Co
 }
 
 
-/// Symbolize an address using the provided [`SymResolver`].
+/// Symbolize an address using the provided [`Resolver`].
 pub(crate) fn symbolize_with_resolver<'slf>(
     addr: Addr,
     resolver: &Resolver<'_, 'slf>,
@@ -747,7 +747,7 @@ impl Symbolizer {
         Builder::default()
     }
 
-    /// Symbolize an address using the provided [`SymResolver`].
+    /// Symbolize an address using the provided [`Resolver`].
     #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(addr = format_args!("{addr:#x}"), resolver = ?resolver.inner())))]
     fn symbolize_with_resolver<'slf>(
         &'slf self,
@@ -757,7 +757,7 @@ impl Symbolizer {
         symbolize_with_resolver(addr, resolver, &self.find_sym_opts, self.demangle)
     }
 
-    /// Symbolize a list of addresses using the provided [`SymResolver`].
+    /// Symbolize a list of addresses using the provided [`Resolver`].
     fn symbolize_addrs<'slf>(
         &'slf self,
         addrs: &[Addr],
@@ -1136,15 +1136,15 @@ impl Symbolizer {
     /// Symbolize a list of addresses.
     ///
     /// Symbolize a list of addresses using the provided symbolization
-    /// [`Source`][Source].
+    /// [`Source`].
     ///
     /// This function returns exactly one [`Symbolized`] object for each input
     /// address, in the order of input addresses.
     ///
     /// The following table lists which features the various formats
-    /// (represented by the [`Source`][Source] argument) support. If a feature
-    /// is not supported, the corresponding data in the [`Sym`] result will not
-    /// be populated.
+    /// (represented by the [`Source`] argument) support. If a feature is not
+    /// supported, the corresponding data in the [`Sym`] result will not be
+    /// populated.
     ///
     /// | Format      | Feature                          | Supported by format? | Supported by blazesym? |
     /// |-------------|----------------------------------|:--------------------:|:----------------------:|


### PR DESCRIPTION
We use rustdoc style documentation for both public and private items. By default, however, rustdoc only generates documentation for public ones, completely ignoring anything private. As a result, a bunch of unresolved references and other issues snug into the documentation of private bits.
Fix those, and adjust the CI job to actually document private items as well to catch these digressions in the future.