### PR TITLE
Loosen tempfile version requirement

### DIFF
--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -33,7 +33,7 @@ dont-generate-unit-test-files = []
 dump_syms = {version = "2.3", optional = true, default-features = false}
 libc = "0.2"
 reqwest = {version = "0.12", optional = true, features = ["blocking"]}
-tempfile = {version = "3.21", optional = true}
+tempfile = {version = "3", optional = true}
 vmlinux = {git = "https://github.com/libbpf/vmlinux.h.git", rev = "a9c092aa771310bf8b00b5018f7d40a1fdb6ec82"}
 xz2 = {version = "0.1.7", optional = true}
 zip = {version = "4", optional = true, default-features = false}


### PR DESCRIPTION
Loosen the tempfile version requirement to keep Dependabot from bumping versions in our Cargo.toml manifest.