### PR TITLE
Fix code info directory reporting for DWARF symbolization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 - Adjusted `symbolize::Symbolizer::symbolize` behavior to stop being
   short-circuiting
   - Added `Reason::IgnoredError` variant
+- Fixed reporting of code info directory for DWARF symbolization if not
+  explicitly overwritten by source file
 
 
 0.2.0

--- a/data/test-empty.c
+++ b/data/test-empty.c
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}


### PR DESCRIPTION
We were incorrectly not reporting a source file directory when the source file did not overwrite said directory, because it is the same as that of the symbol's compilation unit:

```
  $ cargo run -p blazecli -- symbolize elf --path data/test-empty.bin 0x1125
  > 0x00000000001125: main @ 0x1125+0x0 test-empty.c:1:12
```

Fix this issue by adjusting the logic to correctly handle such cases.