### PR TITLE
Add "SAFETY" comment about mmap usage

### DIFF
--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -59,6 +59,10 @@ impl Builder {
         } else {
             let opts = MmapOptions::new();
 
+            // SAFETY: The library doesn't modify mmap'ed data, but we cannot
+            //         control users modifying files behind our back. This is a
+            //         systemic problem of contemporary memory mapping
+            //         implementations.
             let mapping = if self.exec {
                 unsafe { opts.map_exec(file) }
             } else {


### PR DESCRIPTION
Usage of memory mapped I/O is inherently problematic in Rust, because of its strong aliasing assumptions, which can break when data is modified behind its back. This is nothing that we expect users to do, but we cannot prevent it either (we could, conceivably, refuse to work on writable files, but there is no guarantee they will stay that way and the usability hit would in all likelihood be unacceptable). Add a SAFETY comment alluding to the situation at the usage site of the mmap APIs.