### PR TITLE
Shrink compressed elf sections to fit before caching

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -525,13 +525,14 @@ where
                             (chdr.ch_type, chdr.ch_size)
                         };
 
-                        let decompressed = match ch_type {
+                        let mut decompressed = match ch_type {
                             t if t == ELFCOMPRESS_ZLIB => decompress_zlib(data),
                             t if t == ELFCOMPRESS_ZSTD => decompress_zstd(data),
                             _ => Err(Error::with_unsupported(format!(
                                 "ELF section is compressed with unknown compression algorithm ({ch_type})",
                             ))),
                         }?;
+                        decompressed.shrink_to_fit();
                         debug_assert_eq!(
                             decompressed.len(),
                             ch_size as usize,


### PR DESCRIPTION
Decompressed data might have extra capacity, which means extra memory used when a section is cached for reuse. Shrinking to size helps with this.

Testing with a 5MB glibc debug info on Debian Trixie by creating 10 symbolizers:

* Before: 480MB, 40.6% in `load_section`

<img width="1428" height="772" alt="image" src="https://github.com/user-attachments/assets/0f45d8ab-00f3-405d-bc85-bf1918194065" />

* After: 431MB, 31.9% in `load_section`

<img width="1428" height="706" alt="image" src="https://github.com/user-attachments/assets/fda70fe3-5835-4178-82fc-7f72cc89469f" />

The exact win here is dependent on how much memory is over-allocated in decompression. I'm adding it as a generic step for any compression algorithm to make it harder to regress.