### PR TITLE
Add CI workflow to enable auto-merge for Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,29 @@
+# Adapted from https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'libbpf/blazesym'
+    steps:
+      - name: Check if Cargo.lock was modified
+        id: check_cargo_lock
+        run: |
+          # For the time being, we only enable auto-merge for changes
+          # confined to Cargo.lock.
+          if [ "$(git show --no-prefix --name-only --format='' HEAD)" = "Cargo.lock" ]; then
+            echo "enable_auto_merge=true" >> $GITHUB_OUTPUT
+          else
+            echo "enable_auto_merge=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Enable auto-merge
+        if: steps.check_cargo_lock.outputs.enable_auto_merge == 'true'
+        run: gh pr merge --auto --merge "${{ github.event.pull_request.html_url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a CI workflow to enable auto-merge for certain Dependabot update pull requests. For now we constrain the feature to those PRs *only* modifying Cargo.lock (and not Cargo.toml).
I haven't really tested this workflow yet, for lack of an easy test setup. So we shall see how that things behaves over time.