### PR TITLE
Produce Gsym inline stack more directly

### DIFF
--- a/src/gsym/inline.rs
+++ b/src/gsym/inline.rs
@@ -1,20 +1,16 @@
-use std::ops::Range;
-
 use crate::util::ReadRaw as _;
 use crate::ErrorExt as _;
 use crate::IntoError as _;
 use crate::Result;
 
 
-#[derive(Clone)]
-pub(super) struct InlineInfo {
+pub(super) struct InlineFrame {
     pub name: u32,
     pub call_file: u32,
     pub call_line: u32,
-
-    ranges: Vec<Range<u64>>,
-    children: Vec<Self>,
 }
+
+pub(super) struct InlineInfo;
 
 impl InlineInfo {
     /// Advance `data` past one `InlineInfo` node and all its descendants.
@@ -58,12 +54,12 @@ impl InlineInfo {
         Ok(true)
     }
 
-    /// Parse Gsym `InlineInfo` from raw bytes.
-    pub(crate) fn parse(
+    fn parse_into_stack(
         data: &mut &[u8],
         base_addr: u64,
         lookup_addr: u64,
-    ) -> Result<Option<Self>> {
+        stack: &mut Vec<InlineFrame>,
+    ) -> Result<bool> {
         let range_cnt = data
             .read_u64_leb128()
             .ok_or_invalid_data(|| "failed to read range count from inline information")?;
@@ -71,10 +67,10 @@ impl InlineInfo {
             .ok()
             .ok_or_invalid_data(|| format!("range count ({range_cnt}) is too big"))?;
         if range_cnt == 0 {
-            return Ok(None)
+            return Ok(false);
         }
 
-        let mut ranges = Vec::new();
+        let mut matches = false;
         let mut child_base_addr = 0u64;
 
         for i in 0..range_cnt {
@@ -101,9 +97,8 @@ impl InlineInfo {
                 child_base_addr = start;
             }
 
-            let range = start..end;
-            if range.contains(&lookup_addr) {
-                let () = ranges.push(range);
+            if (start..end).contains(&lookup_addr) {
+                matches = true;
             }
         }
 
@@ -126,52 +121,34 @@ impl InlineInfo {
             .ok_or_invalid_data(|| "failed to read call line from inline information")?;
         let call_line = u32::try_from(call_line).unwrap_or(u32::MAX);
 
-        let mut children = Vec::new();
-        if has_children {
-            if ranges.is_empty() {
-                // This inlined function does not contain `lookup_addr`, no need
-                // to decode ranges, just skip.
-                while Self::skip(data)? {
-                    // Do nothing; we just skip the data.
-                }
-            } else {
-                while let Some(child) = Self::parse(data, child_base_addr, lookup_addr)? {
-                    let () = children.push(child);
-                }
+        if matches {
+            if name > 0 {
+                let () = stack.push(InlineFrame {
+                    name,
+                    call_file,
+                    call_line,
+                });
             }
+
+            if has_children {
+                while Self::parse_into_stack(data, child_base_addr, lookup_addr, stack)? {}
+            }
+        } else if has_children {
+            while Self::skip(data)? {}
         }
 
-        let slf = Self {
-            name,
-            call_file,
-            call_line,
-            ranges,
-            children,
-        };
-        Ok(Some(slf))
+        Ok(true)
     }
 
-    fn inline_stack_impl<'slf>(&'slf self, addr: u64, inlined: &mut Vec<&'slf Self>) -> bool {
-        for range in &self.ranges {
-            if range.contains(&addr) {
-                if self.name > 0 {
-                    let () = inlined.push(self);
-                }
-
-                for child in &self.children {
-                    if child.inline_stack_impl(addr, inlined) {
-                        break
-                    }
-                }
-                return !inlined.is_empty()
-            }
-        }
-        false
-    }
-
-    pub(crate) fn inline_stack(&self, addr: u64) -> Vec<&Self> {
-        let mut inlined = Vec::new();
-        let _done = self.inline_stack_impl(addr, &mut inlined);
-        inlined
+    /// Parse the inline info tree for `lookup_addr` and produce a flat
+    /// inline stack directly, without building an intermediate tree.
+    pub(crate) fn parse_inline_stack(
+        data: &mut &[u8],
+        base_addr: u64,
+        lookup_addr: u64,
+    ) -> Result<Vec<InlineFrame>> {
+        let mut stack = Vec::new();
+        let _parsed = Self::parse_into_stack(data, base_addr, lookup_addr, &mut stack)?;
+        Ok(stack)
     }
 }

--- a/src/gsym/resolver.rs
+++ b/src/gsym/resolver.rs
@@ -22,6 +22,7 @@ use crate::Addr;
 use crate::IntoError as _;
 use crate::Result;
 
+use super::inline::InlineFrame;
 use super::inline::InlineInfo;
 use super::linetab::run_op;
 use super::linetab::LineTableHeader;
@@ -231,7 +232,7 @@ impl GsymResolver<'_> {
         }
 
         let mut line_tab_info = None;
-        let mut inline_info = None;
+        let mut inline_stack = Vec::<InlineFrame>::new();
         let addrdatas = parse_address_data(info.data);
         for addr_ent in addrdatas {
             match addr_ent.typ {
@@ -241,9 +242,9 @@ impl GsymResolver<'_> {
                     }
                 }
                 INFO_TYPE_INLINE_INFO if opts.inlined_fns() => {
-                    if inline_info.is_none() {
+                    if inline_stack.is_empty() {
                         let mut data = addr_ent.data;
-                        inline_info = InlineInfo::parse(&mut data, sym_addr, addr)?;
+                        inline_stack = InlineInfo::parse_inline_stack(&mut data, sym_addr, addr)?;
                     }
                 }
                 typ => {
@@ -261,26 +262,23 @@ impl GsymResolver<'_> {
 
         let mut inlined = Vec::<InlinedFn>::new();
 
-        if let Some(inline_info) = inline_info {
-            let mut inline_stack = inline_info.inline_stack(addr).into_iter();
+        if !inline_stack.is_empty() {
+            let mut frames = inline_stack.into_iter();
             // As per Gsym file format, the first "frame" only contains the
             // name and it effectively is meant to overwrite what is already
             // contained in the line table.
-            if let Some(inline_info) = inline_stack.next() {
+            if let Some(first) = frames.next() {
                 sym.name = self
                     .ctx
-                    .get_str(inline_info.name as usize)
+                    .get_str(first.name as usize)
                     .and_then(|s| s.to_str())
                     .ok_or_invalid_data(|| {
-                        format!(
-                            "failed to read string table entry at offset {}",
-                            inline_info.name
-                        )
+                        format!("failed to read string table entry at offset {}", first.name)
                     })?;
 
-                let () = inlined.reserve(inline_stack.len());
+                let () = inlined.reserve(frames.len());
 
-                for frame in inline_stack {
+                for frame in frames {
                     let name = self
                         .ctx
                         .get_str(frame.name as usize)


### PR DESCRIPTION
Replace the two-phase InlineInfo approach -- build a recursive tree with ranges and children, then walk it via inline_stack() -- with a single-pass parse_into_stack() that produces a flat Vec<InlineFrame> directly. The old code allocated Vec<Range<u64>> and Vec<Self> at every matching tree node, then walked the tree a second time.

The new logic, parse_into_stack(), tracks range containment via a bool flag, pushes matching frames directly to the output vector, and delegates to the skip() function for non-matching subtrees. As a result of this change, we see another sizable improvement to the inline info parsing performance:

```
  > main/symbolize_gsym_multi_no_setup
  >   time:   [95.067 µs 95.256 µs 95.506 µs]
  >   change: [−19.631% −18.795% −17.956%] (p = 0.00 < 0.02)
  >   Performance has improved.
```