### PR TITLE
Add TODO for caching debug link targets

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -112,6 +112,9 @@ fn find_debug_file(file: &OsStr, linker: Option<&Path>, debug_dirs: &[PathBuf]) 
 }
 
 
+// TODO: We really should have a cache of debug link targets as well, to
+//       avoid potentially re-parsing the same files over and over
+//       again.
 fn try_deref_debug_link(
     parser: &ElfParser,
     debug_dirs: &[PathBuf],


### PR DESCRIPTION
We really should be maintaining a cache of debug link targets or, actually, just include them in our per-Symbolizer cache of ELF files. Right now if multiple files have the same debug target we would end up re-parsing each. Add a TODO to address this deficiency in the future.