### PR TITLE
Pin nightly toolchain for bench CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,7 +441,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        # TODO: Remove specification and switch back to @nightly once
+        #       `function_casts_as_integer` lint is stable.
+        toolchain: 'nightly-2025-11-05'
     - name: Run benchmarks
       shell: bash
       run: |


### PR DESCRIPTION
Similar to what commit 132f19dbf8ea ("Pin nightly toolchain for the time being") did for the miri CI job, pin the nightly toolchain for the 'bench' job as well.