### PR TITLE
Simplify load_section() slightly

### DIFF
--- a/src/dwarf/reader.rs
+++ b/src/dwarf/reader.rs
@@ -23,9 +23,6 @@ pub(super) fn load_section(parser: &ElfParser, id: SectionId) -> Result<R<'_>> {
         None => &[],
     };
 
-    #[cfg(target_endian = "little")]
-    let reader = EndianSlice::new(data, gimli::LittleEndian);
-    #[cfg(target_endian = "big")]
-    let reader = EndianSlice::new(data, gimli::BigEndian);
+    let reader = EndianSlice::new(data, Endianess::default());
     Ok(reader)
 }


### PR DESCRIPTION
Simplify the `load_section()` function slightly, by reusing the module local `Endianess` type instead of duplicating the conditional logic.