### PR TITLE
Don't box up created KernelResolver objects

### DIFF
--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -1323,14 +1323,12 @@ impl Symbolizer {
                     }
                 };
 
-                let resolver = Rc::new(self.create_kernel_resolver(kernel)?);
+                let resolver = self.create_kernel_resolver(kernel)?;
                 let symbols = addrs
                     .as_ref()
                     .iter()
                     .copied()
-                    .map(|addr| {
-                        self.symbolize_with_resolver(addr, &Resolver::Uncached(resolver.deref()))
-                    })
+                    .map(|addr| self.symbolize_with_resolver(addr, &Resolver::Uncached(&resolver)))
                     .map(|result| result.or_else(maybe_fold_error))
                     .collect();
                 Ok(symbols)


### PR DESCRIPTION
We never share `KernelResolver` objects or even store them anywhere -- they are basically a temporary object. As such, there is no point in heap allocating the entity or adding reference counting to it; all we need is a stack variable. Simplify the code accordingly.