### PR TITLE
Use explicit Rc::clone in Symbolizer::create_kernel_resolver()

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1114,7 +1114,9 @@ impl Symbolizer {
             MaybeDefault::None => None,
         };
 
-        KernelResolver::new(ksym_resolver.cloned(), elf_resolver.cloned(), *kaslr_offset)
+        let ksym_resolver = ksym_resolver.map(Rc::clone);
+        let elf_resolver = elf_resolver.map(Rc::clone);
+        KernelResolver::new(ksym_resolver, elf_resolver, *kaslr_offset)
     }
 
     #[cfg(not(linux))]


### PR DESCRIPTION
We try to be explicit when cloning reference counted pointers instead of whole objects by using `Rc::clone`. We missed that in the `Symbolizer::create_kernel_resolver()` method where an `Rc` is part of an `Option`. Fix that.