### PR TITLE
capi: Fix documentation of various `*_addrs` arguments

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1397,7 +1397,7 @@ void blaze_symbolize_cache_process(blaze_symbolizer *symbolizer,
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_process`] object
- * - `abs_addrs` point to an array of `abs_addr_cnt` addresses
+ * - `abs_addrs` needs to point to an array of `abs_addr_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_process_abs_addrs(blaze_symbolizer *symbolizer,
                                                            const struct blaze_symbolize_src_process *src,
@@ -1419,7 +1419,7 @@ const struct blaze_syms *blaze_symbolize_process_abs_addrs(blaze_symbolizer *sym
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_kernel`] object
- * - `abs_addrs` point to an array of `abs_addr_cnt` addresses
+ * - `abs_addrs` needs to point to an array of `abs_addr_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_kernel_abs_addrs(blaze_symbolizer *symbolizer,
                                                           const struct blaze_symbolize_src_kernel *src,
@@ -1441,7 +1441,7 @@ const struct blaze_syms *blaze_symbolize_kernel_abs_addrs(blaze_symbolizer *symb
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
- * - `virt_offsets` point to an array of `virt_offset_cnt` addresses
+ * - `virt_offsets` needs to point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_elf_virt_offsets(blaze_symbolizer *symbolizer,
                                                           const struct blaze_symbolize_src_elf *src,
@@ -1463,7 +1463,7 @@ const struct blaze_syms *blaze_symbolize_elf_virt_offsets(blaze_symbolizer *symb
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
- * - `file_offsets` point to an array of `file_offset_cnt` addresses
+ * - `file_offsets` needs to point to an array of `file_offset_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_elf_file_offsets(blaze_symbolizer *symbolizer,
                                                           const struct blaze_symbolize_src_elf *src,
@@ -1485,7 +1485,7 @@ const struct blaze_syms *blaze_symbolize_elf_file_offsets(blaze_symbolizer *symb
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_gsym_data`] object
- * - `virt_offsets` point to an array of `virt_offset_cnt` addresses
+ * - `virt_offsets` needs to point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_gsym_data_virt_offsets(blaze_symbolizer *symbolizer,
                                                                 const struct blaze_symbolize_src_gsym_data *src,
@@ -1507,7 +1507,7 @@ const struct blaze_syms *blaze_symbolize_gsym_data_virt_offsets(blaze_symbolizer
  * # Safety
  * - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
  * - `src` needs to point to a valid [`blaze_symbolize_src_gsym_file`] object
- * - `virt_offsets` point to an array of `virt_offset_cnt` addresses
+ * - `virt_offsets` needs to point to an array of `virt_offset_cnt` addresses
  */
 const struct blaze_syms *blaze_symbolize_gsym_file_virt_offsets(blaze_symbolizer *symbolizer,
                                                                 const struct blaze_symbolize_src_gsym_file *src,

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -1084,7 +1084,7 @@ unsafe fn blaze_symbolize_impl(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_process`] object
-/// - `abs_addrs` point to an array of `abs_addr_cnt` addresses
+/// - `abs_addrs` needs to point to an array of `abs_addr_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_process_abs_addrs(
     symbolizer: *mut blaze_symbolizer,
@@ -1117,7 +1117,7 @@ pub unsafe extern "C" fn blaze_symbolize_process_abs_addrs(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_kernel`] object
-/// - `abs_addrs` point to an array of `abs_addr_cnt` addresses
+/// - `abs_addrs` needs to point to an array of `abs_addr_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_kernel_abs_addrs(
     symbolizer: *mut blaze_symbolizer,
@@ -1150,7 +1150,7 @@ pub unsafe extern "C" fn blaze_symbolize_kernel_abs_addrs(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
-/// - `virt_offsets` point to an array of `virt_offset_cnt` addresses
+/// - `virt_offsets` needs to point to an array of `virt_offset_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_elf_virt_offsets(
     symbolizer: *mut blaze_symbolizer,
@@ -1189,7 +1189,7 @@ pub unsafe extern "C" fn blaze_symbolize_elf_virt_offsets(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_elf`] object
-/// - `file_offsets` point to an array of `file_offset_cnt` addresses
+/// - `file_offsets` needs to point to an array of `file_offset_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_elf_file_offsets(
     symbolizer: *mut blaze_symbolizer,
@@ -1229,7 +1229,7 @@ pub unsafe extern "C" fn blaze_symbolize_elf_file_offsets(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_gsym_data`] object
-/// - `virt_offsets` point to an array of `virt_offset_cnt` addresses
+/// - `virt_offsets` needs to point to an array of `virt_offset_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_gsym_data_virt_offsets(
     symbolizer: *mut blaze_symbolizer,
@@ -1268,7 +1268,7 @@ pub unsafe extern "C" fn blaze_symbolize_gsym_data_virt_offsets(
 /// # Safety
 /// - `symbolizer` needs to point to a valid [`blaze_symbolizer`] object
 /// - `src` needs to point to a valid [`blaze_symbolize_src_gsym_file`] object
-/// - `virt_offsets` point to an array of `virt_offset_cnt` addresses
+/// - `virt_offsets` needs to point to an array of `virt_offset_cnt` addresses
 #[no_mangle]
 pub unsafe extern "C" fn blaze_symbolize_gsym_file_virt_offsets(
     symbolizer: *mut blaze_symbolizer,


### PR DESCRIPTION
The documentation of various `*_addrs` arguments in symbolization functions contains a garbled sentences. Fix everything up.