### PR TITLE
Use gimli::Result typedef more

### DIFF
--- a/src/dwarf/lines.rs
+++ b/src/dwarf/lines.rs
@@ -51,7 +51,7 @@ fn render_file<'dwarf>(
     unit: gimli::UnitRef<'_, R<'dwarf>>,
     file: &gimli::FileEntry<R<'dwarf>, <R<'dwarf> as gimli::Reader>::Offset>,
     header: &gimli::LineProgramHeader<R<'dwarf>, <R<'dwarf> as gimli::Reader>::Offset>,
-) -> Result<(Cow<'dwarf, Path>, &'dwarf OsStr), gimli::Error> {
+) -> gimli::Result<(Cow<'dwarf, Path>, &'dwarf OsStr)> {
     let dir = if let Some(ref comp_dir) = unit.comp_dir {
         bytes_to_path(comp_dir.slice())?
     } else {
@@ -99,7 +99,7 @@ impl<'dwarf> Lines<'dwarf> {
     pub(crate) fn parse(
         unit: gimli::UnitRef<'_, R<'dwarf>>,
         ilnp: gimli::IncompleteLineProgram<R<'dwarf>, <R<'dwarf> as gimli::Reader>::Offset>,
-    ) -> Result<Self, gimli::Error> {
+    ) -> gimli::Result<Self> {
         let mut sequences = Vec::new();
         let mut sequence_rows = Vec::<LineRow>::new();
         let mut rows = ilnp.rows();

--- a/src/dwarf/location.rs
+++ b/src/dwarf/location.rs
@@ -63,7 +63,7 @@ impl<'unit, 'dwarf> LocationRangeUnitIter<'unit, 'dwarf> {
         units: &Units<'dwarf>,
         probe_low: u64,
         probe_high: u64,
-    ) -> Result<Option<Self>, gimli::Error> {
+    ) -> gimli::Result<Option<Self>> {
         let unit_ref = units.unit_ref(unit.dw_unit());
         let lines = unit.parse_lines(unit_ref)?;
 

--- a/src/dwarf/range.rs
+++ b/src/dwarf/range.rs
@@ -49,7 +49,7 @@ impl<R: gimli::Reader> RangeAttributes<R> {
         &self,
         unit: gimli::UnitRef<'_, R>,
         mut f: F,
-    ) -> Result<bool, gimli::Error> {
+    ) -> gimli::Result<bool> {
         let mut added_any = false;
         let mut add_range = |range: gimli::Range| {
             if range.begin < range.end {

--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -72,7 +72,7 @@ impl<'dwarf> Unit<'dwarf> {
     pub(super) fn parse_functions<'unit>(
         &'unit self,
         units: &Units<'dwarf>,
-    ) -> Result<&'unit Functions<'dwarf>, gimli::Error> {
+    ) -> gimli::Result<&'unit Functions<'dwarf>> {
         let unit = units.unit_ref(&self.dw_unit);
         let functions = self.parse_functions_dwarf_and_unit(unit, units)?;
         Ok(functions)
@@ -83,7 +83,7 @@ impl<'dwarf> Unit<'dwarf> {
     pub(super) fn parse_inlined_functions<'unit>(
         &'unit self,
         units: &Units<'dwarf>,
-    ) -> Result<&'unit Functions<'dwarf>, gimli::Error> {
+    ) -> gimli::Result<&'unit Functions<'dwarf>> {
         self.funcs.get_or_try_init_(|| {
             let unit = units.unit_ref(&self.dw_unit);
             let funcs = Functions::parse(unit, units)?;
@@ -95,7 +95,7 @@ impl<'dwarf> Unit<'dwarf> {
     pub(super) fn parse_lines(
         &self,
         unit: gimli::UnitRef<'_, R<'dwarf>>,
-    ) -> Result<Option<&Lines<'dwarf>>, gimli::Error> {
+    ) -> gimli::Result<Option<&Lines<'dwarf>>> {
         // NB: line information is always stored in the main debug file so this does not
         // need to handle DWOs.
         let ilnp = match unit.unit.line_program {
@@ -111,7 +111,7 @@ impl<'dwarf> Unit<'dwarf> {
         &self,
         probe: u64,
         units: &Units<'dwarf>,
-    ) -> Result<Option<Location<'_>>, gimli::Error> {
+    ) -> gimli::Result<Option<Location<'_>>> {
         if let Some(mut iter) = LocationRangeUnitIter::new(self, units, probe, probe + 1)? {
             match iter.next() {
                 None => Ok(None),
@@ -126,7 +126,7 @@ impl<'dwarf> Unit<'dwarf> {
         &self,
         unit: gimli::UnitRef<'_, R<'dwarf>>,
         units: &Units<'dwarf>,
-    ) -> Result<&Functions<'dwarf>, gimli::Error> {
+    ) -> gimli::Result<&Functions<'dwarf>> {
         self.funcs
             .get_or_try_init_(|| Functions::parse(unit, units))
     }
@@ -135,7 +135,7 @@ impl<'dwarf> Unit<'dwarf> {
         &self,
         probe: u64,
         units: &Units<'dwarf>,
-    ) -> Result<Option<&Function<'dwarf>>, gimli::Error> {
+    ) -> gimli::Result<Option<&Function<'dwarf>>> {
         let unit = units.unit_ref(&self.dw_unit);
         let functions = self.parse_functions_dwarf_and_unit(unit, units)?;
         let function = match functions.find_address(probe) {
@@ -153,7 +153,7 @@ impl<'dwarf> Unit<'dwarf> {
         &'slf self,
         name: &str,
         units: &Units<'dwarf>,
-    ) -> Result<Option<&'slf Function<'dwarf>>, gimli::Error> {
+    ) -> gimli::Result<Option<&'slf Function<'dwarf>>> {
         let unit = units.unit_ref(&self.dw_unit);
         let functions = self.parse_functions_dwarf_and_unit(unit, units)?;
         for func in functions.functions.iter() {


### PR DESCRIPTION
Use the `gimli::Result` typedef more instead of the longer `Result<..., gimli::Error>` construct.