### PR TITLE
capi: Bump version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "blazesym-c"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "bindgen",
  "blazesym",

--- a/capi/CHANGELOG.md
+++ b/capi/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.8
+-----
 - Added `blaze_symbolizer_opts::process_dispatch` providing process
   dispatch functionality
 - Bumped maximum supported `blazesym` dependency to `0.2.4`

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blazesym-c"
 description = "C bindings for blazesym"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Daniel Müller <deso@posteo.net>"]

--- a/capi/include/blazesym.h
+++ b/capi/include/blazesym.h
@@ -1,7 +1,7 @@
 /*
  * Please refer to the documentation hosted at
  *
- *   https://docs.rs/blazesym-c/0.1.7
+ *   https://docs.rs/blazesym-c/0.1.8
  */
 
 


### PR DESCRIPTION
This change bumps the crate's version to 0.1.8. The following notable changes have been made since 0.1.7:
- Added blaze_symbolizer_opts::process_dispatch providing process dispatch functionality
- Bumped maximum supported blazesym dependency to 0.2.4
- Bumped minimum supported Rust version to 1.88