### PR TITLE
Fix test-block link failure with stack protector

### DIFF
--- a/data/test-block.c
+++ b/data/test-block.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 
+void __stack_chk_fail(void) {}
 
 void _start(void) {
   char buf[2];


### PR DESCRIPTION
When a system has the stack protector feature enabled, our test-block test program may fail to link, with the linker citing an undefined reference to the __stack_chk_fail() function. Define it to fix this error.

Closes: #1283

Reported-by: Arvid Norlander <VorpalBlade@users.noreply.github.com>