### PR TITLE
Remove --cfg has_large_test_files flag from benchmarking notes

### DIFF
--- a/README-devel.md
+++ b/README-devel.md
@@ -56,14 +56,14 @@ To run the benchmark suite, use:
 ```sh
 # Perform one-time setup of required data.
 $ cargo check --package blazesym-dev --features=generate-large-test-files
-$ RUSTFLAGS='--cfg has_large_test_files' cargo bench --features=nightly
+$ cargo bench --features=nightly
 ```
 
 By default benchmarks measure wall clock time. On Linux we also support
 reporting instruction counts (for Criterion based benchmarks) instead.
 To enable that, use the feature `bench-instrs`:
 ```sh
-$ RUSTFLAGS='--cfg has_large_test_files' cargo bench features=nightly,blazesym-dev/bench-instrs
+$ cargo bench features=nightly,blazesym-dev/bench-instrs
 ```
 
 Some benchmarks require the `PROCMAP_QUERY` ioctl kernel functionality,


### PR DESCRIPTION
Multiple of our benchmarks assume our large kernel debug information image to be present and none actually honors the has_large_test_files configuration -- it's only a test that does that. Make sure to adjust the documentation accordingly.