### PR TITLE
Loosen tempfile version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ criterion = {version = "0.7", default-features = false, features = ["rayon", "ca
 rand = {version = "0.9", default-features = false, features = ["std", "thread_rng"]}
 scopeguard = "1.2"
 stats_alloc = {version = "0.1.1", features = ["nightly"]}
-tempfile = "3.21"
+tempfile = "3"
 test-fork = "0.1"
 test-log = {version = "0.2.18", default-features = false, features = ["trace"]}
 test-tag = "0.1.3"

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -85,7 +85,7 @@ blazesym = {version = "=0.2.0-rc.5", path = "../", features = ["test"]}
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}
 bindgen = {version = "0.72", default-features = false, features = ["runtime"]}
 criterion = {version = "0.7", default-features = false, features = ["rayon", "cargo_bench_support"]}
-tempfile = "3.21"
+tempfile = "3"
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
 test-tag = "0.1"
 


### PR DESCRIPTION
Loosen the tempfile version requirement to keep Dependabot from bumping versions in our Cargo.toml manifest.