### PR TITLE
Properly cache KASLR offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Improved data caching for debug link targets and DWP files
+- Improved kernel symbolization performance when no KASLR offset is
+  provided by the user
 
 
 0.2.1

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -5,6 +5,7 @@ mod ksym;
 mod resolver;
 
 // TODO: KsymResolver should ideally be an implementation detail.
+pub(crate) use kaslr::find_kalsr_offset;
 pub(crate) use ksym::KsymResolver;
 pub(crate) use ksym::KALLSYMS;
 pub(crate) use resolver::KernelResolver;


### PR DESCRIPTION
When the user doesn't provide the KASLR offset, we currently calculate it every time a kernel address is symbolized, because at the moment we recreate a new `KernelResolver` on every such symbolization request. This is a potential performance hog, to say the least.
Make sure to cache the result of the calculation at the `Symbolizer` level, so that we can reuse the result across symbolization requests.

The resulting performance improvement is potentially significant. Using `blazecli` along (which is truly end-to-end but includes other overheads), I measured a 3.2x improvement (from ~80ms down to 25ms), presumably because the core file is rather large and we do additional I/O without caching.