### PR TITLE
Derive Debug impl for more DWARF types

### DIFF
--- a/src/dwarf/function.rs
+++ b/src/dwarf/function.rs
@@ -121,6 +121,7 @@ struct InlinedState<'call, 'dwarf> {
     units: &'call Units<'dwarf>,
 }
 
+#[derive(Debug)]
 pub(super) struct InlinedFunction<'dwarf> {
     pub(crate) name: Option<R<'dwarf>>,
     pub(crate) call_file: Option<u64>,

--- a/src/dwarf/lines.rs
+++ b/src/dwarf/lines.rs
@@ -79,12 +79,14 @@ fn render_file<'dwarf>(
 }
 
 
+#[derive(Debug)]
 pub(crate) struct LineSequence {
     pub(crate) start: u64,
     pub(crate) end: u64,
     pub(crate) rows: Box<[LineRow]>,
 }
 
+#[derive(Debug)]
 pub(crate) struct LineRow {
     pub(crate) address: u64,
     pub(crate) file_index: u64,
@@ -92,6 +94,7 @@ pub(crate) struct LineRow {
     pub(crate) column: u32,
 }
 
+#[derive(Debug)]
 pub(crate) struct Lines<'dwarf> {
     pub(crate) files: Box<[(Cow<'dwarf, Path>, &'dwarf OsStr)]>,
     pub(crate) sequences: Box<[LineSequence]>,

--- a/src/dwarf/unit.rs
+++ b/src/dwarf/unit.rs
@@ -42,6 +42,7 @@ pub(super) struct UnitRange {
 }
 
 
+#[derive(Debug)]
 pub(super) struct Unit<'dwarf> {
     offset: gimli::DebugInfoOffset<<R<'dwarf> as gimli::Reader>::Offset>,
     dw_unit: gimli::Unit<R<'dwarf>>,


### PR DESCRIPTION
It can be hard to printf-debug DWARF code because some of our types don't implement `Debug`. Fix that.