### PR TITLE
capi: Add missing `blaze_normalize_reason` variants

### DIFF
--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Fixed potential panic when normalizing vDSO addresses
+
+
 0.1.2
 -----
 - Introduced `blaze_user_meta_sym` meta data variant

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -264,6 +264,18 @@ typedef uint8_t blaze_normalize_reason;
  * The address belonged to an entity that is currently unsupported.
  */
 #define BLAZE_NORMALIZE_REASON_UNSUPPORTED 2
+/**
+ * The file offset does not map to a valid piece of code/data.
+ */
+#define BLAZE_NORMALIZE_REASON_INVALID_FILE_OFFSET 3
+/**
+ * The symbolization source has no or no relevant symbols.
+ */
+#define BLAZE_NORMALIZE_REASON_MISSING_SYMS 4
+/**
+ * The address could not be found in the symbolization source.
+ */
+#define BLAZE_NORMALIZE_REASON_UNKNOWN_ADDR 5
 
 /**
  * The valid variant kind in [`blaze_user_meta`].
@@ -1217,7 +1229,7 @@ void blaze_normalizer_free(blaze_normalizer *normalizer);
 /**
  * Retrieve a textual representation of the reason of a normalization failure.
  */
-const char *blaze_normalize_reason_str(blaze_normalize_reason err);
+const char *blaze_normalize_reason_str(blaze_normalize_reason reason);
 
 /**
  * Normalize a list of user space addresses.
@@ -1285,7 +1297,7 @@ void blaze_user_output_free(struct blaze_normalized_user_output *output);
  * Retrieve a textual representation of the reason of a symbolization
  * failure.
  */
-const char *blaze_symbolize_reason_str(blaze_symbolize_reason err);
+const char *blaze_symbolize_reason_str(blaze_symbolize_reason reason);
 
 /**
  * Create an instance of a symbolizer.

--- a/capi/src/normalize.rs
+++ b/capi/src/normalize.rs
@@ -493,6 +493,12 @@ impl blaze_normalize_reason {
     pub const MISSING_COMPONENT: blaze_normalize_reason = blaze_normalize_reason(1);
     /// The address belonged to an entity that is currently unsupported.
     pub const UNSUPPORTED: blaze_normalize_reason = blaze_normalize_reason(2);
+    /// The file offset does not map to a valid piece of code/data.
+    pub const INVALID_FILE_OFFSET: blaze_normalize_reason = blaze_normalize_reason(3);
+    /// The symbolization source has no or no relevant symbols.
+    pub const MISSING_SYMS: blaze_normalize_reason = blaze_normalize_reason(4);
+    /// The address could not be found in the symbolization source.
+    pub const UNKNOWN_ADDR: blaze_normalize_reason = blaze_normalize_reason(5);
 }
 
 impl From<Reason> for blaze_normalize_reason {
@@ -501,6 +507,9 @@ impl From<Reason> for blaze_normalize_reason {
             Reason::Unmapped => blaze_normalize_reason::UNMAPPED,
             Reason::MissingComponent => blaze_normalize_reason::MISSING_COMPONENT,
             Reason::Unsupported => blaze_normalize_reason::UNSUPPORTED,
+            Reason::InvalidFileOffset => blaze_normalize_reason::INVALID_FILE_OFFSET,
+            Reason::MissingSyms => blaze_normalize_reason::MISSING_SYMS,
+            Reason::UnknownAddr => blaze_normalize_reason::UNKNOWN_ADDR,
             _ => unreachable!(),
         }
     }
@@ -509,13 +518,18 @@ impl From<Reason> for blaze_normalize_reason {
 
 /// Retrieve a textual representation of the reason of a normalization failure.
 #[no_mangle]
-pub extern "C" fn blaze_normalize_reason_str(err: blaze_normalize_reason) -> *const c_char {
-    match err {
+pub extern "C" fn blaze_normalize_reason_str(reason: blaze_normalize_reason) -> *const c_char {
+    match reason {
         blaze_normalize_reason::UNMAPPED => Reason::Unmapped.as_bytes().as_ptr().cast(),
         blaze_normalize_reason::MISSING_COMPONENT => {
             Reason::MissingComponent.as_bytes().as_ptr().cast()
         }
         blaze_normalize_reason::UNSUPPORTED => Reason::Unsupported.as_bytes().as_ptr().cast(),
+        blaze_normalize_reason::INVALID_FILE_OFFSET => {
+            Reason::InvalidFileOffset.as_bytes().as_ptr().cast()
+        }
+        blaze_normalize_reason::MISSING_SYMS => Reason::MissingSyms.as_bytes().as_ptr().cast(),
+        blaze_normalize_reason::UNKNOWN_ADDR => Reason::UnknownAddr.as_bytes().as_ptr().cast(),
         _ => b"unknown reason\0".as_ptr().cast(),
     }
 }
@@ -963,6 +977,12 @@ mod tests {
                 blaze_normalize_reason::MISSING_COMPONENT,
             ),
             (Reason::Unsupported, blaze_normalize_reason::UNSUPPORTED),
+            (
+                Reason::InvalidFileOffset,
+                blaze_normalize_reason::INVALID_FILE_OFFSET,
+            ),
+            (Reason::MissingSyms, blaze_normalize_reason::MISSING_SYMS),
+            (Reason::UnknownAddr, blaze_normalize_reason::UNKNOWN_ADDR),
         ];
 
         for (reason, expected) in data {

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -460,6 +460,8 @@ pub type blaze_symbolizer = Symbolizer;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct blaze_symbolize_reason(u8);
 
+// Please adjust `blaze_normalize_reason` as well when adding a new
+// variant.
 impl blaze_symbolize_reason {
     /// Symbolization was successful.
     pub const SUCCESS: blaze_symbolize_reason = blaze_symbolize_reason(0);
@@ -499,8 +501,8 @@ impl From<Reason> for blaze_symbolize_reason {
 /// Retrieve a textual representation of the reason of a symbolization
 /// failure.
 #[no_mangle]
-pub extern "C" fn blaze_symbolize_reason_str(err: blaze_symbolize_reason) -> *const c_char {
-    match err {
+pub extern "C" fn blaze_symbolize_reason_str(reason: blaze_symbolize_reason) -> *const c_char {
+    match reason {
         blaze_symbolize_reason::SUCCESS => b"success\0".as_ptr().cast(),
         blaze_symbolize_reason::UNMAPPED => Reason::Unmapped.as_bytes().as_ptr().cast(),
         blaze_symbolize_reason::INVALID_FILE_OFFSET => {


### PR DESCRIPTION
With commit 59942c900c54 ("Merged normalize::Reason and symbolize::Reason") we merged the two Reason enums employed by the main crate. As a result, it is now possible for the C API to receive symbolization reason variants, but currently it cannot handle converting them into a blaze_normalize_reason object.
Make these new reasons known and wire them up to the conversion routine. Note that ideally we'd be unifying blaze_symbolize_reason and blaze_normalize_reason as well, but we cannot for binary compatibility reasons: equally named variants have assigned to them different values.