### PR TITLE
Move KALLSYMS constant into kernel/mod.rs

### DIFF
--- a/src/kernel/ksym.rs
+++ b/src/kernel/ksym.rs
@@ -36,7 +36,6 @@ use super::bpf::BpfProg;
 #[cfg(not(feature = "bpf"))]
 type BpfInfoCache = ();
 
-pub const KALLSYMS: &str = "/proc/kallsyms";
 const DFL_KSYM_CAP: usize = 200000;
 
 
@@ -348,6 +347,7 @@ mod tests {
     use test_log::test;
     use test_tag::tag;
 
+    use crate::kernel::KALLSYMS;
     use crate::ErrorKind;
 
 

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -4,8 +4,10 @@ mod kaslr;
 mod ksym;
 mod resolver;
 
+/// The path to the `/proc/kallsyms` file.
+pub(crate) const KALLSYMS: &str = "/proc/kallsyms";
+
 // TODO: KsymResolver should ideally be an implementation detail.
 pub(crate) use kaslr::find_kalsr_offset;
 pub(crate) use ksym::KsymResolver;
-pub(crate) use ksym::KALLSYMS;
 pub(crate) use resolver::KernelResolver;


### PR DESCRIPTION
Move the `KALLSYMS` constant from the `kernel/ksyms.rs` module into `kernel/mod.rs`. In the future we may add additional fixed kernel path constants and it makes the most sense to have them all in a central location.