### PR TITLE
Use unstable sorting in DWARF logic

### DIFF
--- a/src/dwarf/function.rs
+++ b/src/dwarf/function.rs
@@ -283,7 +283,7 @@ impl<'dwarf> InlinedFunctions<'dwarf> {
         // In this example, if you want to look up address 7 at depth 0,
         // and you encounter [0..2 at depth 1], are you before or after
         // the target range? You don't know.
-        state.addresses.sort_by(|r1, r2| {
+        state.addresses.sort_unstable_by(|r1, r2| {
             (r1.call_depth, r1.range.begin).cmp(&(r2.call_depth, r2.range.begin))
         });
 
@@ -539,7 +539,7 @@ impl<'dwarf> Functions<'dwarf> {
         // It's possible for multiple functions to have the same address range if the
         // compiler can detect and remove functions with identical code. In that case
         // we'll non-deterministically return one of them.
-        addresses.sort_by_key(|x| x.range.begin);
+        addresses.sort_unstable_by_key(|x| x.range.begin);
 
         Ok(Functions {
             functions: functions.into_boxed_slice(),

--- a/src/dwarf/lines.rs
+++ b/src/dwarf/lines.rs
@@ -142,7 +142,7 @@ impl<'dwarf> Lines<'dwarf> {
                 column,
             });
         }
-        sequences.sort_by_key(|x| x.start);
+        sequences.sort_unstable_by_key(|x| x.start);
 
         let mut files = Vec::new();
         let header = rows.header();

--- a/src/dwarf/units.rs
+++ b/src/dwarf/units.rs
@@ -66,7 +66,7 @@ impl<'dwarf> Units<'dwarf> {
             while let Some(header) = headers.next()? {
                 aranges.push((header.debug_info_offset(), header.offset()));
             }
-            aranges.sort_by_key(|i| i.0);
+            aranges.sort_unstable_by_key(|i| i.0);
             aranges
         };
 
@@ -225,7 +225,7 @@ impl<'dwarf> Units<'dwarf> {
         }
 
         // Sort this for faster lookups.
-        unit_ranges.sort_by_key(|i| i.range.begin);
+        unit_ranges.sort_unstable_by_key(|i| i.range.begin);
 
         // Calculate the `max_end` field now that we've determined the order of
         // CUs.


### PR DESCRIPTION
We use binary searches in a couple of data places inside the DWARF logic and sort the operated-on data accordingly. Right now we use a stable sort, which may allocate a temporary buffer to preserve order of equal elements.
We shouldn't really require the order-preservation for equal elements, so let's switch over to using unstable sorts.