### PR TITLE
Update debuginfod dependency to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,15 +673,17 @@ dependencies = [
 
 [[package]]
 name = "debuginfod"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44707b94e359a67ca946c43ed0054c53a54cb975e142f6dea1ab75a0eed06e05"
+checksum = "a8488c5714ac62facd3069194eb2a88ce4c0fe9da333be7c08cf27532060b132"
 dependencies = [
  "anyhow",
  "dirs",
+ "http",
  "reqwest",
  "tempfile",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -847,12 +849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,9 +856,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1075,12 +1071,11 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1294,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1783,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf_shared"
@@ -2973,13 +2968,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/examples/sym-debuginfod/Cargo.toml
+++ b/examples/sym-debuginfod/Cargo.toml
@@ -14,7 +14,7 @@ path = "main.rs"
 anyhow = "1.0"
 blazesym = {version = "0.2", path = "../..", features = ["tracing"]}
 clap = {version = "4.5", features = ["derive", "string"]}
-debuginfod = {version = "0.2.1", features = ["fs-cache", "tracing"]}
+debuginfod = {version = "0.3", features = ["fs-cache", "reqwest", "tracing"]}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["ansi", "env-filter", "fmt"]}
 

--- a/examples/sym-debuginfod/main.rs
+++ b/examples/sym-debuginfod/main.rs
@@ -22,6 +22,7 @@ use blazesym::Pid;
 use clap::ArgAction;
 use clap::Parser;
 
+use debuginfod::reqwest::blocking::Client as ReqwestBlockingClient;
 use debuginfod::BuildId;
 use debuginfod::CachingClient;
 use debuginfod::Client;
@@ -174,7 +175,10 @@ fn main() -> Result<()> {
 
     set_global_subscriber(subscriber).with_context(|| "failed to set tracing subscriber")?;
 
-    let client = Client::from_env()
+
+    let client = Client::builder()
+        .http_client(ReqwestBlockingClient::new())
+        .build_from_env()
         .context("failed to create debuginfod client")?
         .context("failed to find valid URLs in DEBUGINFOD_URLS environment variable")?;
     let client = CachingClient::from_env(client)?;


### PR DESCRIPTION
Update the `debuginfod` dependency in the `sym-debuginfod` example to `0.3.0`, to get the latest and greatest.