### PR TITLE
Fix typo in find_find_kalsr_offset() function

### DIFF
--- a/src/kernel/cache.rs
+++ b/src/kernel/cache.rs
@@ -12,7 +12,7 @@ use crate::util::OnceCellExt as _;
 use crate::ErrorExt as _;
 use crate::Result;
 
-use super::kaslr::find_kalsr_offset;
+use super::kaslr::find_kaslr_offset;
 use super::ksym::KsymResolver;
 use super::DepmodIndex;
 use super::ModMap;
@@ -109,7 +109,7 @@ impl KernelCache {
     pub fn kaslr_offset(&self) -> Result<u64> {
         self.kaslr_offset
             .get_or_try_init_(|| {
-                find_kalsr_offset()
+                find_kaslr_offset()
                     .context("failed to query system KASLR offset")
                     .map(Option::unwrap_or_default)
             })

--- a/src/kernel/kaslr.rs
+++ b/src/kernel/kaslr.rs
@@ -104,20 +104,18 @@ fn find_kcore_kaslr_offset() -> Result<Option<u64>> {
         Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
         Err(err) => return Err(err),
     };
-    let offset = read_kcore_kaslr_offset(&parser)?;
+    let offset = read_kcore_kaslr_offset(&parser)?.inspect(|offset| {
+        log::debug!("determined KASLR offset to be {offset:#x} based on {PROC_KCORE} contents");
+    });
     Ok(offset)
 }
 
-pub(crate) fn find_kalsr_offset() -> Result<Option<u64>> {
+pub(crate) fn find_kaslr_offset() -> Result<Option<u64>> {
     // TODO: Try other methods of determining KASLR offset, including
     //       comparisons between `/proc/kallsyms` values to
     //       `System.map-*` contents or parsing `dmesg` (no, really...)
 
-    if let offset @ Some(o) = find_kcore_kaslr_offset()? {
-        log::debug!("determined KASLR offset to be {o:#x} based on {PROC_KCORE} contents");
-        return Ok(offset)
-    }
-    Ok(None)
+    find_kcore_kaslr_offset()
 }
 
 


### PR DESCRIPTION
Fix the name of the find_kalsr_offset() helper function. While at it, also move the debug!() log around a bit to simplify the code a bit.