### PR TITLE
Add a basic Go library that wraps blazesym-c

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -492,6 +492,31 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo doc --workspace --exclude=blazesym-dev --exclude=gsym-in-apk --no-deps --document-private-items
+  go:
+    name: Run Go tests
+    runs-on: ubuntu-24.04
+    env:
+      LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
+    steps:
+      - name: Install development dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo check --package blazesym-dev --features=generate-unit-test-files
+      - run: cargo build --package blazesym-c
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.6
+          working-directory: go
+        env:
+          CGO_CFLAGS: "-I${{ github.workspace }}/capi/include"
+      # Tests are compiled first to include debug info, which is skipped in regular `go test`.
+      - run: cd go && CGO_CFLAGS="-I$(pwd)/../capi/include" CGO_LDFLAGS="-L$(pwd)/../target/debug" go test -v -c -o /tmp/test . && LD_LIBRARY_PATH=$(pwd)/../target/debug /tmp/test -test.v
 
   required-checks:
     needs: [

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,42 @@
+# blazsym-go
+
+Go wrapper for C bindings of blazesym.
+
+## Building
+
+First of all, you need to have [blazesym-c](https://docs.rs/blazesym-c/) available on your system.
+If it is installed in the expected places, everything should build out of the box.
+
+If you don't have installed, you can build it yourself from [capi](../capi) dir in the repo:
+
+```
+cargo build --release
+```
+
+You can then pass flags to tell Go where to find things:
+
+```
+CGO_CFLAGS="-I/path/to/blazesym/capi/include" CGO_LDFLAGS="-L/path/to/blazesym/target/release"
+```
+
+At runtime you need to set `LD_LIBRARY_PATH=/path/to/blazesym/target/release`.
+
+### Static linking
+
+You might want to link against blazesym statically by adding the following to `CGO_LDFLAGS`:
+
+```
+-Wl,-Bstatic -lblazesym_c -Wl,-Bdynamic
+```
+
+This way `blazesym_c.so` doesn't need to be installed on the system where the binary will run.
+
+Fully static builds are possible if you pass the following to `go build` or `go install`:
+
+```
+-ldflags='-extldflags "-static"'
+```
+
+### Example usage
+
+See [example_source_elf_test.go](example_source_elf_test.go) for a basic example.

--- a/go/error.go
+++ b/go/error.go
@@ -1,0 +1,50 @@
+package blazesym
+
+import "errors"
+
+/*
+#cgo LDFLAGS: -lblazesym_c
+#include "blazesym.h"
+*/
+import "C"
+
+// blazeErr is an enum providing a rough classification of errors.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_err.html
+type blazeErr int
+
+const (
+	// The operation was successful.
+	blazeErrOk blazeErr = 0
+	// An entity was not found, often a file.
+	blazeErrNotFound blazeErr = -2
+	// The operation lacked the necessary privileges to complete.
+	blazeErrPermissionDenied blazeErr = -1
+	// An entity already exists, often a file.
+	blazeErrAlreadyExists blazeErr = -17
+	// The operation needs to block to complete, but the blocking operation was requested to not occur.
+	blazeErrWouldBlock blazeErr = -11
+	// Data not valid for the operation were encountered.
+	blazeErrInvalidData blazeErr = -22
+	// The I/O operation’s timeout expired, causing it to be canceled.
+	blazeErrTimedOut blazeErr = -110
+	// This operation is unsupported on this platform.
+	blazeErrUnsupported blazeErr = -95
+	// An operation could not be completed, because it failed to allocate enough memory.
+	blazeErrOutOfMemory blazeErr = -12
+	// A parameter was incorrect.
+	blazeErrInvalidInput blazeErr = -256
+	// An error returned when an operation could not be completed because a call to write returned Ok(0).
+	blazeErrWriteZero blazeErr = -257
+	// An error returned when an operation would not be completed because an “end of file” was reached prematurely.
+	blazeErrUnexpectedEOF blazeErr = -258
+	// DWARF input data was invalid.
+	blazeErrInvalidDwarf blazeErr = -259
+	// A custom error that does not fall under any other I/O error kind.
+	blazeErrOther blazeErr = -260
+)
+
+// Error returns an error representation of a blazesym error.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/fn.blaze_err_str.html
+func (e blazeErr) Error() error {
+	return errors.New(C.GoString(C.blaze_err_str(C.blaze_err(e))))
+}

--- a/go/example_source_elf_test.go
+++ b/go/example_source_elf_test.go
@@ -1,0 +1,23 @@
+package blazesym_test
+
+import (
+	"fmt"
+	"log"
+
+	blazesym "github.com/libbpf/blazesym/go"
+)
+
+func ExampleElfSource() {
+	symbolizer, err := blazesym.NewSymbolizer()
+	if err != nil {
+		log.Fatalf("error creating symbolizer: %v", err)
+	}
+
+	symbols, err := symbolizer.SymbolizeElfVirtOffsets(&blazesym.ElfSource{Path: "../data/test-stable-addrs-compressed-debug-zlib.bin", DebugSyms: true}, []uint64{0x2000200})
+	if err != nil {
+		log.Fatalf("error symbolizing: %v", err)
+	}
+
+	fmt.Printf("%s @ 0x%x %s\n", symbols[0].Name, symbols[0].Addr, symbols[0].CodeInfo.File)
+	// Output: factorial @ 0x2000200 test-stable-addrs.c
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/libbpf/blazesym/go
+
+go 1.25.0

--- a/go/reason.go
+++ b/go/reason.go
@@ -1,0 +1,24 @@
+package blazesym
+
+// SymbolizeReason describes the reason why symbolization failed.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_reason.html
+type SymbolizeReason int
+
+const (
+	// Symbolization was successful.
+	SymbolizeReasonSuccess SymbolizeReason = 0
+	// The absolute address was not found in the corresponding process' virtual memory map.
+	SymbolizeReasonUnmapped SymbolizeReason = 1
+	// The file offset does not map to a valid piece of code/data.
+	SymbolizeReasonInvalidFileOffset SymbolizeReason = 2
+	// The `/proc/<pid>/maps` entry corresponding to the address does
+	// not have a component (file system path, object, ...) associated
+	// with it.
+	SymbolizeReasonMissingComponent SymbolizeReason = 3
+	// The symbolization source has no or no relevant symbols.
+	SymbolizeReasonMissingSyms SymbolizeReason = 4
+	// The address could not be found in the symbolization source.
+	SymbolizeReasonUnknownAddr SymbolizeReason = 5
+	// The address belonged to an entity that is currently unsupported.
+	SymbolizeReasonUnsupported SymbolizeReason = 6
+)

--- a/go/source_elf.go
+++ b/go/source_elf.go
@@ -1,0 +1,29 @@
+package blazesym
+
+/*
+#include "blazesym.h"
+*/
+import "C"
+
+import "unsafe"
+
+// ElfSource described the parameters to load symbols and debug information from an ELF.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_elf.html
+type ElfSource struct {
+	// The path to an ELF file.
+	Path string
+	// Whether or not to consult debug symbols to satisfy the request (if present).
+	DebugSyms bool
+}
+
+func (s *ElfSource) toCStruct() *C.struct_blaze_symbolize_src_elf {
+	elf := C.struct_blaze_symbolize_src_elf{}
+	elf.type_size = C.ulong(unsafe.Sizeof(elf))
+	elf.path = C.CString(s.Path)
+	elf.debug_syms = C.bool(s.DebugSyms)
+	return &elf
+}
+
+func cleanupElfSourceStruct(elf *C.struct_blaze_symbolize_src_elf) {
+	C.free(unsafe.Pointer(elf.path))
+}

--- a/go/source_process.go
+++ b/go/source_process.go
@@ -1,0 +1,33 @@
+package blazesym
+
+/*
+#include "blazesym.h"
+*/
+import "C"
+import "unsafe"
+
+// ProcessSource describes the parameters to load symbols and debug information from a process.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html
+type ProcessSource struct {
+	// The referenced process’ ID.
+	Pid uint32
+	// Whether or not to consult debug symbols to satisfy the request (if present).
+	DebugSyms bool
+	// Whether to incorporate a process’ perf map file into the symbolization procedure.
+	PerfMap bool
+	// Whether to work with /proc/<pid>/map_files/ entries or with symbolic paths mentioned in /proc/<pid>/maps instead.
+	NoMapFiles bool
+	// Whether or not to symbolize addresses in a vDSO (virtual dynamic shared object).
+	NoVdso bool
+}
+
+func (s *ProcessSource) toCStruct() *C.struct_blaze_symbolize_src_process {
+	process := C.struct_blaze_symbolize_src_process{}
+	process.type_size = C.ulong(unsafe.Sizeof(process))
+	process.pid = C.uint32_t(s.Pid)
+	process.debug_syms = C.bool(s.DebugSyms)
+	process.perf_map = C.bool(s.PerfMap)
+	process.no_map_files = C.bool(s.NoMapFiles)
+	process.no_vdso = C.bool(s.NoVdso)
+	return &process
+}

--- a/go/sym.go
+++ b/go/sym.go
@@ -1,0 +1,44 @@
+package blazesym
+
+// The result of address symbolization by Symbolizer.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_sym.html
+type Sym struct {
+	// The symbol name that an address belongs to.
+	Name string
+	// The path to or name of the module containing the symbol.
+	Module string
+	// The address at which the symbol is located (i.e., its “start”).
+	Addr uint64
+	// The byte offset of the address that got symbolized from the start of the symbol (i.e., from addr).
+	Offset uint64
+	// The symbol’s size, if available.
+	Size int64
+	// Source code location information for the symbol.
+	CodeInfo *CodeInfo
+	// Inlined function information, if requested and available.
+	Inlined []InlinedFn
+	// On error (i.e., if name is NULL), a reason trying to explain why symbolization failed.
+	Reason SymbolizeReason
+}
+
+// Source code location information for a symbol or inlined function.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_code_info.html
+type CodeInfo struct {
+	// The directory in which the source file resides.
+	Dir string
+	// The file that defines the symbol.
+	File string
+	// The line number of the symbolized instruction in the source code.
+	Line uint32
+	// The column number of the symbolized instruction in the source code.
+	Column uint16
+}
+
+// A type representing an inlined function.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_inlined_fn.html
+type InlinedFn struct {
+	// The symbol name of the inlined function.
+	Name string
+	// Source code location information for the call to the function.
+	CodeInfo *CodeInfo
+}

--- a/go/symbolizer.go
+++ b/go/symbolizer.go
@@ -1,0 +1,124 @@
+package blazesym
+
+import (
+	"unsafe"
+)
+
+/*
+#cgo LDFLAGS: -lblazesym_c
+#include "blazesym.h"
+
+// Adding a C function to return syms from blaze_result
+struct blaze_sym* get_result(blaze_syms* res, size_t pos) {
+	return &res->syms[pos];
+}
+*/
+import "C"
+
+// Symbolizer represents a Blazesym symbolizer.
+type Symbolizer struct {
+	s *C.blaze_symbolizer
+}
+
+// NewSymbolizer creates an instance of a symbolizer.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/fn.blaze_symbolizer_new.html
+func NewSymbolizer() (*Symbolizer, error) {
+	s := C.blaze_symbolizer_new()
+	if s == nil {
+		return nil, blazeErr(C.blaze_err_last()).Error()
+	}
+
+	return &Symbolizer{s: s}, nil
+}
+
+// Close closes the a symbolizer.
+func (s *Symbolizer) Close() {
+	C.blaze_symbolizer_free(s.s)
+}
+
+// SymbolizeElfVirtOffsets symbolizes virtual offsets in an ELF file.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/fn.blaze_symbolize_elf_virt_offsets.html
+func (s *Symbolizer) SymbolizeElfVirtOffsets(source *ElfSource, input []uint64) ([]Sym, error) {
+	elf := source.toCStruct()
+	defer cleanupElfSourceStruct(elf)
+
+	caddr, clen := addrsToPtr(input)
+
+	return s.processSyms(C.blaze_symbolize_elf_virt_offsets(s.s, elf, caddr, clen), input)
+}
+
+// SymbolizeProcessAbsAddrs symbolizes a list of process absolute addresses.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/fn.blaze_symbolize_process_abs_addrs.html
+func (s *Symbolizer) SymbolizeProcessAbsAddrs(source *ProcessSource, input []uint64) ([]Sym, error) {
+	process := source.toCStruct()
+
+	caddr, clen := addrsToPtr(input)
+
+	return s.processSyms(C.blaze_symbolize_process_abs_addrs(s.s, process, caddr, clen), input)
+}
+
+func (s *Symbolizer) processSyms(syms *C.blaze_syms, input []uint64) ([]Sym, error) {
+	lastErr := blazeErr(C.blaze_err_last())
+	if lastErr != blazeErrOk {
+		return nil, lastErr.Error()
+	}
+
+	// this should not happen, but we make sure to not call blaze_syms_free for nothing
+	if syms == nil {
+		return nil, nil
+	}
+
+	defer C.blaze_syms_free(syms)
+
+	results := make([]Sym, syms.cnt)
+	for i := 0; i < int(syms.cnt); i++ {
+		sym := C.get_result(syms, C.size_t(i))
+
+		results[i].Name = C.GoString(sym.name)
+		results[i].Module = C.GoString(sym.module)
+		results[i].Addr = uint64(sym.addr)
+		results[i].Offset = uint64(sym.offset)
+		results[i].Size = int64(sym.size)
+
+		if sym.code_info.file != nil {
+			results[i].CodeInfo = &CodeInfo{
+				Dir:    C.GoString(sym.code_info.dir),
+				File:   C.GoString(sym.code_info.file),
+				Line:   uint32(sym.code_info.line),
+				Column: uint16(sym.code_info.column),
+			}
+		}
+
+		results[i].Inlined = make([]InlinedFn, sym.inlined_cnt)
+
+		if sym.inlined_cnt > 0 {
+			inlined := (*[1 << 30]C.blaze_symbolize_inlined_fn)(unsafe.Pointer(sym.inlined))[:sym.inlined_cnt:sym.inlined_cnt]
+
+			for j := 0; j < int(sym.inlined_cnt); j++ {
+				results[i].Inlined[j].Name = C.GoString(inlined[j].name)
+
+				if inlined[j].code_info.file != nil {
+					results[i].Inlined[j].CodeInfo = &CodeInfo{
+						Dir:    C.GoString(inlined[j].code_info.dir),
+						File:   C.GoString(inlined[j].code_info.file),
+						Line:   uint32(inlined[j].code_info.line),
+						Column: uint16(inlined[j].code_info.column),
+					}
+				}
+			}
+		}
+
+		results[i].Reason = SymbolizeReason(sym.reason)
+	}
+
+	return results, nil
+}
+
+func addrsToPtr(input []uint64) (*C.uint64_t, C.size_t) {
+	var result *C.uint64_t
+	length := len(input)
+	if length > 0 {
+		result = (*C.uint64_t)(unsafe.Pointer(&input[0]))
+	}
+	return result, C.size_t(length)
+}


### PR DESCRIPTION
As discussed in https://github.com/facebook/dns/pull/116, this adds a Go library in the same repo as blazesym itself.

I only added two methods for the symbolizer: one for pid based resolution and one for ELF based one. There's also a cli tool that I used to compare against `blazecli`. The output seems to match. The README explains how to build this. 

I think it's reasonable to start with this small API surface area and then expand to more of it later.

If this makes sense, I can add tests and general CI scaffolding. Let me know if there's anything else you'd like to see before this is good to merge.