### PR TITLE
elf: Only match sizeless .dynsym symbols on exact addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Adjusted ELF symbolization to report sizeless `.dynsym` entries only on
+  exact address matches
+
+
 0.2.5
 -----
 - Improved DWARF symbolization performance for some debug info variants

--- a/data/test-so.c
+++ b/data/test-so.c
@@ -9,6 +9,19 @@ int the_answer(void) {
   return 42;
 }
 
+/* A function defined in assembly without a `.size` directive, as could
+ * appear in hand-written assembly. Its symbol ends up in `.dynsym` with
+ * `st_size == 0`.
+ */
+__asm__(
+    ".globl sizeless_fn\n"
+    ".type sizeless_fn, @function\n"
+    "sizeless_fn:\n"
+    "  nop\n"
+    "  nop\n"
+    "  nop\n"
+    "  ret\n");
+
 int the_ignored_answer(void) {
   return 43;
 }

--- a/src/elf/parser.rs
+++ b/src/elf/parser.rs
@@ -145,11 +145,21 @@ fn symbol_name<'elf>(strtab: &'elf [u8], sym: &Elf64_Sym) -> Result<&'elf str> {
     Ok(name)
 }
 
+/// The flavor of ELF symbol table that a lookup is served from.
+#[derive(Clone, Copy)]
+enum SymTab {
+    /// The regular symbol table (`.symtab`).
+    Symtab,
+    /// The dynamic symbol table (`.dynsym`).
+    Dynsym,
+}
+
 fn find_sym<'elf>(
     syms: &ElfN_Syms<'_>,
     module: Option<&'elf OsStr>,
     by_addr_idx: &[usize],
     strtab: &'elf [u8],
+    table: SymTab,
     addr: Addr,
     type_: SymType,
 ) -> Result<Option<ResolvedSym<'elf>>> {
@@ -174,12 +184,27 @@ fn find_sym<'elf>(
                 }
 
                 // In ELF, a symbol size of 0 indicates "no size or an unknown
-                // size" (see elf(5)). We take our chances and report these on a
-                // best-effort basis.
-                if sym.matches(type_)
-                    && sym.st_shndx != SHN_UNDEF
-                    && (sym.st_size == 0 || addr < sym.st_value + sym.st_size)
-                {
+                // size" (see elf(5)).
+                let matches_addr = if sym.st_size == 0 {
+                    match table {
+                        // For the regular symbol table we take our chances and
+                        // report such symbols for any address at or past their
+                        // value on a best-effort basis; the next symbol bounds
+                        // the reported range.
+                        SymTab::Symtab => true,
+                        // The dynamic symbol table is often sparse relative to
+                        // the contained code. Extending a sizeless symbol up
+                        // to the next entry can attribute large swaths of
+                        // unrelated code to it, resulting in confidently
+                        // reported but wrong symbol names. Hence, only report
+                        // sizeless symbols on exact address matches here.
+                        SymTab::Dynsym => addr == sym.st_value,
+                    }
+                } else {
+                    addr < sym.st_value + sym.st_size
+                };
+
+                if sym.matches(type_) && sym.st_shndx != SHN_UNDEF && matches_addr {
                     let sym = ResolvedSym {
                         name: symbol_name(strtab, &sym)?,
                         module,
@@ -955,6 +980,7 @@ where
                 module,
                 symtab_by_addr_idx,
                 &symtab.strs,
+                SymTab::Symtab,
                 sym.value(),
                 // SANITY: We filter out all unsupported symbol types,
                 //         so this conversion should always succeed.
@@ -1496,6 +1522,7 @@ where
             self.module.as_deref(),
             symtab_by_addr_idx,
             &symtab_cache.strs,
+            SymTab::Symtab,
             addr,
             SymType::Undefined,
         )? {
@@ -1509,6 +1536,7 @@ where
             self.module.as_deref(),
             dynsym_by_addr_idx,
             &dynsym_cache.strs,
+            SymTab::Dynsym,
             addr,
             SymType::Undefined,
         )? {
@@ -2050,8 +2078,19 @@ mod tests {
         ]));
         let by_addr_idx = [2, 1, 0];
 
-        let result = find_sym(&syms, None, &by_addr_idx, strs, 0x10d20, SymType::Function).unwrap();
-        assert_eq!(result, None);
+        for table in [SymTab::Symtab, SymTab::Dynsym] {
+            let result = find_sym(
+                &syms,
+                None,
+                &by_addr_idx,
+                strs,
+                table,
+                0x10d20,
+                SymType::Function,
+            )
+            .unwrap();
+            assert_eq!(result, None);
+        }
     }
 
     /// Check that we report a symbol with an unknown `st_size` value is
@@ -2060,28 +2099,66 @@ mod tests {
     fn lookup_symbol_with_unknown_size() {
         fn test(syms: &ElfN_Syms<'_>, by_addr_idx: &[usize]) {
             let strs = b"\x00__libc_init_first\x00versionsort64\x00";
-            let sym = find_sym(syms, None, by_addr_idx, strs, 0x29d00, SymType::Function)
+            for table in [SymTab::Symtab, SymTab::Dynsym] {
+                let sym = find_sym(
+                    syms,
+                    None,
+                    by_addr_idx,
+                    strs,
+                    table,
+                    0x29d00,
+                    SymType::Function,
+                )
                 .unwrap()
                 .unwrap();
+                assert_eq!(sym.name, "__libc_init_first");
+                assert_eq!(sym.addr, 0x29d00);
+                assert_eq!(sym.size, None);
+            }
+
+            // For a regular symbol table, because the symbol has a size
+            // of 0 and is the only conceivable match, we report it on
+            // the basis that ELF reserves these for "no size or an
+            // unknown size" cases.
+            let sym = find_sym(
+                syms,
+                None,
+                by_addr_idx,
+                strs,
+                SymTab::Symtab,
+                0x29d90,
+                SymType::Function,
+            )
+            .unwrap()
+            .unwrap();
             assert_eq!(sym.name, "__libc_init_first");
             assert_eq!(sym.addr, 0x29d00);
             assert_eq!(sym.size, None);
 
-            // Because the symbol has a size of 0 and is the only conceivable
-            // match, we report it on the basis that ELF reserves these for "no
-            // size or an unknown size" cases.
-            let sym = find_sym(syms, None, by_addr_idx, strs, 0x29d90, SymType::Function)
-                .unwrap()
-                .unwrap();
-            assert_eq!(sym.name, "__libc_init_first");
-            assert_eq!(sym.addr, 0x29d00);
-            assert_eq!(sym.size, None);
+            // For the dynamic symbol table, sizeless symbols are only reported
+            // on exact address matches, because the table may be sparse
+            // relative to the contained code and an extended match could
+            // attribute unrelated code to the symbol.
+            let result = find_sym(
+                syms,
+                None,
+                by_addr_idx,
+                strs,
+                SymTab::Dynsym,
+                0x29d90,
+                SymType::Function,
+            )
+            .unwrap();
+            assert_eq!(result, None);
 
             // Note that despite of the first symbol (the invalid one; present
             // by default and reserved by ELF), is not being reported here
             // because it has an `st_shndx` value of `SHN_UNDEF`.
-            let result = find_sym(syms, None, by_addr_idx, strs, 0x1, SymType::Function).unwrap();
-            assert_eq!(result, None);
+            for table in [SymTab::Symtab, SymTab::Dynsym] {
+                let result =
+                    find_sym(syms, None, by_addr_idx, strs, table, 0x1, SymType::Function).unwrap();
+                assert_eq!(result, None);
+            }
         }
 
         let syms = ElfN_Syms::B64(Cow::Borrowed(&[

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -598,6 +598,48 @@ fn symbolize_elf_stripped() {
     assert_eq!(result, Symbolized::Unknown(Reason::MissingSyms));
 }
 
+/// Check that a sizeless symbol from the dynamic symbol table is only
+/// reported when an address matches its value exactly.
+#[tag(other_os)]
+#[test]
+fn symbolize_elf_dynsym_sizeless() {
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("libtest-so-stripped.so");
+
+    let isrc = inspect::source::Source::Elf(inspect::source::Elf::new(&path));
+    let inspector = inspect::Inspector::new();
+    let results = inspector
+        .lookup(&isrc, &["sizeless_fn"])
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
+    let addr = results[0].addr;
+
+    let src = Source::Elf(Elf::new(&path));
+    let symbolizer = Symbolizer::new();
+
+    // An address matching the sizeless symbol's value exactly is
+    // reported.
+    let sym = symbolizer
+        .symbolize_single(&src, Input::VirtOffset(addr))
+        .unwrap()
+        .into_sym()
+        .unwrap();
+    assert_eq!(sym.name, "sizeless_fn");
+    assert_eq!(sym.addr, addr);
+    assert_eq!(sym.size, None);
+
+    // An address past the symbol's value is not attributed to it,
+    // because with a size of 0 the symbol's extent is unknown.
+    let result = symbolizer
+        .symbolize_single(&src, Input::VirtOffset(addr + 1))
+        .unwrap();
+    assert_eq!(result, Symbolized::Unknown(Reason::MissingSyms));
+}
+
 /// Make sure that we can symbolize data from a compressed
 /// `.gnu_debugdata` section.
 #[tag(other_os)]


### PR DESCRIPTION
`find_sym()` reports a symbol with `st_size == 0` for any address at or past its `st_value`, bounded only by the next symbol in the table. For `.symtab` that is a reasonable best-effort heuristic: when present, it describes the code in the file reasonably completely, so the gap between a sizeless symbol and the next entry is typically just that symbol's body (hand-written assembly lacking a `.size` directive, and similar).

For `.dynsym` the assumption does not hold. It describes the dynamic linking interface, not the code layout, and in binaries whose regular symbol table has been stripped it is often extremely sparse relative to the contained code. Go binaries built with cgo are a prominent example (system components such as kubelet are shipped this way on some platforms): a handful of surviving exports over many megabytes of code. If any surviving entry is sizeless — assembly routines without `.size`, or marker symbols such as `runtime.text` — every address in the potentially huge gap following it is confidently attributed to that symbol. A profiler symbolizing such a binary reports wrong symbol names rather than honest misses, which is arguably worse than no data: the output looks healthy.

## Reproduction

A stripped cgo Go binary whose `.dynsym` ends up with four defined `FUNC` entries, one of them a sizeless assembly stub (`.type ... @function` but no `.size`):

```
   48: 00000000004a01a9     0 FUNC    GLOBAL DEFAULT   15 early_asm_stub
   49: 0000000000488760    45 FUNC    GLOBAL DEFAULT   15 _cgo_panic
   50: 0000000000480f80    25 FUNC    GLOBAL DEFAULT   15 _cgo_topofstack
   51: 00000000004887e0   104 FUNC    GLOBAL DEFAULT   15 crosscall2
```

Before this change (`blazecli symbolize elf`; ground truth from the unstripped twin of the same binary):

```
0x4a01d0: early_asm_stub @ 0x4a01a9+0x27      <- actually x_cgo_clearenv
0x4a0ca0: early_asm_stub @ 0x4a01a9+0xaf7     <- actually _cgo_libc_setuid
0x600000: early_asm_stub @ 0x4a01a9+0x15fe57  <- 1.4 MiB past the stub, beyond .text entirely
```

After:

```
0x4a01a9: early_asm_stub @ 0x4a01a9+0x0       (exact match still reported)
0x4a01d0: <no-symbol>
0x4a0ca0: <no-symbol>
0x600000: <no-symbol>
0x488770: _cgo_panic @ 0x488760+0x10          (sized entries unaffected)
```

<details>
<summary>Reproduction script</summary>

```sh
cat > stub.s <<'ASM'
	.text
	.globl	early_asm_stub
	.type	early_asm_stub, @function
early_asm_stub:
	ret
/* deliberately no .size directive -> st_size stays 0 */
ASM
cat > main.go <<'GO'
package main

/*
extern void early_asm_stub(void);
*/
import "C"

func main() {
	C.early_asm_stub()
}
GO
cat > go.mod <<'MOD'
module repro

go 1.26
MOD
go build -ldflags='-linkmode=external -extldflags "-Wl,--no-export-dynamic -Wl,--export-dynamic-symbol=early_asm_stub"' -o repro .
cp repro repro-stripped && strip --strip-all repro-stripped
readelf -W --dyn-syms repro-stripped | awk '$7!="UND" && $4=="FUNC"'
# pick any address past the sizeless stub and compare:
#   blazecli symbolize elf --path repro-stripped <addr>
# against the unstripped twin:
#   blazecli symbolize elf --path repro <addr>
```
</details>

## Why exact-match-only is the right line for `.dynsym`

Sizeless defined function symbols are essentially extinct in `.dynsym` in practice: across 39 common libraries of a current Linux distribution I count 42 of 330540 defined `FUNC` entries with `st_size == 0` (0.013%), every one of them a compiler-emitted stub (`_init`, `_fini`, `register_tm_clones`, `frame_dummy`, ...). There is essentially nothing left for the stretch heuristic to help with in `.dynsym`, and plenty for it to corrupt. Restricting sizeless `.dynsym` matches to exact address hits therefore loses essentially nothing.

`.symtab` behavior is unchanged: the `__libc_init_first`-style case remains covered (`lookup_symbol_with_unknown_size` now pins both semantics), and kallsyms-based kernel symbolization is a separate code path that is untouched.
