### PR TITLE
Update usage blurb in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ guaranteed to build with `1.63` and higher.
 
 
 ## Status
-**blazesym** is at the core of Meta's internal continuous profiling solution,
-where it handles billions of symbolization requests per day.
+**blazesym** is at the core of Meta's continuous profiling solution,
+[Strobelight][strobelight], where it handles billions of symbolization
+requests per day. It also powers the company's crash dump backtrace
+symbolization and is helping developers identify performance bottlenecks
+across millions of Quest Virtual Reality devices.
 
 The library is being actively worked on, with a major goal being stabilization
 of the API surface. Feel free to contribute with discussions, feature
@@ -115,3 +118,4 @@ Statically linked binaries for various target triples are available on-demand
 
 [blazecli-bins]: https://github.com/libbpf/blazesym/actions/workflows/build-cli.yml
 [cargo-semver]: https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility
+[strobelight]: https://engineering.fb.com/2025/01/21/production-engineering/strobelight-a-profiling-service-built-on-open-source-technology/

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -468,9 +468,9 @@ where
     /// `idx`.
     ///
     /// # Notes
-    /// This method returns potentially compressed data, but adheres is
-    /// able to do so with 'elf lifetime. To transparently decompress,
-    /// use [`Cache::section_data`] instead.
+    /// This method returns potentially compressed data, but is able to
+    /// do so with the `'elf` lifetime. To transparently decompress, use
+    /// [`Cache::section_data`] instead.
     fn section_data_raw(&self, idx: usize) -> Result<Cow<'elf, [u8]>> {
         let shdr = self.section_hdr(idx)?;
         if shdr.type_() != SHT_NOBITS {


### PR DESCRIPTION
Strobelight has been announced publicly and we should reference the corresponding blog article. While at it, also allude to additional known usages.