### PR TITLE
Unify Symbolizer::symbolize{,_single} implementations

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -22,13 +22,16 @@ use crate::Addr;
 
 
 #[cfg(feature = "tracing")]
-pub(crate) struct Hexify<'addrs>(pub &'addrs [Addr]);
+pub(crate) struct Hexify<T>(pub T);
 
 #[cfg(feature = "tracing")]
-impl Debug for Hexify<'_> {
+impl<T> Debug for Hexify<T>
+where
+    T: AsRef<[Addr]>,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let mut lst = f.debug_list();
-        for addr in self.0 {
+        for addr in self.0.as_ref() {
             let _lst = lst.entry(&format_args!("{addr:#x}"));
         }
         lst.finish()


### PR DESCRIPTION
Unify the implementations of the Symbolizer::symbolize() and Symbolizer::symbolize_single() methods. In the past, for various reasons pertaining to Rust intricacies, these two methods had largely distinct implementations, which lead to an unfortunate amount of code duplication as well as the maintenance of separate "lists" of supported address types in each.
With this change we employ some generic magic to share a single implementation, while preserving optimality with respect to allocations.