### PR TITLE
Update build-linux action to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       kernel-artifact-url: ${{ steps.build.outputs.kernel-artifact-url }}
     steps:
       - uses: actions/checkout@v6
-      - uses: d-e-s-o/build-linux@23cb60a346b84ab120feb1a4e584f18563b3867f
+      - uses: d-e-s-o/build-linux@58977e713dea1596c0690ac20e9dcec85fde16b1
         id: build
         with:
           rev: v6.18


### PR DESCRIPTION
Update the build-linux composite action we rely on to the latest and greatest. In this version caches are only saved for the project's default branch.