### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.2.0
+-----
 - Adjusted `symbolize::{Resolved,}Sym::code_info` to be heap allocated
 - Made `symbolize::ResolvedSym` non-exhaustive
 - Report special module string when symbolizing vDSO and BPF symbols

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "blazesym"
-version = "0.2.0-rc.5"
+version = "0.2.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ wildcard-imports = "warn"
 [package]
 name = "blazesym"
 description = "blazesym is a library for address symbolization and related tasks."
-version = "0.2.0-rc.5"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Daniel Müller <deso@posteo.net>", "Kui-Feng <thinker.li@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -34,15 +34,11 @@ guaranteed to build with `1.63` and higher.
 
 
 ## Status
-**blazesym** is at the core of Meta's continuous profiling solution,
-[Strobelight][strobelight], where it handles billions of symbolization
-requests per day. It also powers the company's crash dump backtrace
-symbolization and is helping developers identify performance bottlenecks
-across millions of Quest Virtual Reality devices.
-
-The library is being actively worked on, with a major goal being stabilization
-of the API surface. Feel free to contribute with discussions, feature
-suggestions, or code contributions!
+**blazesym** is being used in production: it is at the core of Meta's continuous
+profiling solution, [Strobelight][strobelight], where it handles billions of
+symbolization requests per day. It also powers the company's crash dump
+backtrace symbolization and is helping developers identify performance
+bottlenecks across millions of Quest Virtual Reality devices.
 
 As alluded to above, the library provides support for a variety of formats. For
 symbolization specifically, the following table lays out what features each
@@ -87,7 +83,7 @@ project manager (e.g., `cargo build`).
 Consumption from a Rust project should happen via `Cargo.toml`:
 ```toml
 [dependencies]
-blazesym = "=0.2.0-rc.5"
+blazesym = "0.2"
 ```
 
 For a quick set of examples please refer to the [`examples/` folder](examples/).

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Bumped `blazesym` dependency to `0.2.0`
+
+
 0.1.4
 -----
 - Bumped `blazesym` dependency to `0.2.0-rc.5`

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -70,7 +70,7 @@ which = {version = "8.0.0", optional = true}
 # Pinned, because we use #[doc(hidden)] APIs.
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-rc.5", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
+blazesym = {version = "=0.2.0", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
 libc = "0.2"
 # TODO: Remove dependency once MSRV is 1.77.
 memoffset = "0.9"
@@ -78,10 +78,10 @@ tracing = "0.1"
 tracing-subscriber = {version = "0.3", default-features = false, features = ["fmt"]}
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-blazesym = {version = "=0.2.0-rc.5", path = "../", features = ["bpf"]}
+blazesym = {version = "=0.2.0", path = "../", features = ["bpf"]}
 
 [dev-dependencies]
-blazesym = {version = "=0.2.0-rc.5", path = "../", features = ["test"]}
+blazesym = {version = "=0.2.0", path = "../", features = ["test"]}
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}
 bindgen = {version = "0.72", default-features = false, features = ["runtime"]}
 criterion = {version = "0.7", default-features = false, features = ["rayon", "cargo_bench_support"]}

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Bumped `blazesym` dependency to `0.2.0`
+
+
 0.1.11
 ------
 - Bumped `blazesym` dependency to `0.2.0-rc.5`

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,14 +40,14 @@ anyhow = "1.0"
 bufio = "0.1"
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = "=0.2.0-rc.5", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
+blazesym = {version = "0.2", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
 clap = {version = "4.5", features = ["derive"]}
 clap_complete = {version = "4.5", optional = true}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["ansi", "env-filter", "fmt"]}
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-blazesym = {version = "=0.2.0-rc.5", path = "../", features = ["bpf"]}
+blazesym = {version = "0.2", path = "../", features = ["bpf"]}
 
 [lints]
 workspace = true

--- a/cli/README.md
+++ b/cli/README.md
@@ -63,5 +63,5 @@ the list of supported shells.
 
 [blazecli-bins]: https://github.com/libbpf/blazesym/actions/workflows/build-cli.yml
 [blazesym]: https://crates.io/crates/blazesym
-[blazesym-sym]: https://docs.rs/blazesym/0.2.0-rc.5/blazesym/symbolize/struct.Symbolizer.html
-[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0-rc.5/blazesym/symbolize/enum.Source.html#variant.Elf
+[blazesym-sym]: https://docs.rs/blazesym/0.2.0/blazesym/symbolize/struct.Symbolizer.html
+[blazesym-elf-src]: https://docs.rs/blazesym/0.2.0/blazesym/symbolize/enum.Source.html#variant.Elf

--- a/examples/gsym-in-apk/Cargo.toml
+++ b/examples/gsym-in-apk/Cargo.toml
@@ -11,7 +11,7 @@ name = "gsym-in-apk"
 path = "main.rs"
 
 [dependencies]
-blazesym = {version = "=0.2.0-rc.5", path = "../..", default-features = false, features = [
+blazesym = {version = "0.2", path = "../..", default-features = false, features = [
   "apk",
   "gsym",
 ]}

--- a/examples/sym-debuginfod/Cargo.toml
+++ b/examples/sym-debuginfod/Cargo.toml
@@ -12,7 +12,7 @@ path = "main.rs"
 
 [dependencies]
 anyhow = "1.0"
-blazesym = {version = "=0.2.0-rc.5", path = "../..", features = ["tracing"]}
+blazesym = {version = "0.2", path = "../..", features = ["tracing"]}
 clap = {version = "4.5", features = ["derive", "string"]}
 debuginfod = {version = "0.2.1", features = ["fs-cache", "tracing"]}
 tracing = "0.1"


### PR DESCRIPTION
This change bumps the version of the crate to 0.2.0, marking the first stable 0.2 release.