### PR TITLE
Report backtrace on contextualized Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 - Improved data caching for debug link targets and DWP files
 - Improved kernel symbolization performance when no KASLR offset is
   provided by the user
+- Fixed backtrace reporting on contextualized errors
 
 
 0.2.1

--- a/src/error.rs
+++ b/src/error.rs
@@ -166,8 +166,8 @@ impl ErrorImpl {
             Self::Dwarf { backtrace, .. } => Some(backtrace),
             Self::Io { backtrace, .. } => Some(backtrace),
             Self::Std { backtrace, .. } => Some(backtrace),
-            Self::ContextOwned { .. } => None,
-            Self::ContextStatic { .. } => None,
+            Self::ContextOwned { source, .. } => source.backtrace(),
+            Self::ContextStatic { source, .. } => source.backtrace(),
         }
     }
 
@@ -881,6 +881,13 @@ Caused by:
 
         let err = io::Error::new(io::ErrorKind::InvalidData, "some invalid data");
         let err = Error::from(err);
+        let debug = format!("{err:?}");
+
+        let start_idx = debug.find("Stack backtrace").unwrap();
+        let backtrace = &debug[start_idx..];
+        assert!(backtrace.contains("src/error.rs"), "{backtrace}");
+
+        let err = err.context("foobar");
         let debug = format!("{err:?}");
 
         let start_idx = debug.find("Stack backtrace").unwrap();


### PR DESCRIPTION
As it turns out, once an Error object received additional context, we no longer reported the backtrace of the inner-most error, making the feature largely useless. Fix this short coming by recursively checking nested errors for backtraces.