### PR TITLE
capi: Add callback for symbolizer

### DIFF
--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -768,10 +768,42 @@ typedef struct blaze_symbolizer_opts {
    */
   bool demangle;
   /**
+   * Explicit pad to avoid implicit gaps.
+   */
+  uint8_t _pad_a[4];
+  /**
+   * Callback for custom process member path dispatch.
+   *
+   * When set, this callback is invoked for each process member that
+   * has a file path during process symbolization. It allows the
+   * caller to provide an alternative ELF file path for
+   * symbolization (e.g., fetched via debuginfod).
+   *
+   * The callback receives the `/proc/<pid>/map_files/...` path and
+   * the symbolic path from `/proc/<pid>/maps`, along with the
+   * user-provided context pointer
+   * ([`process_dispatch_ctx`][Self::process_dispatch_ctx]).
+   *
+   * The callback should return one of:
+   * - A `malloc`'d path string to an alternative ELF file to use for
+   *   symbolization. The library will `free` this string after use.
+   * - `NULL` to use the default symbolization behavior for this member.
+   *
+   * Set to `NULL` to disable custom dispatch.
+   */
+  char *(*process_dispatch_cb)(const char *maps_file,
+                               const char *symbolic_path,
+                               void *ctx);
+  /**
+   * Opaque context pointer passed to
+   * [`process_dispatch_cb`][Self::process_dispatch_cb].
+   */
+  void *process_dispatch_ctx;
+  /**
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[20];
+  uint8_t reserved[24];
 } blaze_symbolizer_opts;
 
 /**

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -710,6 +710,38 @@ typedef struct blaze_normalize_opts {
 typedef struct blaze_symbolizer blaze_symbolizer;
 
 /**
+ * Configuration for custom process member dispatch.
+ *
+ * When provided to [`blaze_symbolizer_opts`] via
+ * [`process_dispatch`][blaze_symbolizer_opts::process_dispatch], the
+ * callback is invoked for each process member that has a file path during
+ * process symbolization. It allows the caller to provide an alternative
+ * ELF file path for symbolization. For example, the path may be fetched
+ * via debuginfod.
+ *
+ * The callback receives the `/proc/<pid>/map_files/...` path and the
+ * symbolic path from `/proc/<pid>/maps`, along with the user-provided
+ * context pointer ([`ctx`][Self::ctx]).
+ *
+ * The callback should return one of:
+ * - A `malloc`'d path string to an alternative ELF file to use for
+ *   symbolization. The library will `free` this string after use.
+ * - `NULL` to use the default symbolization behavior for this member.
+ */
+typedef struct blaze_symbolizer_dispatch {
+  /**
+   * The dispatch callback function. Must not be `NULL`.
+   */
+  char *(*dispatch_cb)(const char *maps_file,
+                       const char *symbolic_path,
+                       void *ctx);
+  /**
+   * Opaque context pointer passed to [`dispatch_cb`][Self::dispatch_cb].
+   */
+  void *ctx;
+} blaze_symbolizer_dispatch;
+
+/**
  * Options for configuring [`blaze_symbolizer`] objects.
  */
 typedef struct blaze_symbolizer_opts {
@@ -768,42 +800,20 @@ typedef struct blaze_symbolizer_opts {
    */
   bool demangle;
   /**
-   * Explicit pad to avoid implicit gaps.
+   * Unused member available for future expansion. Must be initialized
+   * to zero.
    */
-  uint8_t _pad_a[4];
+  uint8_t _reserved1[4];
   /**
-   * Callback for custom process member path dispatch.
-   *
-   * When set, this callback is invoked for each process member that
-   * has a file path during process symbolization. It allows the
-   * caller to provide an alternative ELF file path for
-   * symbolization (e.g., fetched via debuginfod).
-   *
-   * The callback receives the `/proc/<pid>/map_files/...` path and
-   * the symbolic path from `/proc/<pid>/maps`, along with the
-   * user-provided context pointer
-   * ([`process_dispatch_ctx`][Self::process_dispatch_ctx]).
-   *
-   * The callback should return one of:
-   * - A `malloc`'d path string to an alternative ELF file to use for
-   *   symbolization. The library will `free` this string after use.
-   * - `NULL` to use the default symbolization behavior for this member.
-   *
-   * Set to `NULL` to disable custom dispatch.
+   * Optional pointer to a [`blaze_symbolizer_dispatch`] struct for custom
+   * process member dispatch. Set to `NULL` to disable.
    */
-  char *(*process_dispatch_cb)(const char *maps_file,
-                               const char *symbolic_path,
-                               void *ctx);
-  /**
-   * Opaque context pointer passed to
-   * [`process_dispatch_cb`][Self::process_dispatch_cb].
-   */
-  void *process_dispatch_ctx;
+  const struct blaze_symbolizer_dispatch *process_dispatch;
   /**
    * Unused member available for future expansion. Must be initialized
    * to zero.
    */
-  uint8_t reserved[24];
+  uint8_t reserved[8];
 } blaze_symbolizer_opts;
 
 /**

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -650,6 +650,36 @@ pub(crate) unsafe fn from_cstr(cstr: *const c_char) -> PathBuf {
 }
 
 
+/// Configuration for custom process member dispatch.
+///
+/// When provided to [`blaze_symbolizer_opts`] via
+/// [`process_dispatch`][blaze_symbolizer_opts::process_dispatch], the
+/// callback is invoked for each process member that has a file path during
+/// process symbolization. It allows the caller to provide an alternative
+/// ELF file path for symbolization. For example, the path may be fetched
+/// via debuginfod.
+///
+/// The callback receives the `/proc/<pid>/map_files/...` path and the
+/// symbolic path from `/proc/<pid>/maps`, along with the user-provided
+/// context pointer ([`ctx`][Self::ctx]).
+///
+/// The callback should return one of:
+/// - A `malloc`'d path string to an alternative ELF file to use for
+///   symbolization. The library will `free` this string after use.
+/// - `NULL` to use the default symbolization behavior for this member.
+#[repr(C)]
+#[derive(Debug)]
+pub struct blaze_symbolizer_dispatch {
+    /// The dispatch callback function. Must not be `NULL`.
+    pub dispatch_cb: unsafe extern "C" fn(
+        maps_file: *const c_char,
+        symbolic_path: *const c_char,
+        ctx: *mut c_void,
+    ) -> *mut c_char,
+    /// Opaque context pointer passed to [`dispatch_cb`][Self::dispatch_cb].
+    pub ctx: *mut c_void,
+}
+
 /// Options for configuring [`blaze_symbolizer`] objects.
 #[repr(C)]
 #[derive(Debug)]
@@ -694,39 +724,15 @@ pub struct blaze_symbolizer_opts {
     /// languages are Rust and C++ and the flag will have no effect if
     /// the underlying language does not mangle symbols (such as C).
     pub demangle: bool,
-    /// Explicit pad to avoid implicit gaps.
-    pub _pad_a: [u8; 4],
-    /// Callback for custom process member path dispatch.
-    ///
-    /// When set, this callback is invoked for each process member that
-    /// has a file path during process symbolization. It allows the
-    /// caller to provide an alternative ELF file path for
-    /// symbolization (e.g., fetched via debuginfod).
-    ///
-    /// The callback receives the `/proc/<pid>/map_files/...` path and
-    /// the symbolic path from `/proc/<pid>/maps`, along with the
-    /// user-provided context pointer
-    /// ([`process_dispatch_ctx`][Self::process_dispatch_ctx]).
-    ///
-    /// The callback should return one of:
-    /// - A `malloc`'d path string to an alternative ELF file to use for
-    ///   symbolization. The library will `free` this string after use.
-    /// - `NULL` to use the default symbolization behavior for this member.
-    ///
-    /// Set to `NULL` to disable custom dispatch.
-    pub process_dispatch_cb: Option<
-        unsafe extern "C" fn(
-            maps_file: *const c_char,
-            symbolic_path: *const c_char,
-            ctx: *mut c_void,
-        ) -> *mut c_char,
-    >,
-    /// Opaque context pointer passed to
-    /// [`process_dispatch_cb`][Self::process_dispatch_cb].
-    pub process_dispatch_ctx: *mut c_void,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 24],
+    pub _reserved1: [u8; 4],
+    /// Optional pointer to a [`blaze_symbolizer_dispatch`] struct for custom
+    /// process member dispatch. Set to `NULL` to disable.
+    pub process_dispatch: *const blaze_symbolizer_dispatch,
+    /// Unused member available for future expansion. Must be initialized
+    /// to zero.
+    pub reserved: [u8; 8],
 }
 
 impl Default for blaze_symbolizer_opts {
@@ -739,10 +745,9 @@ impl Default for blaze_symbolizer_opts {
             code_info: false,
             inlined_fns: false,
             demangle: false,
-            _pad_a: [0; 4],
-            process_dispatch_cb: None,
-            process_dispatch_ctx: ptr::null_mut(),
-            reserved: [0; 24],
+            _reserved1: [0; 4],
+            process_dispatch: ptr::null(),
+            reserved: [0; 8],
         }
     }
 }
@@ -798,9 +803,8 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
         code_info,
         inlined_fns,
         demangle,
-        _pad_a: _,
-        process_dispatch_cb,
-        process_dispatch_ctx,
+        _reserved1: _,
+        process_dispatch,
         reserved: _,
     } = opts;
 
@@ -810,37 +814,39 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
         .enable_inlined_fns(inlined_fns)
         .enable_demangling(demangle);
 
-    let builder = if debug_dirs.is_null() {
-        builder
+    let debug_dir_paths = if debug_dirs.is_null() {
+        None
     } else {
-        #[cfg(feature = "dwarf")]
-        {
-            // SAFETY: The caller ensures that the pointer is valid and the count
-            //         matches.
-            let slice = unsafe { slice_from_user_array(debug_dirs, _debug_dirs_len) };
-            let iter = slice.iter().map(|cstr| {
-                Path::new(OsStr::from_bytes(
-                    // SAFETY: The caller ensures that valid C strings are
-                    //         provided.
-                    unsafe { CStr::from_ptr(cstr.cast()) }.to_bytes(),
-                ))
-            });
-
-            builder.set_debug_dirs(Some(iter))
-        }
-
-        #[cfg(not(feature = "dwarf"))]
-        {
-            builder
-        }
+        // SAFETY: The caller ensures that the pointer is valid and the count
+        //         matches.
+        let slice = unsafe { slice_from_user_array(debug_dirs, _debug_dirs_len) };
+        Some(
+            slice
+                .iter()
+                .map(|cstr| {
+                    PathBuf::from(OsStr::from_bytes(
+                        // SAFETY: The caller ensures that valid C strings are
+                        //         provided.
+                        unsafe { CStr::from_ptr(cstr.cast()) }.to_bytes(),
+                    ))
+                })
+                .collect::<Vec<_>>(),
+        )
     };
 
-    let builder = if let Some(cb) = process_dispatch_cb {
-        // Cast the context pointer to usize so the closure is Send.
-        // The caller is responsible for thread safety of the context.
-        let ctx = process_dispatch_ctx as usize;
+    #[cfg(feature = "dwarf")]
+    let builder = if let Some(ref dirs) = debug_dir_paths {
+        builder.set_debug_dirs(Some(dirs.iter().map(PathBuf::as_path)))
+    } else {
+        builder
+    };
+
+    let builder = if !process_dispatch.is_null() {
+        // SAFETY: The caller guarantees that the pointer is valid.
+        let dispatch = unsafe { &*process_dispatch };
+        let cb = dispatch.dispatch_cb;
+        let ctx = dispatch.ctx;
         builder.set_process_dispatcher(move |info| {
-            let ctx = ctx as *mut c_void;
             match info.member_entry {
                 ProcessMemberType::Path(entry) => {
                     let maps_file = CString::new(entry.maps_file.as_os_str().as_bytes())
@@ -858,7 +864,11 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
                     //         NUL-terminated, `malloc`'d C string.
                     let path_cstr = unsafe { CStr::from_ptr(result) };
                     let path = Path::new(OsStr::from_bytes(path_cstr.to_bytes()));
-                    let resolver = ElfResolver::open(path);
+                    let resolver = if let Some(ref dirs) = debug_dir_paths {
+                        ElfResolver::open_with_debug_dirs(path, dirs)
+                    } else {
+                        ElfResolver::open(path)
+                    };
                     // SAFETY: The string was `malloc`'d by the callback.
                     unsafe { libc::free(result.cast()) };
                     Ok(Some(Box::new(resolver?)))
@@ -1431,7 +1441,7 @@ mod tests {
         assert_eq!(mem::size_of::<blaze_symbolize_src_process>(), 32);
         assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_data>(), 40);
         assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_file>(), 32);
-        assert_eq!(mem::size_of::<blaze_symbolizer_opts>(), 72);
+        assert_eq!(mem::size_of::<blaze_symbolizer_opts>(), 48);
         assert_eq!(mem::size_of::<blaze_symbolize_code_info>(), 32);
         assert_eq!(mem::size_of::<blaze_symbolize_inlined_fn>(), 48);
         assert_eq!(mem::size_of::<blaze_sym>(), 104);
@@ -1541,7 +1551,7 @@ mod tests {
         };
         assert_eq!(
             format!("{opts:?}"),
-            "blaze_symbolizer_opts { type_size: 16, debug_dirs: 0x0, debug_dirs_len: 0, auto_reload: false, code_info: false, inlined_fns: false, demangle: true, _pad_a: [0, 0, 0, 0], process_dispatch_cb: None, process_dispatch_ctx: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
+            "blaze_symbolizer_opts { type_size: 16, debug_dirs: 0x0, debug_dirs_len: 0, auto_reload: false, code_info: false, inlined_fns: false, demangle: true, _reserved1: [0, 0, 0, 0], process_dispatch: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0] }"
         );
     }
 
@@ -2379,19 +2389,19 @@ mod tests {
         let () = unsafe { blaze_symbolizer_free(symbolizer) };
     }
 
-    /// Helper to test process dispatch callbacks. Creates a symbolizer
-    /// with the given callback (ctx set to `0xc0ffee`), symbolizes
-    /// the given address, and checks that the symbol name contains
-    /// `expected_sym`. If `expected_sym` is `None`, asserts that
-    /// symbolization failed.
+    /// Symbolize `addr` in the current process using the given dispatch
+    /// callback.
     unsafe fn symbolize_with_dispatch(
         cb: unsafe extern "C" fn(*const c_char, *const c_char, *mut c_void) -> *mut c_char,
         addr: Addr,
         expected_sym: Option<&str>,
     ) {
+        let dispatch = blaze_symbolizer_dispatch {
+            dispatch_cb: cb,
+            ctx: 0xc0ffee as *mut c_void,
+        };
         let opts = blaze_symbolizer_opts {
-            process_dispatch_cb: Some(cb),
-            process_dispatch_ctx: 0xc0ffee as *mut c_void,
+            process_dispatch: &dispatch,
             ..Default::default()
         };
         let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -2,16 +2,20 @@ use std::alloc::alloc;
 use std::alloc::dealloc;
 use std::alloc::Layout;
 use std::ffi::CStr;
+use std::ffi::CString;
 use std::ffi::OsStr;
 use std::fmt::Debug;
+use std::io;
 use std::mem;
 use std::ops::Deref as _;
 use std::os::raw::c_char;
+use std::os::raw::c_void;
 use std::os::unix::ffi::OsStrExt as _;
 use std::path::Path;
 use std::path::PathBuf;
 use std::ptr;
 
+use blazesym::helper::ElfResolver;
 use blazesym::symbolize::cache;
 use blazesym::symbolize::source::Elf;
 use blazesym::symbolize::source::GsymData;
@@ -21,6 +25,7 @@ use blazesym::symbolize::source::Process;
 use blazesym::symbolize::source::Source;
 use blazesym::symbolize::CodeInfo;
 use blazesym::symbolize::Input;
+use blazesym::symbolize::ProcessMemberType;
 use blazesym::symbolize::Reason;
 use blazesym::symbolize::Sym;
 use blazesym::symbolize::Symbolized;
@@ -689,9 +694,39 @@ pub struct blaze_symbolizer_opts {
     /// languages are Rust and C++ and the flag will have no effect if
     /// the underlying language does not mangle symbols (such as C).
     pub demangle: bool,
+    /// Explicit pad to avoid implicit gaps.
+    pub _pad_a: [u8; 4],
+    /// Callback for custom process member path dispatch.
+    ///
+    /// When set, this callback is invoked for each process member that
+    /// has a file path during process symbolization. It allows the
+    /// caller to provide an alternative ELF file path for
+    /// symbolization (e.g., fetched via debuginfod).
+    ///
+    /// The callback receives the `/proc/<pid>/map_files/...` path and
+    /// the symbolic path from `/proc/<pid>/maps`, along with the
+    /// user-provided context pointer
+    /// ([`process_dispatch_ctx`][Self::process_dispatch_ctx]).
+    ///
+    /// The callback should return one of:
+    /// - A `malloc`'d path string to an alternative ELF file to use for
+    ///   symbolization. The library will `free` this string after use.
+    /// - `NULL` to use the default symbolization behavior for this member.
+    ///
+    /// Set to `NULL` to disable custom dispatch.
+    pub process_dispatch_cb: Option<
+        unsafe extern "C" fn(
+            maps_file: *const c_char,
+            symbolic_path: *const c_char,
+            ctx: *mut c_void,
+        ) -> *mut c_char,
+    >,
+    /// Opaque context pointer passed to
+    /// [`process_dispatch_cb`][Self::process_dispatch_cb].
+    pub process_dispatch_ctx: *mut c_void,
     /// Unused member available for future expansion. Must be initialized
     /// to zero.
-    pub reserved: [u8; 20],
+    pub reserved: [u8; 24],
 }
 
 impl Default for blaze_symbolizer_opts {
@@ -704,7 +739,10 @@ impl Default for blaze_symbolizer_opts {
             code_info: false,
             inlined_fns: false,
             demangle: false,
-            reserved: [0; 20],
+            _pad_a: [0; 4],
+            process_dispatch_cb: None,
+            process_dispatch_ctx: ptr::null_mut(),
+            reserved: [0; 24],
         }
     }
 }
@@ -760,6 +798,9 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
         code_info,
         inlined_fns,
         demangle,
+        _pad_a: _,
+        process_dispatch_cb,
+        process_dispatch_ctx,
         reserved: _,
     } = opts;
 
@@ -792,6 +833,41 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
         {
             builder
         }
+    };
+
+    let builder = if let Some(cb) = process_dispatch_cb {
+        // Cast the context pointer to usize so the closure is Send.
+        // The caller is responsible for thread safety of the context.
+        let ctx = process_dispatch_ctx as usize;
+        builder.set_process_dispatcher(move |info| {
+            let ctx = ctx as *mut c_void;
+            match info.member_entry {
+                ProcessMemberType::Path(entry) => {
+                    let maps_file = CString::new(entry.maps_file.as_os_str().as_bytes())
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                    let sym_path = CString::new(entry.symbolic_path.as_os_str().as_bytes())
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                    // SAFETY: The caller guarantees that the callback is safe
+                    //         to call with valid C string pointers and the
+                    //         provided context.
+                    let result = unsafe { cb(maps_file.as_ptr(), sym_path.as_ptr(), ctx) };
+                    if result.is_null() {
+                        return Ok(None)
+                    }
+                    // SAFETY: The callback is required to return a valid,
+                    //         NUL-terminated, `malloc`'d C string.
+                    let path_cstr = unsafe { CStr::from_ptr(result) };
+                    let path = Path::new(OsStr::from_bytes(path_cstr.to_bytes()));
+                    let resolver = ElfResolver::open(path);
+                    // SAFETY: The string was `malloc`'d by the callback.
+                    unsafe { libc::free(result.cast()) };
+                    Ok(Some(Box::new(resolver?)))
+                }
+                _ => Ok(None),
+            }
+        })
+    } else {
+        builder
     };
 
     let symbolizer = builder.build();
@@ -1355,7 +1431,7 @@ mod tests {
         assert_eq!(mem::size_of::<blaze_symbolize_src_process>(), 32);
         assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_data>(), 40);
         assert_eq!(mem::size_of::<blaze_symbolize_src_gsym_file>(), 32);
-        assert_eq!(mem::size_of::<blaze_symbolizer_opts>(), 48);
+        assert_eq!(mem::size_of::<blaze_symbolizer_opts>(), 72);
         assert_eq!(mem::size_of::<blaze_symbolize_code_info>(), 32);
         assert_eq!(mem::size_of::<blaze_symbolize_inlined_fn>(), 48);
         assert_eq!(mem::size_of::<blaze_sym>(), 104);
@@ -1465,7 +1541,7 @@ mod tests {
         };
         assert_eq!(
             format!("{opts:?}"),
-            "blaze_symbolizer_opts { type_size: 16, debug_dirs: 0x0, debug_dirs_len: 0, auto_reload: false, code_info: false, inlined_fns: false, demangle: true, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
+            "blaze_symbolizer_opts { type_size: 16, debug_dirs: 0x0, debug_dirs_len: 0, auto_reload: false, code_info: false, inlined_fns: false, demangle: true, _pad_a: [0, 0, 0, 0], process_dispatch_cb: None, process_dispatch_ctx: 0x0, reserved: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }"
         );
     }
 
@@ -2301,5 +2377,115 @@ mod tests {
 
         let () = unsafe { blaze_syms_free(result) };
         let () = unsafe { blaze_symbolizer_free(symbolizer) };
+    }
+
+    /// Helper to test process dispatch callbacks. Creates a symbolizer
+    /// with the given callback (ctx set to `0xc0ffee`), symbolizes
+    /// the given address, and checks that the symbol name contains
+    /// `expected_sym`. If `expected_sym` is `None`, asserts that
+    /// symbolization failed.
+    unsafe fn symbolize_with_dispatch(
+        cb: unsafe extern "C" fn(*const c_char, *const c_char, *mut c_void) -> *mut c_char,
+        addr: Addr,
+        expected_sym: Option<&str>,
+    ) {
+        let opts = blaze_symbolizer_opts {
+            process_dispatch_cb: Some(cb),
+            process_dispatch_ctx: 0xc0ffee as *mut c_void,
+            ..Default::default()
+        };
+        let symbolizer = unsafe { blaze_symbolizer_new_opts(&opts) };
+        assert!(!symbolizer.is_null());
+
+        let process_src = blaze_symbolize_src_process {
+            pid: 0,
+            debug_syms: true,
+            ..Default::default()
+        };
+
+        let addrs = [addr];
+        let result = unsafe {
+            blaze_symbolize_process_abs_addrs(symbolizer, &process_src, addrs.as_ptr(), addrs.len())
+        };
+        let () = unsafe { blaze_symbolizer_free(symbolizer) };
+
+        if let Some(expected) = expected_sym {
+            assert!(!result.is_null());
+            let result = unsafe { &*result };
+            assert_eq!(result.cnt, 1);
+            let syms = unsafe { slice::from_raw_parts(result.syms.as_ptr(), result.cnt) };
+            let name = unsafe { CStr::from_ptr(syms[0].name) }.to_str().unwrap();
+            assert!(name.contains(expected), "{name}");
+            let () = unsafe { blaze_syms_free(result) };
+        } else {
+            assert!(result.is_null());
+        }
+    }
+
+    /// Make sure that we can symbolize an address in the current process
+    /// using a custom process dispatch callback that returns the
+    /// `maps_file` path as-is.
+    #[test]
+    fn symbolize_in_process_with_dispatch() {
+        unsafe extern "C" fn cb(
+            maps_file: *const c_char,
+            _symbolic_path: *const c_char,
+            ctx: *mut c_void,
+        ) -> *mut c_char {
+            assert_eq!(ctx as usize, 0xc0ffee);
+            unsafe { libc::strdup(maps_file) }
+        }
+
+        unsafe {
+            symbolize_with_dispatch(
+                cb,
+                symbolize_in_process_with_dispatch as *const () as Addr,
+                Some("symbolize_in_process_with_dispatch"),
+            )
+        };
+    }
+
+    /// Make sure that a dispatch callback returning NULL falls back to
+    /// the default symbolization behavior.
+    #[test]
+    fn symbolize_in_process_with_null_dispatch() {
+        unsafe extern "C" fn cb(
+            _maps_file: *const c_char,
+            _symbolic_path: *const c_char,
+            ctx: *mut c_void,
+        ) -> *mut c_char {
+            assert_eq!(ctx as usize, 0xc0ffee);
+            ptr::null_mut()
+        }
+
+        unsafe {
+            symbolize_with_dispatch(
+                cb,
+                symbolize_in_process_with_null_dispatch as *const () as Addr,
+                Some("symbolize_in_process_with_null_dispatch"),
+            )
+        };
+    }
+
+    /// Make sure that a dispatch callback returning a non-existent path
+    /// causes symbolization to fail for that address.
+    #[test]
+    fn symbolize_in_process_with_bad_dispatch() {
+        unsafe extern "C" fn cb(
+            _maps_file: *const c_char,
+            _symbolic_path: *const c_char,
+            ctx: *mut c_void,
+        ) -> *mut c_char {
+            assert_eq!(ctx as usize, 0xc0ffee);
+            unsafe { libc::strdup(c"/no/such/file".as_ptr()) }
+        }
+
+        unsafe {
+            symbolize_with_dispatch(
+                cb,
+                symbolize_in_process_with_bad_dispatch as *const () as Addr,
+                None,
+            )
+        };
     }
 }

--- a/capi/src/symbolize.rs
+++ b/capi/src/symbolize.rs
@@ -798,7 +798,7 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
     let blaze_symbolizer_opts {
         type_size: _,
         debug_dirs,
-        debug_dirs_len: _debug_dirs_len,
+        debug_dirs_len,
         auto_reload,
         code_info,
         inlined_fns,
@@ -819,7 +819,7 @@ pub unsafe extern "C" fn blaze_symbolizer_new_opts(
     } else {
         // SAFETY: The caller ensures that the pointer is valid and the count
         //         matches.
-        let slice = unsafe { slice_from_user_array(debug_dirs, _debug_dirs_len) };
+        let slice = unsafe { slice_from_user_array(debug_dirs, debug_dirs_len) };
         Some(
             slice
                 .iter()
@@ -2391,7 +2391,7 @@ mod tests {
 
     /// Symbolize `addr` in the current process using the given dispatch
     /// callback.
-    unsafe fn symbolize_with_dispatch(
+    fn symbolize_with_dispatch(
         cb: unsafe extern "C" fn(*const c_char, *const c_char, *mut c_void) -> *mut c_char,
         addr: Addr,
         expected_sym: Option<&str>,
@@ -2446,13 +2446,11 @@ mod tests {
             unsafe { libc::strdup(maps_file) }
         }
 
-        unsafe {
-            symbolize_with_dispatch(
-                cb,
-                symbolize_in_process_with_dispatch as *const () as Addr,
-                Some("symbolize_in_process_with_dispatch"),
-            )
-        };
+        symbolize_with_dispatch(
+            cb,
+            symbolize_in_process_with_dispatch as *const () as Addr,
+            Some("symbolize_in_process_with_dispatch"),
+        )
     }
 
     /// Make sure that a dispatch callback returning NULL falls back to
@@ -2468,13 +2466,11 @@ mod tests {
             ptr::null_mut()
         }
 
-        unsafe {
-            symbolize_with_dispatch(
-                cb,
-                symbolize_in_process_with_null_dispatch as *const () as Addr,
-                Some("symbolize_in_process_with_null_dispatch"),
-            )
-        };
+        symbolize_with_dispatch(
+            cb,
+            symbolize_in_process_with_null_dispatch as *const () as Addr,
+            Some("symbolize_in_process_with_null_dispatch"),
+        )
     }
 
     /// Make sure that a dispatch callback returning a non-existent path
@@ -2490,12 +2486,10 @@ mod tests {
             unsafe { libc::strdup(c"/no/such/file".as_ptr()) }
         }
 
-        unsafe {
-            symbolize_with_dispatch(
-                cb,
-                symbolize_in_process_with_bad_dispatch as *const () as Addr,
-                None,
-            )
-        };
+        symbolize_with_dispatch(
+            cb,
+            symbolize_in_process_with_bad_dispatch as *const () as Addr,
+            None,
+        )
     }
 }

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -174,6 +174,24 @@ impl ElfResolver {
         Self::from_parser(parser, Some(&debug_dirs), elf_cache)
     }
 
+    /// Create an `ElfResolver` that loads data from the provided file,
+    /// using the given directories to search for split debug
+    /// information.
+    pub fn open_with_debug_dirs<P, D, DP>(path: P, debug_dirs: D) -> Result<Self>
+    where
+        P: AsRef<Path>,
+        D: IntoIterator<Item = DP>,
+        DP: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        let parser = Rc::new(ElfParser::open(path)?);
+        let debug_dirs = debug_dirs
+            .into_iter()
+            .map(|p| p.as_ref().to_path_buf())
+            .collect::<Vec<_>>();
+        Self::from_parser(parser, Some(&debug_dirs), None)
+    }
+
     /// Create a new [`ElfResolver`] using `parser`.
     ///
     /// If `debug_dirs` is `Some`, interpret DWARF debug information. If it is

--- a/src/elf/resolver.rs
+++ b/src/elf/resolver.rs
@@ -177,6 +177,7 @@ impl ElfResolver {
     /// Create an `ElfResolver` that loads data from the provided file,
     /// using the given directories to search for split debug
     /// information.
+    #[cfg(feature = "dwarf")]
     pub fn open_with_debug_dirs<P, D, DP>(path: P, debug_dirs: D) -> Result<Self>
     where
         P: AsRef<Path>,

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -2112,3 +2112,30 @@ fn create_elf_resolver_from_non_existing_path() {
 
     assert_eq!(err.kind(), ErrorKind::NotFound);
 }
+
+/// Make sure that [`ElfResolver::open_with_debug_dirs`] can be created and
+/// registered successfully.
+#[test]
+fn create_elf_resolver_with_debug_dirs() {
+    let bin_name = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs.bin");
+
+    let debug_dirs = vec![PathBuf::from("/usr/lib/debug")];
+    let resolver = ElfResolver::open_with_debug_dirs(&bin_name, &debug_dirs).unwrap();
+    let mut symbolizer = Symbolizer::new();
+    let () = symbolizer
+        .register_elf_resolver(&bin_name, Rc::new(resolver))
+        .unwrap();
+}
+
+/// Make sure that [`ElfResolver::open_with_debug_dirs`] fails for a
+/// non-existing file.
+#[test]
+fn create_elf_resolver_with_debug_dirs_non_existing_path() {
+    let path = Path::new("/This/Path/Does.Not/Exist");
+    let debug_dirs = vec![PathBuf::from("/usr/lib/debug")];
+    let err = ElfResolver::open_with_debug_dirs(path, &debug_dirs).unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+}

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -2115,6 +2115,7 @@ fn create_elf_resolver_from_non_existing_path() {
 
 /// Make sure that [`ElfResolver::open_with_debug_dirs`] can be created and
 /// registered successfully.
+#[cfg(feature = "dwarf")]
 #[test]
 fn create_elf_resolver_with_debug_dirs() {
     let bin_name = Path::new(&env!("CARGO_MANIFEST_DIR"))
@@ -2131,6 +2132,7 @@ fn create_elf_resolver_with_debug_dirs() {
 
 /// Make sure that [`ElfResolver::open_with_debug_dirs`] fails for a
 /// non-existing file.
+#[cfg(feature = "dwarf")]
 #[test]
 fn create_elf_resolver_with_debug_dirs_non_existing_path() {
     let path = Path::new("/This/Path/Does.Not/Exist");


### PR DESCRIPTION
Expose parts of set_process_dispatcher in the capi to enable users to provide alternative ELF file paths for symbolization (e.g., fetched via debuginfod).

As discussed in https://github.com/libbpf/blazesym/issues/1443.

Please let me know if this goes in the direction you had in mind.