### PR TITLE
Make Go test success a requirement for merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -537,6 +537,7 @@ jobs:
       clippy,
       rustfmt,
       cargo-doc,
+      go,
     ]
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
Include the Go test suite in the set of checks required for a merge. There is no good reason to exclude them at this point.