### PR TITLE
Disable ASLR when running tests/benchmarks

### DIFF
--- a/.cargo/runner.sh
+++ b/.cargo/runner.sh
@@ -6,4 +6,4 @@ sync
 echo 3 > /proc/sys/vm/drop_caches
 
 # Niceness adjustments are mostly done for benchmarking.
-nice --adjustment=-20 ionice --class=realtime "$@"
+nice --adjustment=-20 ionice --class=realtime setarch --addr-no-randomize "$@"


### PR DESCRIPTION
We try to minimize perturbance of benchmarks by "configuring" the system in a way to exhibit less noise during test runs. One thing we didn't cover is address space layout randomization. Disable it as well using setarch(8). The program is assumed to be present on virtually all systems by virtue of being part of util-linux.