### PR TITLE
Use rebasing instead of merging in dependabot-merge workflow

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -27,6 +27,6 @@ jobs:
           fi
       - name: Enable auto-merge
         if: steps.check_cargo_lock.outputs.enable_auto_merge == 'true'
-        run: gh pr merge --auto --merge "${{ github.event.pull_request.html_url }}"
+        run: gh pr merge --auto --rebase "${{ github.event.pull_request.html_url }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Current logic for enabling auto-merge now fails with:
> Merge method merge commits are not allowed on this repository
> (enablePullRequestAutoMerge)

The reason seems to be our usage of the --merge option. Let's try with --rebase and see how many more issues we have to work around from here on out. If only "merge" wasn't the most overloaded term ever.