### PR TITLE
Loosen tracing version requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,8 @@ jobs:
   build-minimum:
     name: Build using minimum versions of dependencies
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '-A warnings -C debuginfo=line-tables-only'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ memmap2 = {version = "0.9", default-features = false}
 miniz_oxide = {version = "0.8", default-features = false, features = ["simd", "with-alloc"], optional = true}
 nom = {version = "7", optional = true}
 rustc-demangle = {version = "0.1", optional = true}
-tracing = {version = "0.1.38", default-features = false, features = ["attributes"], optional = true}
+tracing = {version = "0.1", default-features = false, features = ["attributes"], optional = true}
 zstd = {version = "0.13.3", default-features = false, optional = true}
 
 [dev-dependencies]


### PR DESCRIPTION
Loosen the `tracing` version requirement to keep Dependabot from bumping versions in our Cargo.toml manifest.