### PR TITLE
Remove dependency on `memoffset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,6 @@ dependencies = [
  "cbindgen",
  "criterion",
  "libc",
- "memoffset",
  "tempfile",
  "test-log",
  "test-tag",
@@ -1591,15 +1590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -72,8 +72,6 @@ which = {version = "8", optional = true}
 # Pinned, because we use #[doc(hidden)] APIs.
 blazesym = {version = ">=0.2.0, <=0.2.5", path = "../", features = ["apk", "demangle", "gsym", "tracing", "zlib"]}
 libc = "0.2"
-# TODO: Remove dependency once MSRV is 1.77.
-memoffset = "0.9"
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", default-features = false, features = ["fmt"]}
 

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -40,7 +40,7 @@ macro_rules! input_zeroed {
         if user_size < std::mem::size_of_val(&user_size) {
             false
         } else {
-            let effective_size = memoffset::offset_of!($container_ty, reserved);
+            let effective_size = core::mem::offset_of!($container_ty, reserved);
             unsafe {
                 crate::util::is_mem_zero(
                     $container_ptr.cast::<u8>().add(effective_size),


### PR DESCRIPTION
Hi, I may or may not have used your crate but I'd like to say a quick thank you for it anyway!
I'm going down the list of reverse dependencies on `memoffset`.

This PR aims to remove the `memoffset` crate from your dependencies.
[`core::mem::offset_of`](https://doc.rust-lang.org/core/mem/macro.offset_of.html) was stabilised in rustc 1.77 which I believe is at or below your MSRV.

The `memoffset` crate 0.9.1 says that

> If you're using a rustc version greater or equal to 1.77,
> this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

I consider it very unlikely (see [here](https://github.com/rust-lang/rust/issues/111839)) for any usage of the `offset_of!` macro to break but please check anyway.
I hope we can all enjoy the benefits of one less dependency :)
