### PR TITLE
Don't use empty square brackets for rustdoc links

### DIFF
--- a/src/normalize/normalizer.rs
+++ b/src/normalize/normalizer.rs
@@ -341,7 +341,7 @@ impl Normalizer {
 
     /// Normalize addresses belonging to a process.
     ///
-    /// A convenience wrapper around [`Normalizer::normalize_user_addrs_opts`][]
+    /// A convenience wrapper around [`Normalizer::normalize_user_addrs_opts`]
     /// that uses the default normalization options.
     pub fn normalize_user_addrs(&self, pid: Pid, addrs: &[Addr]) -> Result<UserOutput<'_>> {
         self.normalize_user_addrs_opts(pid, addrs, &NormalizeOpts::default())

--- a/src/symbolize/source.rs
+++ b/src/symbolize/source.rs
@@ -269,7 +269,7 @@ pub struct Process {
     /// built with the `dwarf` feature to actually consult debug
     /// symbols. If neither is satisfied, ELF symbols will be used.
     pub debug_syms: bool,
-    /// Whether to incorporate a process' [perf map][] file into the
+    /// Whether to incorporate a process' [perf map] file into the
     /// symbolization procedure.
     ///
     /// Perf map files mostly have relevance in just-in-time compiled languages,


### PR DESCRIPTION
Rustdoc doesn't require the usage of empty square brackets for links, so don't provide them.