### PR TITLE
Amend RemoteProcess contract to require child to print PID

### DIFF
--- a/data/test-mnt-ns-child.c
+++ b/data/test-mnt-ns-child.c
@@ -1,0 +1,148 @@
+/* A binary that sets up a tmpfs mount, copies a shared object into it,
+ * and then loads and calls the await_input function from that library.
+ *
+ * This is designed to be run inside a mount namespace (e.g., via
+ * test-mnt-ns.bin) to test symbolization of libraries that are only
+ * visible within that namespace.
+ *
+ * Usage: test-mnt-ns-child <path-to-libtest.so>
+ */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <unistd.h>
+
+void rm_dir(char **path) {
+  int rc;
+  int err;
+
+  rc = rmdir(*path);
+  if (rc != 0) {
+    err = errno;
+    fprintf(stderr, "warning: failed to remove directory %s: %s (errno: %d)\n",
+            *path, strerror(err), err);
+  }
+}
+
+void unmount(char **path) {
+  int rc;
+  int err;
+
+  rc = umount(*path);
+  if (rc != 0) {
+    err = errno;
+    fprintf(stderr, "warning: failed to unmount %s: %s (errno: %d)\n", *path,
+            strerror(err), err);
+  }
+}
+
+void close_so(void **handle) {
+  int rc;
+  rc = dlclose(*handle);
+  if (rc != 0) {
+    fprintf(stderr, "warning: failed to dlclose: %s\n", dlerror());
+  }
+}
+
+void rm_file(const char **path) {
+  int rc;
+  int err;
+
+  rc = unlink(*path);
+  if (rc != 0) {
+    err = errno;
+    fprintf(stderr, "warning: failed to remove file %s: %s (errno: %d)\n",
+            *path, strerror(err), err);
+  }
+}
+
+int main(int argc, char **argv) {
+  int rc;
+  int err;
+
+  if (argc != 2) {
+    fprintf(stderr, "usage: %s <path-to-libtest.so>\n",
+            argc > 0 ? argv[0] : "<program>");
+    return -1;
+  }
+
+  char const *libtest_src = argv[1];
+
+  /* Create a temporary directory and mount a ramdisk in there.
+   * This should be done inside a mount namespace so that the mount
+   * is only visible to this process.
+   */
+  char tmpl[] = "/tmp/mnt-ns.XXXXXX";
+  char *dir = mkdtemp(tmpl);
+
+  if (dir == NULL) {
+    err = errno;
+    fprintf(stderr, "mkdtemp failed: %s (errno: %d)\n", strerror(err), err);
+    return err;
+  }
+  char *_rm_dir __attribute__((cleanup(rm_dir))) = dir;
+
+  rc = mount("tmpfs", dir, "tmpfs", 0, "size=16M");
+  if (rc != 0) {
+    err = errno;
+    fprintf(stderr, "mount failed: %s (errno: %d)\n", strerror(err), err);
+    return err;
+  }
+  char *_umount __attribute__((cleanup(unmount))) = dir;
+
+  char libtest_buf[256];
+  rc = snprintf(libtest_buf, sizeof(libtest_buf), "%s/libtest-so.so", dir);
+  if (rc >= sizeof(libtest_buf)) {
+    fprintf(
+        stderr,
+        "failed to construct destination path: insufficient buffer space\n");
+    return -1;
+  }
+  libtest_buf[rc] = 0;
+  char const *libtest_dst = libtest_buf;
+
+  char cmd_buf[256];
+  rc = snprintf(cmd_buf, sizeof(cmd_buf), "cp %s %s", libtest_src, libtest_dst);
+  if (rc >= sizeof(cmd_buf)) {
+    fprintf(stderr,
+            "failed to construct cp command: insufficient buffer space\n");
+    return -1;
+  }
+  cmd_buf[rc] = 0;
+
+  char const *cp_cmd = cmd_buf;
+  /* Sorry, not gonna put up with copying a file in C using system
+   * APIs...
+   */
+  rc = system(cp_cmd);
+  if (rc != 0) {
+    err = errno;
+    fprintf(stderr, "failed to copy %s to %s: %d\n", libtest_src, libtest_dst,
+            rc);
+    return err;
+  }
+  const char *_rm __attribute__((cleanup(rm_file))) = libtest_dst;
+
+  void *handle;
+  handle = dlopen(libtest_dst, RTLD_NOW);
+  if (handle == NULL) {
+    fprintf(stderr, "failed to dlopen %s: %s\n", libtest_dst, dlerror());
+    return -1;
+  }
+  void *_dlclose __attribute__((cleanup(close_so))) = handle;
+
+  void *sym;
+  sym = dlsym(handle, "await_input");
+  if (sym == NULL) {
+    fprintf(stderr, "failed to dlsym `await_input` function: %s\n", dlerror());
+    return -1;
+  }
+
+  int (*await_input)(void) = sym;
+  return await_input();
+}

--- a/data/test-mnt-ns.c
+++ b/data/test-mnt-ns.c
@@ -1,68 +1,27 @@
+/* A binary that creates a new mount namespace and then executes
+ * a specified binary with any provided arguments.
+ *
+ * This is a generic launcher for running programs in isolated mount
+ * namespaces. The actual work is delegated to the child binary.
+ */
+
 #define _GNU_SOURCE
-#include <dlfcn.h>
 #include <errno.h>
 #include <sched.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <sys/mount.h>
 #include <unistd.h>
-
-void rm_dir(char **path) {
-  int rc;
-  int err;
-
-  rc = rmdir(*path);
-  if (rc != 0) {
-    err = errno;
-    fprintf(stderr, "warning: failed to remove directory %s: %s (errno: %d)\n",
-            *path, strerror(err), err);
-  }
-}
-
-void unmount(char **path) {
-  int rc;
-  int err;
-
-  rc = umount(*path);
-  if (rc != 0) {
-    err = errno;
-    fprintf(stderr, "warning: failed to unmount %s: %s (errno: %d)\n", *path,
-            strerror(err), err);
-  }
-}
-
-void close_so(void **handle) {
-  int rc;
-  rc = dlclose(*handle);
-  if (rc != 0) {
-    fprintf(stderr, "warning: failed to dlclose: %s\n", dlerror());
-  }
-}
-
-void rm_file(const char **path) {
-  int rc;
-  int err;
-
-  rc = unlink(*path);
-  if (rc != 0) {
-    err = errno;
-    fprintf(stderr, "warning: failed to remove file %s: %s (errno: %d)\n",
-            *path, strerror(err), err);
-  }
-}
 
 int main(int argc, char **argv) {
   int rc;
   int err;
 
-  if (argc != 2) {
-    fprintf(stderr, "usage: %s <path-to-libtest.so>\n",
+  if (argc < 2) {
+    fprintf(stderr, "usage: %s <binary> [args...]\n",
             argc > 0 ? argv[0] : "<program>");
     return -1;
   }
 
-  char const *libtest_src = argv[1];
   /* Detach ourselves from the default mount namespace, effectively
    * creating a new one for this program.
    */
@@ -73,75 +32,15 @@ int main(int argc, char **argv) {
     return err;
   }
 
-  /* Create a temporary directory (now already inside this mount
-   * namespace) and mount a ramdisk in there.
+  /* Execute the specified binary with the remaining arguments.
+   * argv[1] is the binary path, argv[2..] are its arguments.
+   * We pass &argv[1] so that argv[1] becomes argv[0] for the child.
    */
-  char tmpl[] = "/tmp/mnt-ns.XXXXXX";
-  char *dir = mkdtemp(tmpl);
+  execv(argv[1], &argv[1]);
 
-  if (dir == NULL) {
-    err = errno;
-    fprintf(stderr, "mkdtemp failed: %s (errno: %d)\n", strerror(err), err);
-    return err;
-  }
-  char *_rm_dir __attribute__((cleanup(rm_dir))) = dir;
-
-  rc = mount("tmpfs", dir, "tmpfs", 0, "size=16M");
-  if (rc != 0) {
-    err = errno;
-    fprintf(stderr, "mount failed: %s (errno: %d)\n", strerror(err), err);
-    return err;
-  }
-  char *_umount __attribute__((cleanup(unmount))) = dir;
-
-  char libtest_buf[256];
-  rc = snprintf(libtest_buf, sizeof(libtest_buf), "%s/libtest-so.so", dir);
-  if (rc >= sizeof(libtest_buf)) {
-    fprintf(
-        stderr,
-        "failed to construct destination path: insufficient buffer space\n");
-    return -1;
-  }
-  libtest_buf[rc] = 0;
-  char const *libtest_dst = libtest_buf;
-
-  char cmd_buf[256];
-  rc = snprintf(cmd_buf, sizeof(cmd_buf), "cp %s %s", libtest_src, libtest_dst);
-  if (rc >= sizeof(cmd_buf)) {
-    fprintf(stderr,
-            "failed to construct cp command: insufficient buffer space\n");
-    return -1;
-  }
-  cmd_buf[rc] = 0;
-
-  char const *cp_cmd = cmd_buf;
-  /* Sorry, not gonna put up with copying a file in C using system
-   * APIs...
-   */
-  rc = system(cp_cmd);
-  if (rc != 0) {
-    err = errno;
-    fprintf(stderr, "failed to copy %s to %s: %d\n", libtest_src, libtest_dst,
-            rc);
-    return err;
-  }
-  const char *_rm __attribute__((cleanup(rm_file))) = libtest_dst;
-
-  void *handle;
-  handle = dlopen(libtest_dst, RTLD_NOW);
-  if (handle == NULL) {
-    fprintf(stderr, "failed to dlopen %s: %s\n", libtest_dst, dlerror());
-    return -1;
-  }
-  void *_dlclose __attribute__((cleanup(close_so))) = handle;
-
-  void *sym;
-  sym = dlsym(handle, "await_input");
-  if (sym == NULL) {
-    fprintf(stderr, "failed to dlsym `await_input` function: %s\n", dlerror());
-    return -1;
-  }
-
-  int (*await_input)(void) = sym;
-  return await_input();
+  /* If we get here, execv failed */
+  err = errno;
+  fprintf(stderr, "execv failed for %s: %s (errno: %d)\n", argv[1],
+          strerror(err), err);
+  return err;
 }

--- a/data/test-so.c
+++ b/data/test-so.c
@@ -1,5 +1,6 @@
 #include <unistd.h>
 #include <stdio.h>
+#include <sys/types.h>
 
 #include "test-so.h"
 
@@ -12,8 +13,15 @@ int the_ignored_answer(void) {
 }
 
 int await_input(void) {
+  pid_t pid = getpid();
+  int rc = write(STDOUT_FILENO, &pid, sizeof(pid));
+  if (rc < 0) {
+    perror("failed to write pid to stdout");
+    return 1;
+  }
+
   void* addr = (void*)&await_input;
-  int rc = write(STDOUT_FILENO, &addr, sizeof(addr));
+  rc = write(STDOUT_FILENO, &addr, sizeof(addr));
   if (rc < 0) {
     perror("failed to write address to stdout");
     return 1;

--- a/dev/build.rs
+++ b/dev/build.rs
@@ -688,6 +688,9 @@ fn prepare_test_files() {
     let src = data_dir.join("test-mnt-ns.c");
     cc(&src, "test-mnt-ns.bin", &[]);
 
+    let src = data_dir.join("test-mnt-ns-child.c");
+    cc(&src, "test-mnt-ns-child.bin", &[]);
+
     let src = data_dir.join("test-block.c");
     let ld_script = data_dir.join("test-block-augmented.ld");
     let args = &[


### PR DESCRIPTION
The current contract of the RemoteProcess only requires the child spawned to print some address for later symbolization --- with the assumption being that this address belongs to <PID-of-child>. In order to be more flexible down the line, amend the contract to require children print the PID to use for symbolization as well. This will make nesting of child processes feasible, which will increase flexibility.