### PR TITLE
Relax libbpf-sys version requirement

### DIFF
--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -40,7 +40,7 @@ zip = {version = "4", optional = true, default-features = false}
 zstd = {version = "0.13.3", default-features = false, optional = true}
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.build-dependencies]
-libbpf-sys = {version = "1.6.1", default-features = false, optional = true}
+libbpf-sys = {version = "1.6", default-features = false, optional = true}
 
 [dependencies]
 # TODO: Enable `zstd` feature once toolchain support for it is more


### PR DESCRIPTION
Relax the libbpf-sys version requirement. At this point we don't care about the patch level.