### PR TITLE
Loosen `test-log` version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ scopeguard = "1.2"
 stats_alloc = {version = "0.1.1", features = ["nightly"]}
 tempfile = "3"
 test-fork = "0.1"
-test-log = {version = "0.2.19", default-features = false, features = ["trace"]}
+test-log = {version = "0.2", default-features = false, features = ["trace"]}
 test-tag = "0.1.3"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -86,7 +86,7 @@ blazesym-c = {path = ".", features = ["check-doc-snippets"]}
 bindgen = {version = "0.72", default-features = false, features = ["runtime"]}
 criterion = {version = "0.7", default-features = false, features = ["rayon", "cargo_bench_support"]}
 tempfile = "3"
-test-log = {version = "0.2.19", default-features = false, features = ["trace"]}
+test-log = {version = "0.2", default-features = false, features = ["trace"]}
 test-tag = "0.1"
 
 [lints]


### PR DESCRIPTION
Loosen the `test-log` version requirement to keep Dependabot from bumping versions in our `Cargo.toml` manifest.