### PR TITLE
Allow collapsible-match Clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ unused = "warn"
 [workspace.lints.clippy]
 collapsible-else-if = "allow"
 collapsible-if = "allow"
+collapsible-match = "allow"
 fn-to-numeric-cast = "allow"
 let-and-return = "allow"
 let-unit-value = "allow"


### PR DESCRIPTION
Allow the collapsible-match Clippy lint (added in Rust 1.95), similar to what we already do for collapsible-if and collapsible-else-if.