### PR TITLE
Add TODO about exhaustiveness of ResolvedSym type

### DIFF
--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -353,6 +353,9 @@ pub struct ResolvedSym<'src> {
     /// Inlined function information.
     pub inlined: Box<[InlinedFn<'src>]>,
     /// The struct is non-exhaustive and open to extension.
+    // TODO: In the future we may want to make this type exhaustive to
+    //       allow users to construct it easily themselves, in order to
+    //       enable usage of custom "resolvers".
     #[doc(hidden)]
     pub _non_exhaustive: (),
 }


### PR DESCRIPTION
Commit 8e1ba8272638 ("Make ResolvedSym non-exhaustive") made the ResolvedSym type non-exhaustive, to make it more future proof. We may eventually want to make it exhaustive again in order to enable users to create objects of this type when implementing custom resolvers. Add a TODO comment highlighting this fact.