### PR TITLE
capi: Add test for failed vDSO normalization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,9 @@ pub mod __private {
     pub use crate::test_helper::find_the_answer_fn;
     #[cfg(feature = "test")]
     pub use crate::test_helper::find_the_answer_fn_in_zip;
+    #[cfg(linux)]
+    #[cfg(feature = "test")]
+    pub use crate::test_helper::find_vdso_range;
 }
 
 

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 use std::mem::transmute;
 #[cfg(linux)]
 use std::ops::ControlFlow;
+use std::ops::Range;
 use std::path::Path;
 #[cfg(linux)]
 use std::slice;
@@ -70,6 +71,12 @@ pub fn find_the_answer_fn_in_zip(mmap: &Mmap) -> (inspect::SymInfo<'static>, Add
 
     let (sym, the_answer_addr) = find_the_answer_fn(&elf_mmap);
     (sym, the_answer_addr)
+}
+
+/// Find the range of the sytem's vDSO.
+#[cfg(linux)]
+pub fn find_vdso_range() -> Range<Addr> {
+    find_vdso().unwrap().unwrap()
 }
 
 /// Find the address of the `gettimeofday` function in the given


### PR DESCRIPTION
Add a test for the failed normalization of an address inside a vDSO. This effectively is a regression test for commit d4e1733e4369 ("capi: Add missing blaze_normalize_reason variants"), without which we would panic.