### PR TITLE
Use madvise on Breakpad mmap

### DIFF
--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -11,6 +11,9 @@ use crate::Error;
 use crate::ErrorExt as _;
 use crate::Result;
 
+#[cfg(not(windows))]
+pub(crate) type Advice = memmap2::Advice;
+
 
 #[doc(hidden)]
 #[derive(Debug)]
@@ -91,6 +94,15 @@ impl Mmap {
     /// Map the provided file into memory, in its entirety.
     pub(crate) fn map(file: &File) -> Result<Self> {
         Self::builder().map(file)
+    }
+
+    /// Provide a hint about the mapping to the kernel.
+    #[cfg(not(windows))]
+    pub(crate) fn advise(&self, advise: Advice) -> Result<()> {
+        self.mapping
+            .as_ref()
+            .map(|mmap| mmap.advise(advise).map_err(Error::from))
+            .unwrap_or(Ok(()))
     }
 
     /// Create a new `Mmap` object (sharing the same underlying memory mapping


### PR DESCRIPTION
Our Breakpad parser literally parses the source file in question in its entirety. It seems prudent to hint to the kernel that this is happening, so that it may employ heuristics to optimize for this case. Use `madvise(MADV_WILLNEED)` to do so. Benefits are marginal as per my measurements, with perhaps a decrease in page faults from ~150k down to 140k. However, different kernel may behave differently and it seems reasonable to provide this hint irrespectively.
Real wins are gained with `MADV_POPULATE_READ` (down to ~40k-60k), but it's Linux specific (not a huge deal) and with the drawback that
  > the process can be killed at any moment when the system runs out of memory

which seems like a potentially big downside.