### PR TITLE
Switch to using zlib-rs for zlib based decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Improved DWARF symbolization performance for some debug info variants
+- Switched `zlib` implementation from `miniz_oxide` to `zlib-rs` for
+  improved decoding performance
 
 
 0.2.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,6 @@ dependencies = [
  "gimli 0.33.1",
  "libc",
  "memmap2",
- "miniz_oxide",
  "nom",
  "rustc-demangle",
  "scopeguard",
@@ -848,6 +847,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3708,6 +3708,12 @@ dependencies = [
  "memchr",
  "typed-path",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ xz = ["dep:xz2"]
 # Enable this feature to enable support for zlib decompression. This is
 # used for handling compressed debug information as well as compressed
 # kernel modules.
-zlib = ["dep:flate2", "dep:miniz_oxide"]
+zlib = ["dep:flate2"]
 # Enable this feature to enable support for zstd decompression. This is
 # used for handling compressed debug information as well as compressed
 # kernel modules.
@@ -177,11 +177,10 @@ codegen-units = 256
 
 [dependencies]
 cpp_demangle = {version = "0.5", optional = true}
-flate2 = {version = "1", optional = true}
+flate2 = {version = "1.0.31", default-features = false, features = ["zlib-rs"], optional = true}
 gimli = {version = "0.33", optional = true}
 libc = "0.2"
 memmap2 = {version = "0.9", default-features = false}
-miniz_oxide = {version = "0.8", default-features = false, features = ["simd", "with-alloc"], optional = true}
 nom = {version = "7", optional = true}
 rustc-demangle = {version = "0.1", optional = true}
 tempfile = {version = "3", default-features = false}

--- a/benches/symbolize.rs
+++ b/benches/symbolize.rs
@@ -102,12 +102,11 @@ fn symbolize_dwarf_no_lines() {
     assert_eq!(result.code_info.as_ref(), None);
 }
 
-/// Symbolize an address in a DWARF file, end-to-end, i.e., including all
-/// necessary setup.
-fn symbolize_dwarf() {
+#[track_caller]
+fn symbolize_dwarf_impl(file: &str) {
     let dwarf_vmlinux = Path::new(&env!("CARGO_MANIFEST_DIR"))
         .join("data")
-        .join("vmlinux-5.17.12-100.fc34.x86_64.dwarf");
+        .join(file);
     let src = Source::Elf(Elf::new(dwarf_vmlinux));
     let symbolizer = Symbolizer::new();
 
@@ -122,6 +121,18 @@ fn symbolize_dwarf() {
 
     assert_eq!(result.name, "abort_creds");
     assert_eq!(result.code_info.as_ref().unwrap().line, Some(534));
+}
+
+/// Symbolize an address in a DWARF file, end-to-end, i.e., including all
+/// necessary setup.
+fn symbolize_dwarf() {
+    symbolize_dwarf_impl("vmlinux-5.17.12-100.fc34.x86_64.dwarf")
+}
+
+/// Symbolize an address in a DWARF file whose `.debug_*` sections are
+/// zlib-compressed, end-to-end, i.e., including all necessary setup.
+fn symbolize_dwarf_zlib() {
+    symbolize_dwarf_impl("vmlinux-5.17.12-100.fc34.x86_64.dwarf.zlib")
 }
 
 /// Symbolize an address in a Gsym file, end-to-end, i.e., including all
@@ -228,6 +239,7 @@ where
     bench_fn!(group, symbolize_elf);
     bench_fn!(group, symbolize_dwarf_no_lines);
     bench_fn!(group, symbolize_dwarf);
+    bench_fn!(group, symbolize_dwarf_zlib);
     bench_fn!(group, symbolize_gsym);
     bench_sub_fn!(group, symbolize_gsym_multi_no_setup);
     #[cfg(linux)]

--- a/dev/build.rs
+++ b/dev/build.rs
@@ -1001,6 +1001,13 @@ fn prepare_bench_files() {
     let dst = dst.file_name().unwrap();
     dwarf(&vmlinux, dst);
 
+    let dwarf_src = change_ext(&vmlinux_xz, "dwarf");
+    objcopy(
+        &dwarf_src,
+        "vmlinux-5.17.12-100.fc34.x86_64.dwarf.zlib",
+        &["--compress-debug-sections=zlib"],
+    );
+
     let dst = change_ext(&vmlinux_xz, "sym");
     let dst = dst.file_name().unwrap();
     syms(&vmlinux, dst);

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -8,7 +8,7 @@ use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 use std::fs::File;
 use std::io;
-#[cfg(feature = "xz")]
+#[cfg(any(feature = "xz", feature = "zlib"))]
 use std::io::Read as _;
 use std::io::Seek as _;
 use std::io::SeekFrom;
@@ -254,14 +254,14 @@ fn file_offset(shdrs: &ElfN_Shdrs<'_>, sym: &Elf64_Sym) -> Result<Option<u64>> {
 
 #[cfg(feature = "zlib")]
 fn decompress_zlib(data: &[u8]) -> Result<Vec<u8>> {
-    use miniz_oxide::inflate::decompress_to_vec_zlib;
+    use flate2::bufread::ZlibDecoder;
 
-    match decompress_to_vec_zlib(data) {
-        Ok(data) => Ok(data),
-        Err(err) => Err(Error::with_invalid_data(format!(
-            "zlib decompression failed: {err}"
-        ))),
-    }
+    let mut decoder = ZlibDecoder::new(data);
+    let mut decompressed = Vec::new();
+    let _cnt = decoder
+        .read_to_end(&mut decompressed)
+        .context("failed to zlib decompress section data")?;
+    Ok(decompressed)
 }
 
 #[cfg(not(feature = "zlib"))]
@@ -1551,7 +1551,8 @@ mod tests {
     use std::path::Path;
     use std::slice;
 
-    use miniz_oxide::deflate::compress_to_vec_zlib;
+    use flate2::write::ZlibEncoder;
+    use flate2::Compression;
 
     use tempfile::NamedTempFile;
 
@@ -2226,7 +2227,11 @@ mod tests {
         };
 
         let data = [];
-        let zlib_hdr = compress_to_vec_zlib(&data, 0);
+        let zlib_hdr = {
+            let mut encoder = ZlibEncoder::new(Vec::new(), Compression::none());
+            let () = encoder.write_all(&data).unwrap();
+            encoder.finish().unwrap()
+        };
         let chdr = Elf64_Chdr {
             ch_type: ELFCOMPRESS_ZLIB,
             ch_reserved: 0,


### PR DESCRIPTION
Please see individual commits for descriptions, but bottom line:
```
      > main/symbolize_dwarf_zlib
      >      time:   [660.51 ms 664.32 ms 668.37 ms]
      >      change: [−36.760% −36.366% −35.926%] (p = 0.00 < 0.02)
      >      Performance has improved.
```