### PR TITLE
capi: Remove unconditional 'dwarf' feature enablement

### DIFF
--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -70,7 +70,7 @@ which = {version = "8.0.0", optional = true}
 # Pinned, because we use #[doc(hidden)] APIs.
 # TODO: Enable `zstd` feature once we enabled it for testing in the main
 #       crate.
-blazesym = {version = ">=0.2.0, <=0.2.1", path = "../", features = ["apk", "demangle", "dwarf", "gsym", "tracing", "zlib"]}
+blazesym = {version = ">=0.2.0, <=0.2.1", path = "../", features = ["apk", "demangle", "gsym", "tracing", "zlib"]}
 libc = "0.2"
 # TODO: Remove dependency once MSRV is 1.77.
 memoffset = "0.9"


### PR DESCRIPTION
For better or worse, commit a54cadff0bf8 ("capi: only set_debug_dirs when dwarf feature enabled") guarded DWARF functionality behind the 'dwarf' feature, making it conditional. At the same time commit 4cbe9675cc3c ("capi: Enable 'bpf' feature of main library") then added it back to the list of blazesym features unconditionally used, making the blazesym-c feature effectively a nop. Given that we have the feature now and don't want to remove it, at least make it do something again, by removing it from the list of unconditional features.