### PR TITLE
Provide Units reference to Unit::parse_lines()

### DIFF
--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -340,7 +340,7 @@ impl<'dwarf> Units<'dwarf> {
                 .unwrap_or("");
 
             let code_info = if let Some(call_file) = inlined_fn.call_file {
-                if let Some(lines) = unit.parse_lines(unit_ref)? {
+                if let Some(lines) = unit.parse_lines(self)? {
                     if let Some((dir, file)) = lines.files.get(call_file as usize) {
                         let code_info = Location {
                             dir,
@@ -437,8 +437,7 @@ impl<'dwarf> Units<'dwarf> {
     #[cfg(feature = "nightly")]
     fn parse_lines(&self) -> gimli::Result<()> {
         for unit in self.units.iter() {
-            let unit_ref = self.unit_ref(unit.dw_unit());
-            let _lines = unit.parse_lines(unit_ref)?;
+            let _lines = unit.parse_lines(self)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Passing a readily-formed `UnitRef` to `Unit::parse_lines()` is dangerous, because it can easily lead to shenanigans such as the contained DWARF unit not actually the same one as that referenced by the `Unit` object itself.
Prevent such scenarios from occurring by requiring a Units reference as input instead of a UnitRef.