### PR TITLE
Pre-allocate res_units vector

### DIFF
--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -68,7 +68,7 @@ impl<'dwarf> Units<'dwarf> {
         aranges.sort_by_key(|i| i.0);
 
         let mut unit_ranges = Vec::with_capacity(aranges.len());
-        let mut res_units = Vec::new();
+        let mut res_units = Vec::with_capacity(aranges.len());
         let mut units = sections.units();
         while let Some(header) = units.next()? {
             let unit_id = res_units.len();


### PR DESCRIPTION
Commit d0b99bea3ee3 ("Pre-allocate unit_ranges Vec with aranges-based capacity") improved DWARF parsing performance by sizing the unit_ranges vector based on the number of .debug_aranges entries. Resizing the res_units Vec is even worse in terms of performance, because the contained Unit objects are rather large (making copying more expensive).
Use the same size hint to pre-allocate said vector and minimize copy operations in the process.

```
> main/symbolize_dwarf_no_lines
>      time:   [7.1269 ms 7.1522 ms 7.1901 ms]
>      change: [−30.399% −29.940% −29.484%] (p = 0.00 < 0.02)
>      Performance has improved.
> main/symbolize_dwarf
>      time:   [6.9546 ms 6.9988 ms 7.0619 ms]
>      change: [−34.973% −34.455% −33.805%] (p = 0.00 < 0.02)
>      Performance has improved.
```