### PR TITLE
Use unstable sort for by-address symbol index creation

### DIFF
--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -384,7 +384,7 @@ impl<'elf> SymbolTableCache<'elf> {
 
         // Order symbols by address and those with equal address descending by
         // size.
-        let () = by_addr_idx.sort_by(|idx1, idx2| {
+        let () = by_addr_idx.sort_unstable_by(|idx1, idx2| {
             // SANITY: Both indexes originate in our code and are known
             //         to be in bounds.
             let sym1 = self.syms.get(*idx1).unwrap();
@@ -431,7 +431,7 @@ impl<'elf> SymbolTableCache<'elf> {
             })
             .collect::<Result<Box<[_]>>>()?;
 
-        let () = str2sym.sort_by_key(|(name, _i)| name.bytes(&self.strs));
+        let () = str2sym.sort_unstable_by_key(|(name, _i)| name.bytes(&self.strs));
         Ok(str2sym)
     }
 


### PR DESCRIPTION
Switch create_by_addr_idx() from sort_by() to sort_unstable_by(). The stable sort allocates a temporary buffer equal in size to the input for its merge phase. The unstable variant sorts in-place instead. Stability is not required here because the secondary sort key (size descending) already fully determines the order among equal-address symbols.
Apply the same change to create_str2sym()'s sort_by_key() call.