### PR TITLE
Support benchmark instructions instead of wall clock time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -218,9 +218,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blazecli"
@@ -271,6 +271,7 @@ dependencies = [
  "bindgen",
  "blazesym",
  "blazesym-c",
+ "blazesym-dev",
  "cbindgen",
  "criterion",
  "libc",
@@ -288,10 +289,12 @@ name = "blazesym-dev"
 version = "0.0.0"
 dependencies = [
  "blazesym",
+ "criterion",
  "dump_syms",
  "libbpf-rs",
  "libbpf-sys",
  "libc",
+ "perf-event",
  "reqwest",
  "tempfile",
  "thorin-dwp",
@@ -757,7 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80c7fb163d4350f0527285b3e48ee7d4905ebd94a4a78f836408902944fc0f1a"
 dependencies = [
  "anyhow",
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "cab",
  "crossbeam",
  "dirs",
@@ -1450,7 +1453,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8e8db46a2d5967b5b3dba7aba32a875dc38f222395040607045635ec1f9b63"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "libbpf-sys",
  "libc",
  "vsprintf",
@@ -1489,7 +1492,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -1632,7 +1635,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4c25a3bb7d880e8eceab4822f3141ad0700d20f025991c1f03bd3d00219a5fc"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1647,7 +1650,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1816,6 +1819,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "perf-event"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2529f39584dbaa980f4959510c963ae95f119c127c046012c2834365f694438"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "perf-event-open-sys",
+]
+
+[[package]]
+name = "perf-event-open-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f8d1487a4ffa23c80a1c355dd27235f9b66fb71ba0f261eb417e4fe8451347"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "phf_shared"
@@ -2027,7 +2050,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2143,7 +2166,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2892,7 +2915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3254,7 +3277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
 dependencies = [
  "ahash",
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "hashbrown 0.14.5",
  "indexmap",
  "semver",
@@ -3267,7 +3290,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.2",
  "indexmap",
  "semver",
@@ -3475,7 +3498,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3516,7 +3539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.8.0",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",

--- a/README-devel.md
+++ b/README-devel.md
@@ -59,6 +59,13 @@ $ cargo check --package blazesym-dev --features=generate-large-test-files
 $ RUSTFLAGS='--cfg has_large_test_files' cargo bench --features=nightly
 ```
 
+By default benchmarks measure wall clock time. On Linux we also support
+reporting instruction counts (for Criterion based benchmarks) instead.
+To enable that, use the feature `bench-instrs`:
+```sh
+$ RUSTFLAGS='--cfg has_large_test_files' cargo bench features=nightly,blazesym-dev/bench-instrs
+```
+
 Some benchmarks require the `PROCMAP_QUERY` ioctl kernel functionality,
 which is not yet widely available. As such, they are disabled by
 default. To enable them set the `RUSTFLAGS` environment variable to

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -21,10 +21,9 @@ mod inspect;
 mod normalize;
 mod symbolize;
 
-use std::time::Duration;
-
 use criterion::criterion_group;
 use criterion::criterion_main;
+use criterion::measurement::Measurement;
 use criterion::Criterion;
 
 
@@ -36,9 +35,11 @@ fn bench_fn_name(name: &str) -> String {
 }
 
 
-fn benchmark(c: &mut Criterion) {
+fn benchmark<M>(c: &mut Criterion<M>)
+where
+    M: Measurement,
+{
     let mut group = c.benchmark_group("main");
-    group.warm_up_time(Duration::from_secs(1));
     group.confidence_level(0.98);
     group.significance_level(0.02);
     inspect::benchmark(&mut group);
@@ -46,5 +47,9 @@ fn benchmark(c: &mut Criterion) {
     symbolize::benchmark(&mut group);
 }
 
-criterion_group!(benches, benchmark);
+criterion_group!(
+    name = benches;
+    config = blazesym_dev::criterion_config();
+    targets = benchmark
+);
 criterion_main!(benches);

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -83,6 +83,7 @@ blazesym = {version = ">=0.2.0, <=0.2.4", path = "../", features = ["bpf"]}
 [dev-dependencies]
 blazesym = {version = "0.2", path = "../", features = ["test"]}
 blazesym-c = {path = ".", features = ["check-doc-snippets"]}
+blazesym-dev = {path = "../dev"}
 bindgen = {version = "0.72", default-features = false, features = ["runtime"]}
 criterion = {version = "0.8", default-features = false, features = ["rayon", "cargo_bench_support"]}
 tempfile = {version = "3", default-features = false}

--- a/capi/benches/capi.rs
+++ b/capi/benches/capi.rs
@@ -11,10 +11,9 @@ macro_rules! bench_fn {
 
 mod normalize;
 
-use std::time::Duration;
-
 use criterion::criterion_group;
 use criterion::criterion_main;
+use criterion::measurement::Measurement;
 use criterion::Criterion;
 
 
@@ -26,13 +25,19 @@ fn bench_fn_name(name: &str) -> String {
 }
 
 
-fn benchmark(c: &mut Criterion) {
+fn benchmark<M>(c: &mut Criterion<M>)
+where
+    M: Measurement,
+{
     let mut group = c.benchmark_group("capi");
-    group.warm_up_time(Duration::from_secs(1));
     group.confidence_level(0.98);
     group.significance_level(0.02);
     normalize::benchmark(&mut group);
 }
 
-criterion_group!(benches, benchmark);
+criterion_group!(
+    name = benches;
+    config = blazesym_dev::criterion_config();
+    targets = benchmark
+);
 criterion_main!(benches);

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -13,6 +13,9 @@ path = "lib.rs"
 [features]
 # Enable this feature to enable support for zstd decompression.
 zstd = ["dep:zstd"]
+# Enable this feature to benchmark instructions instead of wall clock
+# time. Only applicable on Linux.
+bench-instrs = []
 # Enable this feature to opt in to the generation of unit test files.
 # Having these test files created is necessary for running tests.
 generate-unit-test-files = [
@@ -49,10 +52,15 @@ libbpf-sys = {version = "1.7", default-features = false, optional = true}
 #       widespread (enabled by default in `ld`). Remove conditionals in
 #       test code alongside.
 blazesym = {path = "../", features = ["apk", "breakpad", "gsym", "tracing", "test", "xz"]}
+criterion = {version = "0.8", default-features = false, features = ["rayon", "cargo_bench_support"]}
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = "0.26"
+
+# `perf-event` doesn't build on 32 bit.
+[target.'cfg(all(target_os = "linux", target_pointer_width = "64"))'.dependencies]
+perf-event = "0.4"
 
 [lints]
 workspace = true

--- a/dev/criterion.rs
+++ b/dev/criterion.rs
@@ -1,0 +1,134 @@
+//! A `criterion` [`Measurement`] that counts retired CPU instructions
+//! instead of measuring wall-clock time.
+
+use std::time::Duration;
+
+use criterion::Criterion;
+
+
+#[cfg(all(linux, target_pointer_width = "64", feature = "bench-instrs"))]
+mod linux {
+    use criterion::measurement::Measurement;
+    use criterion::measurement::ValueFormatter;
+    use criterion::Throughput;
+
+    use perf_event::events::Hardware;
+    use perf_event::Builder;
+    use perf_event::Counter;
+
+
+    /// A `criterion` measurement reporting the number of retired (user space)
+    /// instructions executed by the benchmarked code.
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct InstructionCount;
+
+    impl Measurement for InstructionCount {
+        type Intermediate = Counter;
+        type Value = u64;
+
+        fn start(&self) -> Self::Intermediate {
+            // The `perf_event` crate excludes kernel and hypervisor events by
+            // default, i.e., we only count user space instructions. That keeps
+            // results reproducible and works without elevated privileges.
+            let mut counter = Builder::new().kind(Hardware::INSTRUCTIONS).build().expect(
+                "failed to create instruction counter via `perf_event_open(2)`; ensure it \
+             is supported and `/proc/sys/kernel/perf_event_paranoid` is <= 2",
+            );
+            let () = counter
+                .enable()
+                .expect("failed to enable instruction counter");
+            counter
+        }
+
+        fn end(&self, mut counter: Self::Intermediate) -> Self::Value {
+            let () = counter
+                .disable()
+                .expect("failed to disable instruction counter");
+            counter.read().expect("failed to read instruction counter")
+        }
+
+        fn add(&self, v1: &Self::Value, v2: &Self::Value) -> Self::Value {
+            *v1 + *v2
+        }
+
+        fn zero(&self) -> Self::Value {
+            0
+        }
+
+        fn to_f64(&self, value: &Self::Value) -> f64 {
+            *value as f64
+        }
+
+        fn formatter(&self) -> &dyn ValueFormatter {
+            &InstructionCountFormatter
+        }
+    }
+
+
+    /// The [`ValueFormatter`] for [`InstructionCount`].
+    struct InstructionCountFormatter;
+
+    impl ValueFormatter for InstructionCountFormatter {
+        fn scale_values(&self, typical_value: f64, values: &mut [f64]) -> &'static str {
+            let (factor, unit) = if typical_value < 10f64.powi(3) {
+                (10f64.powi(0), " instr")
+            } else if typical_value < 10f64.powi(6) {
+                (10f64.powi(-3), "Kinstr")
+            } else if typical_value < 10f64.powi(9) {
+                (10f64.powi(-6), "Minstr")
+            } else {
+                (10f64.powi(-9), "Ginstr")
+            };
+
+            for val in values {
+                *val *= factor;
+            }
+            unit
+        }
+
+        fn scale_throughputs(
+            &self,
+            _typical_value: f64,
+            throughput: &Throughput,
+            values: &mut [f64],
+        ) -> &'static str {
+            // Report throughput as the number of instructions spent per
+            // processed unit; fewer instructions per unit is better.
+            let (count, unit) = match *throughput {
+                Throughput::Bits(n) => (n as f64, "instr/bit"),
+                Throughput::Bytes(n) | Throughput::BytesDecimal(n) => (n as f64, "instr/byte"),
+                Throughput::Elements(n) => (n as f64, "instr/elem"),
+                Throughput::ElementsAndBytes { elements, .. } => (elements as f64, "instr/elem"),
+            };
+
+            for val in values {
+                *val /= count;
+            }
+            unit
+        }
+
+        fn scale_for_machines(&self, _values: &mut [f64]) -> &'static str {
+            "instr"
+        }
+    }
+}
+
+/// Provide a `criterion` configuration that measures instructions
+/// counts instead of wall clock time.
+#[cfg(all(linux, target_pointer_width = "64", feature = "bench-instrs"))]
+pub fn config() -> Criterion<linux::InstructionCount> {
+    use linux::*;
+
+    Criterion::default()
+        .warm_up_time(Duration::from_millis(100))
+        // Instruction sampling has extremely low noise. Go with the minimum
+        // amount of samples.
+        .sample_size(10)
+        .with_measurement(InstructionCount)
+}
+
+/// Provide a default `criterion` configuration.
+#[cfg(not(all(linux, target_pointer_width = "64", feature = "bench-instrs")))]
+pub fn config() -> Criterion {
+    Criterion::default().warm_up_time(Duration::from_secs(1))
+}

--- a/dev/lib.rs
+++ b/dev/lib.rs
@@ -1,5 +1,7 @@
 //! Supporting dev-only functionality for `blazesym`.
 
+mod criterion;
+
 #[cfg(linux)]
 mod bpf {
     use std::path::Path;
@@ -117,3 +119,5 @@ mod bpf {
 
 #[cfg(linux)]
 pub use bpf::*;
+
+pub use crate::criterion::config as criterion_config;


### PR DESCRIPTION
Wall clock time is an inherently noisy metric, all the more so on the shared GitHub runners that we use for benchmarking and which do not provide a stable performance baseline to begin with. The number of retired instructions, by contrast, is largely deterministic and makes performance changes much easier to spot (in fact, it's what rustc decided to use for that very reason [0]).

Allow the Criterion based benchmarks to count (user space) retired instructions via perf_event_open(2) when the bench-instrs feature is enabled. Criterion allows for plugging in custom measurements through its Measurement trait, but the trait is tied to a specific Criterion version and none of the existing plugin crates (criterion-perf-events, criterion-linux-perf) are compatible with the 0.8 release that we use. Provide a small Measurement implementation of our own, backed by the perf-event crate instead.

Counting is restricted to user space events. That keeps results reproducible and, as the perf-event crate excludes kernel and hypervisor events by default, works without elevated privileges as long as perf_event_paranoid is <= 2. Our benchmark runner invokes the binaries as root anyway, so no additional system configuration is required.

Note that this only concerns the Criterion based benchmarks. The libtest style #[bench] functions are a separate harness and continue to report wall clock time per iteration.

[0]: https://hackmd.io/sH315lO2RuicY-SEt7ynGA