### PR TITLE
kernel: Don't require /proc/kcore access when only kallsyms is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Added support for kernel module symbolization with DWARF data
 - Improved performance of ELF symbolization
 - Improved performance of Gsym symbolization
+- Fixed kernel symbolization failing when `/proc/kcore` is inaccessible
+  but kallsyms is available
 - Bumped minimum supported Rust version to `1.88`
 
 

--- a/src/kernel/resolver.rs
+++ b/src/kernel/resolver.rs
@@ -180,15 +180,22 @@ impl<'cache> KernelResolver<'cache> {
 
         let ksym_resolver = ksym_resolver.map(Rc::clone);
         let vmlinux_resolver = vmlinux_resolver.map(Rc::clone);
-        let kaslr_offset = kaslr_offset
-            .map(Ok)
-            .unwrap_or_else(|| cache.kaslr_offset())?;
 
         if ksym_resolver.is_none() && vmlinux_resolver.is_none() {
             return Err(Error::with_not_found(
                 "failed to create kernel resolver: neither kallsyms nor vmlinux symbol source are present",
             ))
         }
+
+        // The KASLR offset is only needed for vmlinux based symbolization;
+        // kallsyms addresses are already relocated. Avoid querying it (which
+        // may require reading `/proc/kcore` and, hence, elevated privileges)
+        // unless we actually have a vmlinux resolver.
+        let kaslr_offset = match kaslr_offset {
+            Some(offset) => offset,
+            None if vmlinux_resolver.is_some() => cache.kaslr_offset()?,
+            None => 0,
+        };
 
         Ok(KernelResolver {
             cache,


### PR DESCRIPTION
`KernelResolver::new()` unconditionally queries the KASLR offset, which reads `/proc/kcore`. If that fails with `EPERM` (common in containers or for unprivileged processes), resolver creation hard-fails — even though kallsyms-only symbolization doesn't need the offset at all, since kallsyms addresses are already relocated.

This change only queries the KASLR offset when a vmlinux resolver is actually in use. The kallsyms-only path now works without `/proc/kcore` access; vmlinux based resolution still requires it since we can't correctly relocate addresses without the offset.

Also moves the "no symbol source" check above the offset query so we don't needlessly touch `/proc/kcore` when we're about to error out anyway.