### PR TITLE
capi: Bump version to `0.1.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "blazesym-c"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bindgen",
  "blazesym",

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.3
+-----
 - Fixed potential panic when normalizing vDSO addresses
 
 

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym-c"
 description = "C bindings for blazesym"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Daniel Müller <deso@posteo.net>"]

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1,7 +1,7 @@
 /*
  * Please refer to the documentation hosted at
  *
- *   https://docs.rs/blazesym-c/0.1.2
+ *   https://docs.rs/blazesym-c/0.1.3
  */
 
 


### PR DESCRIPTION
This change bumps the blazesym-c's version to `0.1.3`. The following notable changes have been made since `0.1.2`:
- Fixed potential panic when normalizing vDSO addresses