### PR TITLE
Work around Rust ICE in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,7 +188,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v6
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        # TODO: Remove specification and switch back to @nightly once
+        #       https://github.com/rust-lang/rust/issues/151008 is fixed
+        toolchain: 'nightly-2026-01-09'
     - uses: Swatinem/rust-cache@v2
     - uses: actions/setup-python@v6
       id: py312
@@ -319,7 +323,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v6
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        # TODO: Remove specification and switch back to @nightly once
+        #       https://github.com/rust-lang/rust/issues/151008 is fixed
+        toolchain: 'nightly-2026-01-09'
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.sanitizer }}


### PR DESCRIPTION
Nightly toolchains are hitting an internal compiler error, causing some of our tests to fail. Pin the Nightly toolchain we use until the fix has propagated.