### PR TITLE
Enable zstd feature for test-{sanitizers,release} CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -332,7 +332,9 @@ jobs:
         #CXXFLAGS: "-fsanitize=${{ matrix.sanitizer }}"
         RUSTFLAGS: "-Zsanitizer=${{ matrix.sanitizer }}"
         ASAN_OPTIONS: "detect_odr_violation=0:detect_leaks=1"
-      run: cargo test --workspace --exclude=blazecli --lib --tests --target x86_64-unknown-linux-gnu
+      # Enable `zstd` feature, which is not yet default in
+      # `blazesym-dev` but good to test with in CI.
+      run: cargo test --workspace --lib --tests --features=zstd --target x86_64-unknown-linux-gnu
   test-release:
     name: Test with release build
     runs-on: ubuntu-24.04
@@ -351,7 +353,9 @@ jobs:
         # Support incremental compilation here to not penalize CI compile times too much.
         CARGO_PROFILE_RELEASE_INCREMENTAL: true
         CARGO_PROFILE_RELEASE_LTO: false
-      run: cargo test --workspace --exclude=blazecli --release
+      # Enable `zstd` feature, which is not yet default in
+      # `blazesym-dev` but good to test with in CI.
+      run: cargo test --workspace --features=zstd --release
   test-miri:
     name: Test with Miri
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enable the zstd feature for the test-{sanitizers,release} CI jobs to increase coverage while also eliminating the need for explicitly excluding blazecli tests from being included in them.