### PR TITLE
Loosen anyhow version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ zstd = {version = "0.13.3", default-features = false, optional = true}
 # For performance comparison; pinned, because we use #[doc(hidden)]
 # APIs.
 addr2line = "=0.25.1"
-anyhow = "1.0.99"
+anyhow = "1.0"
 blazesym-dev = {path = "dev", features = ["generate-unit-test-files"]}
 criterion = {version = "0.7", default-features = false, features = ["rayon", "cargo_bench_support"]}
 rand = {version = "0.9", default-features = false, features = ["std", "thread_rng"]}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,11 +32,11 @@ path = "var/shell-complete.rs"
 required-features = ["clap_complete"]
 
 [build-dependencies]
-anyhow = "1.0.99"
+anyhow = "1.0"
 grev = "0.1.3"
 
 [dependencies]
-anyhow = "1.0.99"
+anyhow = "1.0"
 bufio = "0.1"
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.


### PR DESCRIPTION
Loosen the anyhow version requirement to keep Dependabot from bumping versions in our Cargo.toml manifest.