### PR TITLE
Add CHANGELOG entry for #1209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Added `Symbolizer::register_elf_resolver` method
+
+
 0.2.0-rc.4
 ----------
 - Added support for symbolizing addresses in a vDSO

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -1607,7 +1607,8 @@ fn symbolize_normalized_large_memsize() {
     });
 }
 
-#[cfg(linux)]
+/// Make sure that registering an [`ElfResolver`] with a [`Symbolizer`]
+/// fails if one is already present for a given path.
 #[test]
 fn register_an_existing_elfresolver() {
     let bin_name = Path::new(&env!("CARGO_MANIFEST_DIR"))
@@ -1616,13 +1617,13 @@ fn register_an_existing_elfresolver() {
 
     let resolver = Rc::new(ElfResolver::open(&bin_name).unwrap());
     let mut symbolizer = Symbolizer::new();
-    symbolizer
+    let () = symbolizer
         .register_elf_resolver(&bin_name, Rc::clone(&resolver))
         .unwrap();
 
-    let result = symbolizer
+    let err = symbolizer
         .register_elf_resolver(&bin_name, Rc::clone(&resolver))
         .unwrap_err();
 
-    assert_eq!(result.kind(), ErrorKind::AlreadyExists);
+    assert_eq!(err.kind(), ErrorKind::AlreadyExists);
 }


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #1209, which added a new public API method, `register_elf_resolver()`, to the `Symbolizer` type. While at it, fix up a few minor cosmetic issues and add a test for the `ElfResolverData` From impl.