### PR TITLE
cli: Use Symbolizer::symbolize_single() for single address requests

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -304,9 +304,16 @@ fn symbolize(symbolize: args::symbolize::Symbolize) -> Result<()> {
     };
 
     let symbolizer = builder.build();
-    let syms = symbolizer
-        .symbolize(&src, input)
-        .context("failed to symbolize addresses")?;
+    let syms = if let [addr] = input.as_inner_ref() {
+        symbolizer
+            .symbolize_single(&src, input.map(|_| *addr))
+            .context("failed to symbolize address")
+            .map(|symbolized| Vec::from([symbolized]))?
+    } else {
+        symbolizer
+            .symbolize(&src, input)
+            .context("failed to symbolize addresses")?
+    };
 
     for (input_addr, sym) in addrs.iter().copied().zip(syms) {
         match sym {

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -180,7 +180,10 @@ pub enum Input<T> {
 }
 
 impl<T> Input<T> {
-    fn map<F, U>(&self, f: F) -> Input<U>
+    /// Apply a function to the inner address while preserving the
+    /// active variant.
+    #[inline]
+    pub fn map<F, U>(&self, f: F) -> Input<U>
     where
         T: Copy,
         F: FnOnce(T) -> U,


### PR DESCRIPTION
Use the `Symbolizer::symbolize_single()` method in order to serve single address symbolization requests. In so doing we get back the more verbose error behavior that was removed from the batch functionality as part of commit 183e97bf1f3c ("Stop short-circuiting on batch symbolization errors").