### PR TITLE
Fix documentation for more private items

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -64,7 +64,8 @@ typedef int16_t blaze_err;
 #define BLAZE_ERR_INVALID_INPUT -256
 /**
  * An error returned when an operation could not be completed
- * because a call to [`write`] returned [`Ok(0)`].
+ * because a call to [`write`][std::io::Write::write] returned
+ * [`Ok(0)`][Ok].
  */
 #define BLAZE_ERR_WRITE_ZERO -257
 /**

--- a/capi/src/error.rs
+++ b/capi/src/error.rs
@@ -35,7 +35,8 @@ impl blaze_err {
     /// A parameter was incorrect.
     pub const INVALID_INPUT: blaze_err = blaze_err(-256);
     /// An error returned when an operation could not be completed
-    /// because a call to [`write`] returned [`Ok(0)`].
+    /// because a call to [`write`][std::io::Write::write] returned
+    /// [`Ok(0)`][Ok].
     pub const WRITE_ZERO: blaze_err = blaze_err(-257);
     /// An error returned when an operation ould not be completed
     /// because an "end of file" was reached prematurely.

--- a/src/error.rs
+++ b/src/error.rs
@@ -312,7 +312,8 @@ pub enum ErrorKind {
     /// The I/O operation's timeout expired, causing it to be canceled.
     TimedOut,
     /// An error returned when an operation could not be completed
-    /// because a call to [`write`] returned [`Ok(0)`].
+    /// because a call to [`write`][std::io::Write::write] returned
+    /// [`Ok(0)`][Ok].
     WriteZero,
     /// This operation is unsupported on this platform.
     Unsupported,

--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -11,11 +11,11 @@ use super::types::INFO_TYPE_LINE_TABLE_INFO;
 
 /// End of the line table
 const END_SEQUENCE: u8 = 0x00;
-/// Set [`LineTableRow.file_idx`], don't push a row.
+/// Set [`LineTableRow::file_idx`], don't push a row.
 const SET_FILE: u8 = 0x01;
-/// Increment [`LineTableRow.address`], and push a row.
+/// Increment [`LineTableRow::addr`] and push a row.
 const ADVANCE_PC: u8 = 0x02;
-/// Set [`LineTableRow.file_line`], don't push a row.
+/// Set [`LineTableRow::file_line`], don't push a row.
 const ADVANCE_LINE: u8 = 0x03;
 /// All special opcodes push a row.
 const FIRST_SPECIAL: u8 = 0x04;


### PR DESCRIPTION
With commit 364299374fcd ("Document private items in documentation CI job") we started checking the documentation for private items. Since then it appears as if rustc has included more elements in said checks, causing CI to fail. Fix those.