### PR TITLE
Pre-allocate unit_ranges Vec with aranges-based capacity

### DIFF
--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -67,7 +67,7 @@ impl<'dwarf> Units<'dwarf> {
         }
         aranges.sort_by_key(|i| i.0);
 
-        let mut unit_ranges = Vec::new();
+        let mut unit_ranges = Vec::with_capacity(aranges.len());
         let mut res_units = Vec::new();
         let mut units = sections.units();
         while let Some(header) = units.next()? {


### PR DESCRIPTION
Pre-allocate the `unit_ranges` vector in `Units::parse()` using the number of `.debug_aranges` entries as a capacity hint. Each aranges entry will typically produce at least one `UnitRange`, making `aranges.len()` a reasonable lower bound that avoids repeated reallocations during the parsing loop.