### PR TITLE
Allow enabling zstd feature in blazesym-c and blazecli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,7 +219,7 @@ jobs:
         echo "export PYTHON=${PYTHON}" >> env.sh
         source env.sh
 
-        cargo test --no-run --workspace --all-targets --features=nightly,blazesym-dev/generate-large-test-files 2>&1 | tee /tmp/cargo-build.log
+        cargo test --no-run --workspace --all-targets --features=zstd,nightly,blazesym-dev/generate-large-test-files 2>&1 | tee /tmp/cargo-build.log
         tests=$(IFS='' grep Executable /tmp/cargo-build.log |
           awk '{print $NF}' |
           sed 's@[()]@@g' |
@@ -332,7 +332,7 @@ jobs:
         #CXXFLAGS: "-fsanitize=${{ matrix.sanitizer }}"
         RUSTFLAGS: "-Zsanitizer=${{ matrix.sanitizer }}"
         ASAN_OPTIONS: "detect_odr_violation=0:detect_leaks=1"
-      run: cargo test --workspace --lib --tests --target x86_64-unknown-linux-gnu
+      run: cargo test --workspace --exclude=blazecli --lib --tests --target x86_64-unknown-linux-gnu
   test-release:
     name: Test with release build
     runs-on: ubuntu-24.04
@@ -351,7 +351,7 @@ jobs:
         # Support incremental compilation here to not penalize CI compile times too much.
         CARGO_PROFILE_RELEASE_INCREMENTAL: true
         CARGO_PROFILE_RELEASE_LTO: false
-      run: cargo test --workspace --release
+      run: cargo test --workspace --exclude=blazecli --release
   test-miri:
     name: Test with Miri
     runs-on: ubuntu-latest

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -42,6 +42,8 @@ capi = []
 check-doc-snippets = []
 # Enable this feature to enable blazesym's DWARF support.
 dwarf = ["blazesym/dwarf"]
+# Enable this feature to enable blazesym's ZSTD support.
+zstd = ["blazesym/zstd"]
 # Enable this feature to re-generate the library's C header file. An
 # up-to-date version of this header should already be available in the
 # include/ directory, so this feature is only necessary when APIs are
@@ -68,8 +70,6 @@ which = {version = "8.0.0", optional = true}
 
 [dependencies]
 # Pinned, because we use #[doc(hidden)] APIs.
-# TODO: Enable `zstd` feature once we enabled it for testing in the main
-#       crate.
 blazesym = {version = ">=0.2.0, <=0.2.1", path = "../", features = ["apk", "demangle", "gsym", "tracing", "zlib"]}
 libc = "0.2"
 # TODO: Remove dependency once MSRV is 1.77.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,9 +38,7 @@ grev = "0.1.4"
 [dependencies]
 anyhow = "1.0"
 bufio = "0.1"
-# TODO: Enable `zstd` feature once we enabled it for testing in the main
-#       crate.
-blazesym = {version = "0.2", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
+blazesym = {version = "0.2", path = "../", features = ["apk", "breakpad", "demangle", "dwarf", "gsym", "tracing", "zlib", "zstd"]}
 clap = {version = "4.5", features = ["derive"]}
 clap_complete = {version = "4.5", optional = true}
 tracing = "0.1"


### PR DESCRIPTION
I found myself with some error logs with `unsupported`, which turned out to be for zstd compressed debug info.

While there's this TODO:

```
# TODO: Enable `zstd` feature once we enabled it for testing in the main
#       crate.
```

It probably doesn't stop us from having an option to enable it in the meantime.