### PR TITLE
ElfResolver creation must not crash with non-existing file

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -164,7 +164,7 @@ impl ElfResolver {
         P: AsRef<Path>,
     {
         let path = path.as_ref();
-        let parser = Rc::new(ElfParser::open(path).unwrap());
+        let parser = Rc::new(ElfParser::open(path)?);
         Self::from_parser(
             parser,
             Some(

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -1677,3 +1677,13 @@ fn register_an_existing_elfresolver() {
 
     assert_eq!(err.kind(), ErrorKind::AlreadyExists);
 }
+
+/// Make sure that creating an [`ElfResolver`] from a non-existing file
+/// fails with an actual error instead of panicking.
+#[test]
+fn create_elf_resolver_from_non_existing_path() {
+    let path = Path::new("/This/Path/Does.Not/Exist");
+    let err = ElfResolver::open(path).unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+}


### PR DESCRIPTION
This PR addresses the [issue ](https://github.com/libbpf/blazesym/issues/1221).

# Motivation
Prevent `ElfResolver::open` from panicking when it cannot handle cases where the file cannot be opened or does not exist.

# Testing
Added a new test