### PR TITLE
Search /usr/lib/debug/.build-id for debug files

### DIFF
--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -11,6 +11,9 @@ pub(crate) mod types;
 //       of concerns that is not a workable location.
 pub(crate) static DEFAULT_DEBUG_DIRS: &[&str] = &["/usr/lib/debug", "/lib/debug/"];
 
+pub(crate) static BUILD_ID_DEBUG_DIR: &str = "/usr/lib/debug/.build-id";
+pub(crate) static BUILD_ID_DEBUG_EXTENSION: &str = "debug";
+
 pub(crate) use parser::BackendImpl;
 pub(crate) use parser::ElfParser;
 pub(crate) use parser::StaticMem;


### PR DESCRIPTION
This takes a stab at #1401. It works on Debian with `libc6-dbg` installed:

```
$ cargo build --package blazecli && ./target/debug/blazecli symbolize elf --path /lib/x86_64-linux-gnu/libc.so.6 0x29c30
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
0x00000000029c30: __libc_start_call_main @ 0x29c30+0x0 ./csu/../sysdeps/nptl/libc_start_call_main.h:29:1
```

It does not work without the change:

```
ivan@cube:~/projects/blazesym$ cargo build --package blazecli && ./target/debug/blazecli symbolize elf --path /lib/x86_64-linux-gnu/libc.so.6 0x29c30
   Compiling blazesym v0.2.1 (/mnt/data/homes/ivan/projects/blazesym)
   Compiling blazecli v0.1.12 (/mnt/data/homes/ivan/projects/blazesym/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.88s
2026-01-08T06:44:20.381871Z  WARN debug link references destination `f5460e3cee00bfee25b429c97bcc4853e5b3a8.debug` which was not found in any known location
0x00000000029c30: <no-symbol>
```

Let me know if it's the right approach before I go about adding a test.