### PR TITLE
Unify C test files some more

### DIFF
--- a/data/test-chroot-dbg-link.c
+++ b/data/test-chroot-dbg-link.c
@@ -11,7 +11,9 @@
 #include "util.h"
 
 #include <dlfcn.h>
+#include <errno.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -40,7 +42,7 @@ int main(int argc, char **argv) {
    */
   rc = chroot(mount_dir);
   if (rc < 0) {
-    perror("failed to chroot");
+    fprintf(stderr, "failed to chroot: %s\n", strerror(errno));
     return 1;
   }
 
@@ -67,13 +69,13 @@ int main(int argc, char **argv) {
   pid_t pid = getpid();
   rc = write(STDOUT_FILENO, &pid, sizeof(pid));
   if (rc < 0) {
-    perror("failed to write pid to stdout");
+    fprintf(stderr, "failed to write pid to stdout: %s\n", strerror(errno));
     return 1;
   }
 
   rc = write(STDOUT_FILENO, &private_addr, sizeof(private_addr));
   if (rc < 0) {
-    perror("failed to write address to stdout");
+    fprintf(stderr, "failed to write address to stdout: %s\n", strerror(errno));
     return 1;
   }
 

--- a/data/test-so.c
+++ b/data/test-so.c
@@ -1,5 +1,7 @@
-#include <unistd.h>
+#include <errno.h>
 #include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "test-so.h"
 
@@ -30,7 +32,7 @@ int await_input(void) {
   char buf[2];
   int rc = read(STDIN_FILENO, buf, sizeof(buf));
   if (rc < 0) {
-    perror("failed to read from stdin");
+    fprintf(stderr, "failed to read from stdin: %s\n", strerror(errno));
     return 1;
   }
   return 0;


### PR DESCRIPTION
- use fprintf over perror for consistency (dlsym errors, for example, can't use perror)
- return 1 on error
- cast dlsym return immediately