### PR TITLE
Specify Dependabot update time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "05:00"
+      timezone: "America/Los_Angeles"
   - package-ecosystem: "cargo"
     versioning-strategy: "auto"
     directory: "/"
     schedule:
       interval: "daily"
+      time: "06:00"
+      timezone: "America/Los_Angeles"


### PR DESCRIPTION
Specify a saner time for Dependabot to perform its updates rather than "some time in middle of the day". That's particularly useful now that most (?) updates should go through without interaction, so that these runs don't clog up CI.