### PR TITLE
Use functional options for symbolizer calls in Go

### DIFF
--- a/go/example_source_elf_test.go
+++ b/go/example_source_elf_test.go
@@ -13,7 +13,7 @@ func ExampleElfSource() {
 		log.Fatalf("error creating symbolizer: %v", err)
 	}
 
-	symbols, err := symbolizer.SymbolizeElfVirtOffsets(&blazesym.ElfSource{Path: "../data/test-stable-addrs-compressed-debug-zlib.bin", DebugSyms: true}, []uint64{0x2000200})
+	symbols, err := symbolizer.SymbolizeElfVirtOffsets([]uint64{0x2000200}, "../data/test-stable-addrs-compressed-debug-zlib.bin", blazesym.ElfSourceWithDebugSyms(true))
 	if err != nil {
 		log.Fatalf("error symbolizing: %v", err)
 	}

--- a/go/source_elf.go
+++ b/go/source_elf.go
@@ -7,21 +7,30 @@ import "C"
 
 import "unsafe"
 
-// ElfSource described the parameters to load symbols and debug information from an ELF.
+// ElfSource describes the parameters to load symbols and debug information from an ELF.
 // See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_elf.html
 type ElfSource struct {
-	// The path to an ELF file.
-	Path string
-	// Whether or not to consult debug symbols to satisfy the request (if present).
-	DebugSyms bool
+	source C.struct_blaze_symbolize_src_elf
 }
 
-func (s *ElfSource) toCStruct() *C.struct_blaze_symbolize_src_elf {
-	elf := C.struct_blaze_symbolize_src_elf{}
-	elf.type_size = C.ulong(unsafe.Sizeof(elf))
-	elf.path = C.CString(s.Path)
-	elf.debug_syms = C.bool(s.DebugSyms)
-	return &elf
+// newElfSource creates a new elf source with the path to the ELF file.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_elf.html#structfield.path
+func newElfSource(path string) *ElfSource {
+	source := C.struct_blaze_symbolize_src_elf{}
+	source.type_size = C.ulong(unsafe.Sizeof(source))
+	source.path = C.CString(path)
+	return &ElfSource{source: source}
+}
+
+// ElfSourceOption configures ElfSource objects.
+type ElfSourceOption func(*ElfSource)
+
+// ElfSourceWithDebugSyms configures whether or not to consult debug symbols to satisfy the request (if present).
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_elf.html#structfield.debug_syms
+func ElfSourceWithDebugSyms(enabled bool) ElfSourceOption {
+	return func(es *ElfSource) {
+		es.source.debug_syms = C.bool(enabled)
+	}
 }
 
 func cleanupElfSourceStruct(elf *C.struct_blaze_symbolize_src_elf) {

--- a/go/source_process.go
+++ b/go/source_process.go
@@ -4,30 +4,55 @@ package blazesym
 #include "blazesym.h"
 */
 import "C"
+
 import "unsafe"
 
 // ProcessSource describes the parameters to load symbols and debug information from a process.
 // See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html
 type ProcessSource struct {
-	// The referenced process’ ID.
-	Pid uint32
-	// Whether or not to consult debug symbols to satisfy the request (if present).
-	DebugSyms bool
-	// Whether to incorporate a process’ perf map file into the symbolization procedure.
-	PerfMap bool
-	// Whether to work with /proc/<pid>/map_files/ entries or with symbolic paths mentioned in /proc/<pid>/maps instead.
-	NoMapFiles bool
-	// Whether or not to symbolize addresses in a vDSO (virtual dynamic shared object).
-	NoVdso bool
+	source C.struct_blaze_symbolize_src_process
 }
 
-func (s *ProcessSource) toCStruct() *C.struct_blaze_symbolize_src_process {
-	process := C.struct_blaze_symbolize_src_process{}
-	process.type_size = C.ulong(unsafe.Sizeof(process))
-	process.pid = C.uint32_t(s.Pid)
-	process.debug_syms = C.bool(s.DebugSyms)
-	process.perf_map = C.bool(s.PerfMap)
-	process.no_map_files = C.bool(s.NoMapFiles)
-	process.no_vdso = C.bool(s.NoVdso)
-	return &process
+// newProcessSource creates a new process source with the referenced process’ ID.
+// https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html#structfield.pid
+func newProcessSource(pid uint32) *ProcessSource {
+	source := C.struct_blaze_symbolize_src_process{}
+	source.type_size = C.ulong(unsafe.Sizeof(source))
+	source.pid = C.uint32_t(pid)
+	return &ProcessSource{source: source}
+}
+
+// ProcessSourceOption configures ProcessSource objects.
+type ProcessSourceOption func(*ProcessSource)
+
+// ProcessSourceWithDebugSyms configures whether or not to consult debug symbols to satisfy the request (if present).
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html#structfield.debug_syms
+func ProcessSourceWithDebugSyms(enabled bool) ProcessSourceOption {
+	return func(ps *ProcessSource) {
+		ps.source.debug_syms = C.bool(enabled)
+	}
+}
+
+// ProcessSourceWithPerfMap configures whether to incorporate a process’ perf map file into the symbolization procedure.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html#structfield.perf_map
+func ProcessSourceWithPerfMap(enabled bool) ProcessSourceOption {
+	return func(ps *ProcessSource) {
+		ps.source.perf_map = C.bool(enabled)
+	}
+}
+
+// ProcessSourceWithoutMapFiles configures whether to work with /proc/<pid>/map_files/ entries or with symbolic paths mentioned in /proc/<pid>/maps instead.
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html#structfield.no_map_files
+func ProcessSourceWithoutMapFiles(enabled bool) ProcessSourceOption {
+	return func(ps *ProcessSource) {
+		ps.source.no_map_files = C.bool(enabled)
+	}
+}
+
+// ProcessSourceWithoutVDSO configures whether or not to symbolize addresses in a vDSO (virtual dynamic shared object).
+// See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html#structfield.no_vdso
+func ProcessSourceWithoutVDSO(enabled bool) ProcessSourceOption {
+	return func(ps *ProcessSource) {
+		ps.source.no_vdso = C.bool(enabled)
+	}
 }

--- a/go/symbolizer_option.go
+++ b/go/symbolizer_option.go
@@ -35,9 +35,9 @@ func (so *SymbolizerOptions) Close() {
 // SymbolizerOption configures SymbolizerOptions objects.
 type SymbolizerOption func(*SymbolizerOptions)
 
-// WithDebugDirs sets the array of debug directories to search for split debug information.
+// SymbolizerWithDebugDirs sets the array of debug directories to search for split debug information.
 // See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolizer_opts.html#structfield.debug_dirs
-func WithDebugDirs(dirs []string) SymbolizerOption {
+func SymbolizerWithDebugDirs(dirs []string) SymbolizerOption {
 	return func(so *SymbolizerOptions) {
 		if so.opts.debug_dirs_len != 0 {
 			freeCArrayOfStrings(so.opts.debug_dirs, so.opts.debug_dirs_len)
@@ -48,34 +48,34 @@ func WithDebugDirs(dirs []string) SymbolizerOption {
 	}
 }
 
-// WithAutoReload sets whether or not to automatically reload file system based
+// SymbolizerWithAutoReload sets whether or not to automatically reload file system based
 // symbolization sources that were updated since the last symbolization operation.
 // See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolizer_opts.html#structfield.auto_reload
-func WithAutoReload(enabled bool) SymbolizerOption {
+func SymbolizerWithAutoReload(enabled bool) SymbolizerOption {
 	return func(so *SymbolizerOptions) {
 		so.opts.auto_reload = C.bool(enabled)
 	}
 }
 
-// WithCodeInfo sets whether to attempt to gather source code location information.
+// SymbolizerWithCodeInfo sets whether to attempt to gather source code location information.
 // See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolizer_opts.html#structfield.code_info
-func WithCodeInfo(enabled bool) SymbolizerOption {
+func SymbolizerWithCodeInfo(enabled bool) SymbolizerOption {
 	return func(so *SymbolizerOptions) {
 		so.opts.code_info = C.bool(enabled)
 	}
 }
 
-// WithInlinedFns sets whether to report inlined functions as part of symbolization.
+// SymbolizerWithInlinedFns sets whether to report inlined functions as part of symbolization.
 // See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolizer_opts.html#structfield.inlined_fns
-func WithInlinedFns(enabled bool) SymbolizerOption {
+func SymbolizerWithInlinedFns(enabled bool) SymbolizerOption {
 	return func(so *SymbolizerOptions) {
 		so.opts.inlined_fns = C.bool(enabled)
 	}
 }
 
-// WithDemangle sets whether or not to transparently demangle symbols.
+// SymbolizerWithDemangle sets whether or not to transparently demangle symbols.
 // See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolizer_opts.html#structfield.demangle
-func WithDemangle(enabled bool) SymbolizerOption {
+func SymbolizerWithDemangle(enabled bool) SymbolizerOption {
 	return func(so *SymbolizerOptions) {
 		so.opts.demangle = C.bool(enabled)
 	}

--- a/go/symbolizer_test.go
+++ b/go/symbolizer_test.go
@@ -44,7 +44,12 @@ func TestSymbolizeProcess(t *testing.T) {
 
 	addr := reflect.ValueOf(TestSymbolizeProcess).Pointer()
 
-	syms, err := symbolizer.SymbolizeProcessAbsAddrs(&blazesym.ProcessSource{Pid: uint32(os.Getpid()), DebugSyms: true, NoMapFiles: true}, []uint64{uint64(addr)})
+	syms, err := symbolizer.SymbolizeProcessAbsAddrs(
+		[]uint64{uint64(addr)},
+		uint32(os.Getpid()),
+		blazesym.ProcessSourceWithDebugSyms(true),
+		blazesym.ProcessSourceWithoutMapFiles(true),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +65,7 @@ func TestSymbolizeElfStripped(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	syms, err := symbolizer.SymbolizeElfVirtOffsets(&blazesym.ElfSource{Path: "../data/test-stable-addrs-stripped.bin"}, []uint64{uint64(0x2000200)})
+	syms, err := symbolizer.SymbolizeElfVirtOffsets([]uint64{uint64(0x2000200)}, "../data/test-stable-addrs-stripped.bin")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,13 +75,13 @@ func TestSymbolizeElfStripped(t *testing.T) {
 	}
 }
 
-func testElfDwarfSource(t *testing.T, source *blazesym.ElfSource, hasCodeInfo bool) {
+func testElfDwarfSource(t *testing.T, path string, hasCodeInfo bool) {
 	symbolizer, err := blazesym.NewSymbolizer()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	syms, err := symbolizer.SymbolizeElfVirtOffsets(source, []uint64{0x2000200})
+	syms, err := symbolizer.SymbolizeElfVirtOffsets([]uint64{0x2000200}, path, blazesym.ElfSourceWithDebugSyms(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +133,7 @@ func testElfDwarfSource(t *testing.T, source *blazesym.ElfSource, hasCodeInfo bo
 		offsetAddrs[offset] = uint64(0x2000200 + offset + 1)
 	}
 
-	syms, err = symbolizer.SymbolizeElfVirtOffsets(source, offsetAddrs)
+	syms, err = symbolizer.SymbolizeElfVirtOffsets(offsetAddrs, path, blazesym.ElfSourceWithDebugSyms(true))
 	if err != nil {
 		t.Error(err)
 	}
@@ -181,7 +186,7 @@ func TestSymbolizeElfDwarf(t *testing.T) {
 		"test-stable-addrs-32-no-dwarf.bin",
 	} {
 		t.Run(file, func(t *testing.T) {
-			testElfDwarfSource(t, &blazesym.ElfSource{Path: filepath.Join("../data", file), DebugSyms: true}, false)
+			testElfDwarfSource(t, filepath.Join("../data", file), false)
 		})
 	}
 
@@ -191,7 +196,7 @@ func TestSymbolizeElfDwarf(t *testing.T) {
 		"test-stable-addrs-compressed-debug-zlib.bin",
 	} {
 		t.Run(file, func(t *testing.T) {
-			testElfDwarfSource(t, &blazesym.ElfSource{Path: filepath.Join("../data", file), DebugSyms: true}, true)
+			testElfDwarfSource(t, filepath.Join("../data", file), true)
 		})
 	}
 }
@@ -232,12 +237,12 @@ func TestConfigurableDebugDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	symbolizer, err := blazesym.NewSymbolizer(blazesym.WithDebugDirs([]string{}))
+	symbolizer, err := blazesym.NewSymbolizer(blazesym.SymbolizerWithDebugDirs([]string{}))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	syms, err := symbolizer.SymbolizeElfVirtOffsets(&blazesym.ElfSource{Path: dst, DebugSyms: true}, []uint64{0x2000200})
+	syms, err := symbolizer.SymbolizeElfVirtOffsets([]uint64{0x2000200}, dst, blazesym.ElfSourceWithDebugSyms(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,12 +272,12 @@ func TestConfigurableDebugDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	symbolizer, err = blazesym.NewSymbolizer(blazesym.WithDebugDirs([]string{debugDir1, debugDir2}))
+	symbolizer, err = blazesym.NewSymbolizer(blazesym.SymbolizerWithDebugDirs([]string{debugDir1, debugDir2}))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	syms, err = symbolizer.SymbolizeElfVirtOffsets(&blazesym.ElfSource{Path: dst, DebugSyms: true}, []uint64{0x2000200})
+	syms, err = symbolizer.SymbolizeElfVirtOffsets([]uint64{0x2000200}, dst, blazesym.ElfSourceWithDebugSyms(true))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
It is slightly awkward to have addrs in the middle:

```
call(<required param>, <addrs>, [optional params])
```

but maybe that's fine.