### PR TITLE
Introduce InlineInfo::skip() helper for Gsym logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 - Added support for relocatable ELF and DWARF
 - Added support for kernel module symbolization with DWARF data
 - Improved performance of ELF symbolization
+- Improved performance of Gsym symbolization
 - Bumped minimum supported Rust version to `1.88`
 
 

--- a/src/gsym/inline.rs
+++ b/src/gsym/inline.rs
@@ -17,11 +17,52 @@ pub(super) struct InlineInfo {
 }
 
 impl InlineInfo {
+    /// Advance `data` past one `InlineInfo` node and all its descendants.
+    fn skip(data: &mut &[u8]) -> Result<bool> {
+        let range_cnt = data
+            .read_u64_leb128()
+            .ok_or_invalid_data(|| "failed to read range count from inline information")?;
+        if range_cnt == 0 {
+            return Ok(false);
+        }
+
+        for _ in 0..range_cnt {
+            let _offset = data
+                .read_u64_leb128()
+                .ok_or_invalid_data(|| "failed to read offset from inline information")?;
+            let _size = data
+                .read_u64_leb128()
+                .ok_or_invalid_data(|| "failed to read size from inline information")?;
+        }
+
+        let child_cnt = data
+            .read_u8()
+            .ok_or_invalid_data(|| "failed to read child count from inline information")?;
+        let has_children = child_cnt != 0;
+        let _name = data
+            .read_u32()
+            .ok_or_invalid_data(|| "failed to read name from inline information")?;
+        let _call_file = data
+            .read_u64_leb128()
+            .ok_or_invalid_data(|| "failed to read call file from inline information")?;
+        let _call_line = data
+            .read_u64_leb128()
+            .ok_or_invalid_data(|| "failed to read call line from inline information")?;
+
+        if has_children {
+            while Self::skip(data)? {
+                // Do nothing; we just skip the data.
+            }
+        }
+
+        Ok(true)
+    }
+
     /// Parse Gsym `InlineInfo` from raw bytes.
     pub(crate) fn parse(
         data: &mut &[u8],
         base_addr: u64,
-        lookup_addr: Option<u64>,
+        lookup_addr: u64,
     ) -> Result<Option<Self>> {
         let range_cnt = data
             .read_u64_leb128()
@@ -36,44 +77,33 @@ impl InlineInfo {
         let mut ranges = Vec::new();
         let mut child_base_addr = 0u64;
 
-        if let Some(lookup_addr) = lookup_addr {
-            for i in 0..range_cnt {
-                let offset = data
-                    .read_u64_leb128()
-                    .ok_or_invalid_data(|| "failed to read offset from inline information")?;
-                let size = data
-                    .read_u64_leb128()
-                    .ok_or_invalid_data(|| "failed to read size from inline information")?;
+        for i in 0..range_cnt {
+            let offset = data
+                .read_u64_leb128()
+                .ok_or_invalid_data(|| "failed to read offset from inline information")?;
+            let size = data
+                .read_u64_leb128()
+                .ok_or_invalid_data(|| "failed to read size from inline information")?;
 
-                let start = base_addr
-                    .checked_add(offset)
-                    .ok_or_invalid_data(|| {
-                        format!("offset {offset:#x} overflowed base address {base_addr:#x}")
-                    })
-                    .context("failed calculate start address")?;
-                let end = start
-                    .checked_add(size)
-                    .ok_or_invalid_data(|| {
-                        format!("size {size:#x} overflowed start address {start:#x}")
-                    })
-                    .context("failed calculate end address")?;
-                if i == 0 {
-                    child_base_addr = start;
-                }
-
-                let range = start..end;
-                if range.contains(&lookup_addr) {
-                    let () = ranges.push(range);
-                }
+            let start = base_addr
+                .checked_add(offset)
+                .ok_or_invalid_data(|| {
+                    format!("offset {offset:#x} overflowed base address {base_addr:#x}")
+                })
+                .context("failed calculate start address")?;
+            let end = start
+                .checked_add(size)
+                .ok_or_invalid_data(|| {
+                    format!("size {size:#x} overflowed start address {start:#x}")
+                })
+                .context("failed calculate end address")?;
+            if i == 0 {
+                child_base_addr = start;
             }
-        } else {
-            for _ in 0..range_cnt {
-                let _offset = data
-                    .read_u64_leb128()
-                    .ok_or_invalid_data(|| "failed to read offset from inline information")?;
-                let _size = data
-                    .read_u64_leb128()
-                    .ok_or_invalid_data(|| "failed to read size from inline information")?;
+
+            let range = start..end;
+            if range.contains(&lookup_addr) {
+                let () = ranges.push(range);
             }
         }
 
@@ -85,34 +115,23 @@ impl InlineInfo {
             .read_u32()
             .ok_or_invalid_data(|| "failed to read name from inline information")?;
 
-        let (call_file, call_line) = if lookup_addr.is_some() {
-            let call_file = data
-                .read_u64_leb128()
-                .ok_or_invalid_data(|| "failed to read call file from inline information")?;
-            let call_file = u32::try_from(call_file)
-                .ok()
-                .ok_or_invalid_data(|| "call file index ({}) is too big")?;
-            let call_line = data
-                .read_u64_leb128()
-                .ok_or_invalid_data(|| "failed to read call line from inline information")?;
-            let call_line = u32::try_from(call_line).unwrap_or(u32::MAX);
-            (Some(call_file), Some(call_line))
-        } else {
-            let _call_file = data
-                .read_u64_leb128()
-                .ok_or_invalid_data(|| "failed to read call file from inline information")?;
-            let _call_line = data
-                .read_u64_leb128()
-                .ok_or_invalid_data(|| "failed to read call line from inline information")?;
-            (None, None)
-        };
+        let call_file = data
+            .read_u64_leb128()
+            .ok_or_invalid_data(|| "failed to read call file from inline information")?;
+        let call_file = u32::try_from(call_file)
+            .ok()
+            .ok_or_invalid_data(|| "call file index ({}) is too big")?;
+        let call_line = data
+            .read_u64_leb128()
+            .ok_or_invalid_data(|| "failed to read call line from inline information")?;
+        let call_line = u32::try_from(call_line).unwrap_or(u32::MAX);
 
         let mut children = Vec::new();
         if has_children {
             if ranges.is_empty() {
                 // This inlined function does not contain `lookup_addr`, no need
                 // to decode ranges, just skip.
-                while let Some(_child) = Self::parse(data, child_base_addr, None)? {
+                while Self::skip(data)? {
                     // Do nothing; we just skip the data.
                 }
             } else {
@@ -124,8 +143,8 @@ impl InlineInfo {
 
         let slf = Self {
             name,
-            call_file,
-            call_line,
+            call_file: Some(call_file),
+            call_line: Some(call_line),
             ranges,
             children,
         };

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -243,7 +243,7 @@ impl GsymResolver<'_> {
                 INFO_TYPE_INLINE_INFO if opts.inlined_fns() => {
                     if inline_info.is_none() {
                         let mut data = addr_ent.data;
-                        inline_info = InlineInfo::parse(&mut data, sym_addr, Some(addr))?;
+                        inline_info = InlineInfo::parse(&mut data, sym_addr, addr)?;
                     }
                 }
                 typ => {


### PR DESCRIPTION
Our logic for parsing InlineInfo objects is somewhat roundabout and, as it turns out, inefficient: for children we recursively call InlineInfo::parse() but without a lookup address, build up the result as usual, and then discard it. That makes for both a somewhat unintuitive API (with an optional lookup address) as well as weird control flow.

Simplify things by introducing a separate InlineInfo::skip() helper that just skips a bunch of data, without building up a resulting object. In so doing we can make the public parse() method unconditionally accept an address to lookup, while also getting a speed up for inline information decoding:

```
  > main/symbolize_gsym_multi_no_setup
  >   time:   [121.66 µs 122.06 µs 122.51 µs]
  >   change: [−10.779% −9.9541% −9.1500%] (p = 0.00 < 0.02)
  >   Performance has improved.
```