### PR TITLE
Use CStr::count_bytes() in ELF symbol name creation

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -425,9 +425,7 @@ impl<'elf> SymbolTableCache<'elf> {
                     .ok_or_invalid_input(|| "no valid string found in ELF string table")?;
                 let name = SymName {
                     idx: name_idx,
-                    // TODO: May want to use `CStr::count_bytes` once
-                    //       our MSRV is >=1.79.
-                    len: cname.to_bytes().len(),
+                    len: cname.count_bytes(),
                 };
                 Ok((name, idx))
             })


### PR DESCRIPTION
Use the `CStr::count_bytes()` method instead of `CStr::to_bytes().len()` for retrieving the byte length of a C string. That is possible now that our MSRV is >=1.79.