### PR TITLE
Resolve debug symbols in containers

### DIFF
--- a/src/maps.rs
+++ b/src/maps.rs
@@ -46,6 +46,8 @@ pub struct EntryPath {
     /// parsed. This path has been sanitized and no longer contains any
     /// `(deleted)` suffixes.
     pub symbolic_path: PathBuf,
+    /// The path to the root of the mount namespace through `/proc/<xxx>/root`.
+    pub root_path: PathBuf,
     /// The struct is non-exhaustive and open to extension.
     #[doc(hidden)]
     pub _non_exhaustive: (),
@@ -211,9 +213,11 @@ pub(crate) fn parse_path_name(
             let pid = pid.resolve();
             let maps_file =
                 PathBuf::from(format!("/proc/{pid}/map_files/{vma_start:x}-{vma_end:x}"));
+            let root_path = PathBuf::from(format!("/proc/{pid}/root"));
             Some(PathName::Path(EntryPath {
                 maps_file,
                 symbolic_path,
+                root_path,
                 _non_exhaustive: (),
             }))
         }


### PR DESCRIPTION
For the ELF file itself blazesym does the right thing by reading files like:

```
/proc/2367/map_files/79c8000-20aec000
```

This works great when the ELF files are in a container in a separate mount namespace. When it comes to looking for split debug info via `debuglink`, it tries looking in by the path in the root mount namespace, which does not work, as the files are just not there. With this change we try checking the process mount namespace first via `/proc/<xxx>/root`.

Here's a practical example with ClickHouse running in a container with debug symbols installed inside:

* Before:

```
ivan@cube:~/projects/blazesym/cli$ sudo ../target/debug/blazecli symbolize process --pid 2367 0x17658f30
2025-12-26T03:04:41.331043Z  WARN debug link references destination `clickhouse.debug` which was not found in any known location
0x00000017658f30: DB::Block::Block(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> >&&) @ 0x17658e80+0xb0
```

* After:

```
ivan@cube:~/projects/blazesym/cli$ sudo ../target/debug/blazecli symbolize process --pid 2367 0x17658f30
0x00000017658f30: DB::Block::Block(std::__1::vector<DB::ColumnWithTypeAndName, std::__1::allocator<DB::ColumnWithTypeAndName> >&&) @ 0x17658e80+0xb0 ./ci/tmp/build/./src/Core/Block.cpp:175:5
                  DB::Block::initializeIndexByName() @ ./ci/tmp/build/./src/Core/Block.cpp:182:23 [inlined]
                  std::__1::pair<std::__1::__hash_map_iterator<std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned long>, void*>*> >, bool> std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned long, DB::StringHashForHeterogeneousLookup, std::__1::equal_to<void>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, unsigned long> > >::emplace[abi:ne190107]<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, unsigned long&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, unsigned long&) @ ./ci/tmp/build/./contrib/llvm-project/libcxx/include/unordered_map:1255:21 [inlined]
                  _ZNSt3__112__hash_tableINS_17__hash_value_typeINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEmEENS_22__unordered_map_hasherIS7_S8_N2DB32StringHashForHeterogeneousLookupENS_8equal_toIvEELb1EEENS_21__unordered_map_equalIS7_S8_SD_SB_Lb1EEENS5_IS8_EEE16__emplace_uniqueB8ne190107IRS7_RmTnNS_9enable_ifIXsr21__can_extract_map_keyIT_S7_NS_4pairIKS7_mEEEE5valueEiE4typeELi0EEENSO_INS_15__hash_iteratorIPNS_11__hash_nodeIS8_PvEEEEbEEOSN_OT0_ @ ./ci/tmp/build/./contrib/llvm-project/libcxx/include/__hash_table:804:12 [inlined]
```

