### PR TITLE
Eliminate "’" quotation marks

### DIFF
--- a/go/error.go
+++ b/go/error.go
@@ -25,7 +25,7 @@ const (
 	blazeErrWouldBlock blazeErr = -11
 	// Data not valid for the operation were encountered.
 	blazeErrInvalidData blazeErr = -22
-	// The I/O operation’s timeout expired, causing it to be canceled.
+	// The I/O operation's timeout expired, causing it to be canceled.
 	blazeErrTimedOut blazeErr = -110
 	// This operation is unsupported on this platform.
 	blazeErrUnsupported blazeErr = -95

--- a/go/source_process.go
+++ b/go/source_process.go
@@ -13,7 +13,7 @@ type ProcessSource struct {
 	source C.struct_blaze_symbolize_src_process
 }
 
-// newProcessSource creates a new process source with the referenced process’ ID.
+// newProcessSource creates a new process source with the referenced process' ID.
 // https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html#structfield.pid
 func newProcessSource(pid uint32) *ProcessSource {
 	source := C.struct_blaze_symbolize_src_process{}
@@ -33,7 +33,7 @@ func ProcessSourceWithDebugSyms(enabled bool) ProcessSourceOption {
 	}
 }
 
-// ProcessSourceWithPerfMap configures whether to incorporate a process’ perf map file into the symbolization procedure.
+// ProcessSourceWithPerfMap configures whether to incorporate a process' perf map file into the symbolization procedure.
 // See: https://docs.rs/blazesym-c/latest/blazesym_c/struct.blaze_symbolize_src_process.html#structfield.perf_map
 func ProcessSourceWithPerfMap(enabled bool) ProcessSourceOption {
 	return func(ps *ProcessSource) {

--- a/go/sym.go
+++ b/go/sym.go
@@ -11,7 +11,7 @@ type Sym struct {
 	Addr uint64
 	// The byte offset of the address that got symbolized from the start of the symbol (i.e., from addr).
 	Offset uint64
-	// The symbol’s size, if available.
+	// The symbol's size, if available.
 	Size int64
 	// Source code location information for the symbol.
 	CodeInfo *CodeInfo

--- a/src/dwarf/debug_link.rs
+++ b/src/dwarf/debug_link.rs
@@ -10,7 +10,7 @@
 //!   boundary within the section, and
 //! - a four-byte CRC checksum, stored in the same endianness used for the
 //!   executable file itself. The checksum is computed on the debugging
-//!   information file’s full contents by the function given below, passing zero
+//!   information file's full contents by the function given below, passing zero
 //!   as the crc argument.
 
 use std::ffi::OsStr;


### PR DESCRIPTION
Eliminate "’" quotation marks from the code base. We are "'' folks.