### PR TITLE
Inline kernel build into test-coverage job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,20 +19,6 @@ env:
   RUSTFLAGS: '-D warnings -C debuginfo=line-tables-only'
 
 jobs:
-  build-linux-kernel:
-    name: Build Linux
-    runs-on: ubuntu-latest
-    outputs:
-      kernel-artifact-url: ${{ steps.build.outputs.kernel-artifact-url }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: d-e-s-o/build-linux@58977e713dea1596c0690ac20e9dcec85fde16b1
-        id: build
-        with:
-          rev: v6.18
-          config: 'data/config'
-          vmlinux: 'true'
-          modules: 'true'
   build:
     name: Build [${{ matrix.runs-on }}, ${{ matrix.rust }}, ${{ matrix.profile }}, ${{ matrix.args }}]
     runs-on: ${{ matrix.runs-on }}
@@ -191,7 +177,6 @@ jobs:
   test-coverage:
     name: Test and coverage
     runs-on: ubuntu-24.04
-    needs: [build-linux-kernel]
     env:
       LLVM_GSYMUTIL: /usr/bin/llvm-gsymutil-18
     steps:
@@ -200,6 +185,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install --yes --no-install-recommends gcc-multilib libelf-dev zlib1g-dev
     - uses: actions/checkout@v6
+    - uses: d-e-s-o/build-linux@a2c2581c6b44879b6070699618be648480a122c5
+      id: build
+      with:
+        rev: v6.18
+        config: 'data/config'
+        vmlinux: 'true'
+        modules: 'true'
     - uses: dtolnay/rust-toolchain@nightly
     - uses: Swatinem/rust-cache@v2
       with:
@@ -219,7 +211,6 @@ jobs:
       run: rm .cargo/config.toml
     - name: Build main.sh
       env:
-        ARTIFACT_URL: ${{ needs.build-linux-kernel.outputs.kernel-artifact-url }}
         PYTHON: ${{ steps.py312.outputs.python-path }}
         RUSTFLAGS: '--cfg has_large_test_files'
       shell: bash
@@ -233,25 +224,6 @@ jobs:
         echo "export PYTHON=${PYTHON}" >> env.sh
         source env.sh
 
-        # Yes, there appears to be no way to just retrieve the
-        # uploaded artifact. One can't use actions/download-artifact
-        # and provide any of the outputs of actions/upload-artifact.
-        # Neither does it seem possible to just download the thing
-        # directly, because contents are unconditionally zipped. Good.
-        # Lord.
-
-        # Download artifact in parallel with test compilation. The unzip
-        # will produce the kernel bzImage, boot/ with vmlinux and aux
-        # files, and lib/modules/ with modules and aux files.
-        (curl --location \
-          --fail-with-body \
-          --header "Accept: application/vnd.github+json" \
-          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
-          --header "X-GitHub-Api-Version: 2022-11-28" \
-          --output artifact.zip \
-          "${ARTIFACT_URL}" && unzip artifact.zip) &
-        artifact_pid=$!
-
         cargo test --no-run --workspace --all-targets --features=zstd,nightly,blazesym-dev/generate-large-test-files 2>&1 | tee /tmp/cargo-build.log
         tests=$(IFS='' grep Executable /tmp/cargo-build.log |
           awk '{print $NF}' |
@@ -259,17 +231,15 @@ jobs:
           sed 's@.*@\0 --include-ignored@'
         )
 
-        wait $artifact_pid
-
         cat <<EOF > main.sh
         #!/bin/sh
         set -e -u
         . ./env.sh
         mount -t tmpfs tmpfs /boot
-        cp -a boot/* /boot/
+        cp -a ${{ steps.build.outputs.build-dir }}/boot/* /boot/
         mount -t tmpfs tmpfs /lib/modules
-        cp -a lib/modules/* /lib/modules/
-        insmod lib/modules/6.18.0/kernel/lib/test_hexdump.ko.xz
+        cp -a ${{ steps.build.outputs.build-dir }}/lib/modules/* /lib/modules/
+        insmod /lib/modules/6.18.0/kernel/lib/test_hexdump.ko.xz
         $tests
         cargo llvm-cov report --ignore-filename-regex=cli/src/ --lcov --output-path lcov.info
         EOF
@@ -277,7 +247,7 @@ jobs:
     - name: Test and gather coverage
       uses: d-e-s-o/vmsh@3424481c58244ec1410f64dc2d3e52eff3f6e53f
     - run: |
-        vmsh bzImage --env=HOME --env=PATH -- sh -c 'cd ${{ github.workspace }} && ./main.sh'
+        vmsh ${{ steps.build.outputs.build-dir }}/bzImage --env=HOME --env=PATH -- sh -c 'cd ${{ github.workspace }} && ./main.sh'
     - name: Upload code coverage results
       uses: codecov/codecov-action@v6
       env:


### PR DESCRIPTION
With recent changes, the `build-linux` action outputs the build directory path directly instead of uploading an artifact. Since it is a composite action, its steps run in the caller's job and the build directory is already on disk.
Inline the `build-linux` step into the `test-coverage` job, removing the separate `build-linux-kernel` job along with the artifact download via curl. Doing so simplifies things a bunch and eliminates the scheduling issues we have seen where `build-linux-kernel`, despite being on the critical path, was sometimes scheduled to run only after a bunch of other jobs, which artificially worsened total job runtime.