### PR TITLE
Implement Copy for LineTableRow type

### DIFF
--- a/src/gsym/linetab.rs
+++ b/src/gsym/linetab.rs
@@ -67,7 +67,7 @@ impl LineTableHeader {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct LineTableRow {
     pub addr: Addr,
     pub file_idx: u32,

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -134,7 +134,7 @@ impl<'dat> GsymResolver<'dat> {
         let lntab_hdr = LineTableHeader::parse(&mut data)
             .ok_or_invalid_data(|| "failed to parse line table header")?;
         let mut lntab_row = LineTableRow::from_header(&lntab_hdr, symaddr);
-        let mut last_lntab_row = lntab_row.clone();
+        let mut last_lntab_row = lntab_row;
         let mut row_cnt = 0;
         while !data.is_empty() {
             match run_op(&mut lntab_row, &lntab_hdr, &mut data) {
@@ -150,7 +150,7 @@ impl<'dat> GsymResolver<'dat> {
                         lntab_row = last_lntab_row;
                         break
                     }
-                    last_lntab_row = lntab_row.clone();
+                    last_lntab_row = lntab_row;
                 }
                 Some(RunResult::End) | None => break,
             }


### PR DESCRIPTION
Auto-derive Copy for the LineTableRow type. This way, we don't have to manually clone objects of the type.