### PR TITLE
Fix typo in `ElfResolver` documentation

### DIFF
--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -159,7 +159,7 @@ pub struct ElfResolver {
 }
 
 impl ElfResolver {
-    /// Create a `ElfResolver` that loads data from the provided file.
+    /// Create an `ElfResolver` that loads data from the provided file.
     pub fn open<P>(path: P) -> Result<Self>
     where
         P: AsRef<Path>,


### PR DESCRIPTION
Fix a typo in the `ElfResolver` documentation.