### PR TITLE
Allow greater zip dependency version flexibility

### DIFF
--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = {version = "0.12", optional = true, features = ["blocking"]}
 tempfile = {version = "3.20", optional = true}
 vmlinux = {git = "https://github.com/libbpf/vmlinux.h.git", rev = "a9c092aa771310bf8b00b5018f7d40a1fdb6ec82"}
 xz2 = {version = "0.1.7", optional = true}
-zip = {version = "4.3", optional = true, default-features = false}
+zip = {version = "4", optional = true, default-features = false}
 zstd = {version = "0.13.3", default-features = false, optional = true}
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.build-dependencies]

--- a/examples/gsym-in-apk/Cargo.toml
+++ b/examples/gsym-in-apk/Cargo.toml
@@ -17,7 +17,7 @@ blazesym = {version = "=0.2.0-rc.4", path = "../..", default-features = false, f
 ]}
 blazesym-dev = {path = "../../dev", features = ["generate-unit-test-files"]}
 goblin = {version = "0.10", default-features = false, features = ["elf32", "elf64", "std"]}
-zip = {version = "4.3", default-features = false}
+zip = {version = "4", default-features = false}
 
 [lints]
 workspace = true


### PR DESCRIPTION
Dependabot, with its stupid and inflexible update logic, updates Cargo.toml and with that bumps the minimum required version of a dependency, which makes no sense. If past is any guidance, it won't do that if all that is specified is the major version. Do that, which should trigger updates only to Cargo.lock as long as only minor versions are changed.