### PR TITLE
Recognize C++ 17 & 20 DWARF languages

### DIFF
--- a/src/dwarf/resolver.rs
+++ b/src/dwarf/resolver.rs
@@ -78,7 +78,9 @@ impl From<Option<gimli::DwLang>> for SrcLang {
                 gimli::DW_LANG_C_plus_plus
                 | gimli::DW_LANG_C_plus_plus_03
                 | gimli::DW_LANG_C_plus_plus_11
-                | gimli::DW_LANG_C_plus_plus_14,
+                | gimli::DW_LANG_C_plus_plus_14
+                | gimli::DW_LANG_C_plus_plus_17
+                | gimli::DW_LANG_C_plus_plus_20,
             ) => SrcLang::Cpp,
             _ => SrcLang::Unknown,
         }


### PR DESCRIPTION
Recognize the DWARF constants representing the C++ 17 & 20 languages and map them to our notion of C++. This way, demangling is expected to work correctly on symbols in DWARF data for these languages.