### PR TITLE
Loosen rustc-demangle version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ libc = "0.2"
 memmap2 = {version = "0.9", default-features = false}
 miniz_oxide = {version = "0.8", default-features = false, features = ["simd", "with-alloc"], optional = true}
 nom = {version = "7", optional = true}
-rustc-demangle = {version = "0.1.26", optional = true}
+rustc-demangle = {version = "0.1", optional = true}
 tracing = {version = "0.1.38", default-features = false, features = ["attributes"], optional = true}
 zstd = {version = "0.13.3", default-features = false, optional = true}
 


### PR DESCRIPTION
Loosen the `rustc-demangle` version requirement to keep Dependabot from bumping versions in our Cargo.toml manifest.