### PR TITLE
Update TODO for AsSymbolize helper trait

### DIFF
--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -536,8 +536,9 @@ impl<'src> Symbolized<'src> {
 
 
 /// A trait helping with upcasting into a `dyn Symbolize`.
-// TODO: This trait is currently necessary because Rust does not yet support
-//       trait upcasting on stable (check `trait_upcasting` feature).
+// TODO: This trait is currently necessary because our MSRV is <1.86.
+//       Once we upgrade to that, we can make use of "native" upcasting
+//       support on stable.
 #[doc(hidden)]
 pub trait AsSymbolize {
     fn as_symbolize(&self) -> &dyn Symbolize;


### PR DESCRIPTION
The AsSymbolize helper trait exists because in the past Rust didn't support trait upcasting. That gap has now been fixed with version 1.86 [0], but our MSRV policy prevents us from updating to it yet. Update the TODO to make it more actionable and hopefully remind us to remove this wart once we can rely on this version.

[0] https://blog.rust-lang.org/2025/04/03/Rust-1.86.0/#trait-upcasting