### PR TITLE
Remove custom trim_ascii polyfills

### DIFF
--- a/src/maps.rs
+++ b/src/maps.rs
@@ -21,7 +21,6 @@ use crate::util;
 use crate::util::bytes_to_path;
 use crate::util::from_radix_16;
 use crate::util::split_bytes;
-use crate::util::trim_ascii;
 use crate::util::ReadRaw as _;
 use crate::Addr;
 use crate::BuildId;
@@ -323,7 +322,7 @@ fn parse_maps_line<'line>(line: &'line [u8], pid: Pid) -> Result<MapsEntry> {
     // Note that by design, a path may not be present and so we may not be able
     // to successfully split.
     let path_str = split_once_opt(line)
-        .map(|(_inode, line)| trim_ascii(line))
+        .map(|(_inode, line)| line.trim_ascii())
         .unwrap_or(b"");
     let path_name = parse_path_name(path_str, pid, loaded_addr, end_addr)?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -119,42 +119,6 @@ where
     Some((left, &right[1..]))
 }
 
-// TODO: This is a copy of unstable `trim_ascii_start` from std. Once
-//       stabilized, we should remove this functionality in favor of the std
-//       version.
-#[inline]
-pub(crate) fn trim_ascii_start(mut bytes: &[u8]) -> &[u8] {
-    while let [first, rest @ ..] = bytes {
-        if first.is_ascii_whitespace() {
-            bytes = rest;
-        } else {
-            break;
-        }
-    }
-    bytes
-}
-
-// TODO: This is a copy of unstable `trim_ascii_end` from std. Once stabilized,
-//       we should remove this functionality in favor of the std version.
-#[inline]
-pub(crate) fn trim_ascii_end(mut bytes: &[u8]) -> &[u8] {
-    while let [rest @ .., last] = bytes {
-        if last.is_ascii_whitespace() {
-            bytes = rest;
-        } else {
-            break;
-        }
-    }
-    bytes
-}
-
-// TODO: This is a copy of unstable `trim_ascii` from std. Once stabilized,
-//       we should remove this functionality in favor of the std version.
-#[inline]
-pub(crate) fn trim_ascii(bytes: &[u8]) -> &[u8] {
-    trim_ascii_end(trim_ascii_start(bytes))
-}
-
 /// Splits the slice on the first element that matches the specified predicate.
 // TODO: This is a copy of unstable `<[u8]>::split_once` from std. Once
 //       stabilized, we should remove this functionality in favor of the std


### PR DESCRIPTION
Remove the `trim_ascii_start()`, `trim_ascii_end()`, and `trim_ascii()` helper functions from the `util` module, which were copies of then-unstable `std` functionality. The `<[u8]>::trim_ascii` family of methods has been stable since Rust 1.80 and our MSRV is 1.88, so use the `std` versions directly.