### PR TITLE
Loosen zstd version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ miniz_oxide = {version = "0.8", default-features = false, features = ["simd", "w
 nom = {version = "7", optional = true}
 rustc-demangle = {version = "0.1", optional = true}
 tracing = {version = "0.1", default-features = false, features = ["attributes"], optional = true}
-zstd = {version = "0.13.3", default-features = false, optional = true}
+zstd = {version = "0.13", default-features = false, optional = true}
 
 [dev-dependencies]
 # For performance comparison; pinned, because we use #[doc(hidden)]

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -39,7 +39,7 @@ thorin_dwp = {package = "thorin-dwp", version = "0.9", optional = true, default-
 vmlinux = {git = "https://github.com/libbpf/vmlinux.h.git", rev = "a9c092aa771310bf8b00b5018f7d40a1fdb6ec82"}
 xz2 = {version = "0.1.7", optional = true}
 zip = {version = "7", optional = true, default-features = false}
-zstd = {version = "0.13.3", default-features = false, optional = true}
+zstd = {version = "0.13", default-features = false, optional = true}
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.build-dependencies]
 libbpf-sys = {version = "1.6", default-features = false, optional = true}


### PR DESCRIPTION
Loosen the zstd version requirement to keep Dependabot from bumping versions in our Cargo.toml manifest.