### PR TITLE
Add Symbolizer::evict() for evicting cached data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ----------
 - Adjusted ELF symbolization to report sizeless `.dynsym` entries only on
   exact address matches
+- Added `symbolize::Symbolizer::evict` method for evicting cached data
 
 
 0.2.5

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::cell::OnceCell;
+use std::cell::RefCell;
 use std::fs::File;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -43,6 +44,12 @@ impl From<&libc::stat> for FileMeta {
 
 #[derive(Debug)]
 struct Entry<T> {
+    /// The number of paths referencing this entry.
+    ///
+    /// An entry can be referenced by multiple paths, e.g., when
+    /// symbolic or hard links resolve to the same file, or when it
+    /// captures a previous version of a path's file contents.
+    references: Cell<usize>,
     file: File,
     value: OnceCell<T>,
 }
@@ -50,6 +57,7 @@ struct Entry<T> {
 impl<T> Entry<T> {
     fn new(file: File) -> Self {
         Self {
+            references: Cell::new(0),
             file,
             value: OnceCell::new(),
         }
@@ -67,12 +75,34 @@ enum PinState {
 struct PathEntry {
     /// Meta data corresponding to the most recently inserted entry.
     current: Cell<Option<(PinState, FileMeta)>>,
+    /// Meta data corresponding to previously current entries, as can
+    /// accumulate when the underlying file changed and was reloaded.
+    previous: RefCell<Vec<FileMeta>>,
+}
+
+impl PathEntry {
+    /// Retrieve the meta data of all distinct entries associated with
+    /// this path.
+    ///
+    /// The current entry may also be contained in the set of previous
+    /// ones (e.g., after a symbolic link switched to a different
+    /// target and back); it is reported only once.
+    fn metas(&self) -> Vec<FileMeta> {
+        let mut metas = self.previous.borrow().clone();
+        if let Some((_pin_state, meta)) = self.current.get() {
+            if !metas.contains(&meta) {
+                let () = metas.push(meta);
+            }
+        }
+        metas
+    }
 }
 
 impl Default for PathEntry {
     fn default() -> Self {
         Self {
             current: Cell::new(None),
+            previous: RefCell::new(Vec::new()),
         }
     }
 }
@@ -127,7 +157,8 @@ impl<T> Default for Builder<T> {
 /// The cache transparently checks whether the file contents have
 /// changed based on file system meta data and creates and hands out a
 /// new entry if so.
-/// Note that stale/old entries are never evicted.
+/// Note that stale/old entries are only removed on explicit request
+/// (see [`FileCache::evict`]).
 #[derive(Debug)]
 pub(crate) struct FileCache<T> {
     /// The map we use for associating a path with file meta data.
@@ -160,6 +191,23 @@ impl<T> FileCache<T> {
             let entry = Entry::new(file);
             Ok(entry)
         })?;
+        let current = path_entry.current.get();
+        // If the entry current for the path changed (or none was
+        // present), there is bookkeeping to do: preserve the meta data
+        // of the previously current entry and account for the
+        // reference to the new entry that the path gains, unless the
+        // path already references it as one of its previous entries.
+        if current.is_none_or(|(_pin_state, current_meta)| current_meta != meta.1) {
+            let mut previous = path_entry.previous.borrow_mut();
+            if let Some((_pin_state, previous_meta)) = current {
+                if !previous.contains(&previous_meta) {
+                    let () = previous.push(previous_meta);
+                }
+            }
+            if !previous.contains(&meta.1) {
+                let () = entry.references.set(entry.references.get() + 1);
+            }
+        }
         let () = path_entry.current.set(Some(meta));
 
         Ok(entry)
@@ -203,6 +251,38 @@ impl<T> FileCache<T> {
 
     pub(crate) fn unpin(&self, path: &Path) -> Option<()> {
         self.set_pin_state(path, PinState::Unpinned)
+    }
+
+    /// Evict all data cached for the file at the given `path`,
+    /// including any stale data for previous versions of the file.
+    ///
+    /// Data also reachable through another path (e.g., by way of
+    /// symbolic links resolving to the same file) is only removed once
+    /// the last referencing path has been evicted.
+    ///
+    /// Returns `true` if any data was evicted.
+    // TODO: Remove this `allow` once the consumer landed.
+    #[allow(dead_code)]
+    pub(crate) fn evict(&mut self, path: &Path) -> bool {
+        let Some(path_entry) = self.cache.remove(path) else {
+            return false
+        };
+
+        let mut evicted = false;
+        for meta in path_entry.metas() {
+            // SANITY: Our invariant states that every meta data object
+            //         referenced by a path has a corresponding entry.
+            let entry = self.entries.get(&meta).unwrap();
+            let references = entry.references.get();
+            debug_assert_ne!(references, 0);
+            if references > 1 {
+                let () = entry.references.set(references - 1);
+            } else {
+                let _entry = self.entries.remove(&meta);
+                evicted = true;
+            }
+        }
+        evicted
     }
 
     /// Retrieve the total number of entries in the cache.
@@ -274,6 +354,142 @@ mod tests {
             let (_file, cell) = cache.entry(tmpfile.path()).unwrap();
             assert_eq!(cell.get(), Some(&42));
         }
+    }
+
+    /// Check that we can evict data associated with a file.
+    #[test]
+    fn evict_entry() {
+        let mut cache = FileCache::<usize>::default();
+        let tmpfile = NamedTempFile::new().unwrap();
+
+        // Evicting an unknown path is a no-op.
+        assert!(!cache.evict(Path::new("/does/not/exist")));
+
+        {
+            let (_file, cell) = cache.entry(tmpfile.path()).unwrap();
+            let () = cell.set(42).unwrap();
+        }
+        assert_eq!(cache.entry_count(), 1);
+
+        assert!(cache.evict(tmpfile.path()));
+        assert_eq!(cache.entry_count(), 0);
+
+        // Another eviction of the same path is a no-op.
+        assert!(!cache.evict(tmpfile.path()));
+
+        // A subsequent look up transparently creates a new entry.
+        {
+            let (_file, cell) = cache.entry(tmpfile.path()).unwrap();
+            assert_eq!(cell.get(), None);
+        }
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    /// Check that eviction removes stale entries for previous versions
+    /// of a file as well.
+    #[test]
+    fn evict_stale_entries() {
+        let mut cache = FileCache::<usize>::default();
+        let tmpfile = NamedTempFile::new().unwrap();
+
+        {
+            let (_file, cell) = cache.entry(tmpfile.path()).unwrap();
+            let () = cell.set(42).unwrap();
+        }
+
+        // Sleep briefly to make sure that file times will end up being
+        // different.
+        let () = sleep(Duration::from_millis(10));
+
+        let path = tmpfile.path().to_path_buf();
+        let () = drop(tmpfile);
+        let () = write(&path, b"foobar").unwrap();
+
+        {
+            let (_file, cell) = cache.entry(&path).unwrap();
+            assert_eq!(cell.get(), None);
+            let () = cell.set(43).unwrap();
+        }
+        // Both the current and the stale entry should be present.
+        assert_eq!(cache.entry_count(), 2);
+
+        assert!(cache.evict(&path));
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    /// Check that eviction does not remove entries still referenced by
+    /// another path.
+    #[cfg(linux)]
+    #[test]
+    fn evict_shared_entry() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        let tmpdir = tempdir().unwrap();
+        let link = tmpdir.path().join("symlink");
+        let () = symlink(tmpfile.path(), &link).unwrap();
+
+        let mut cache = FileCache::<usize>::default();
+        {
+            let (_file, cell) = cache.entry(tmpfile.path()).unwrap();
+            let () = cell.set(42).unwrap();
+        }
+        // The link resolves to the same entry.
+        {
+            let (_file, cell) = cache.entry(&link).unwrap();
+            assert_eq!(cell.get(), Some(&42));
+        }
+        assert_eq!(cache.entry_count(), 1);
+
+        // Evicting one path keeps the entry alive for the other one.
+        assert!(!cache.evict(tmpfile.path()));
+        assert_eq!(cache.entry_count(), 1);
+        {
+            let (_file, cell) = cache.entry(&link).unwrap();
+            assert_eq!(cell.get(), Some(&42));
+        }
+
+        // Evicting the last referencing path removes the entry.
+        assert!(cache.evict(&link));
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    /// Check that eviction handles a path whose current entry had been
+    /// superseded and then got reinstated (e.g., by way of a symbolic
+    /// link switching to a different target and back), referencing
+    /// each entry only once.
+    #[cfg(linux)]
+    #[test]
+    fn evict_reinstated_entry() {
+        let tmpfile1 = NamedTempFile::new().unwrap();
+        let tmpfile2 = NamedTempFile::new().unwrap();
+        let tmpdir = tempdir().unwrap();
+        let link = tmpdir.path().join("symlink");
+        let () = symlink(tmpfile1.path(), &link).unwrap();
+
+        let mut cache = FileCache::<usize>::default();
+        {
+            let (_file, cell) = cache.entry(&link).unwrap();
+            let () = cell.set(41).unwrap();
+        }
+
+        // Point the link at a different file and then back at the
+        // original one.
+        let () = remove_file(&link).unwrap();
+        let () = symlink(tmpfile2.path(), &link).unwrap();
+        {
+            let (_file, cell) = cache.entry(&link).unwrap();
+            let () = cell.set(42).unwrap();
+        }
+        let () = remove_file(&link).unwrap();
+        let () = symlink(tmpfile1.path(), &link).unwrap();
+        {
+            let (_file, cell) = cache.entry(&link).unwrap();
+            assert_eq!(cell.get(), Some(&41));
+        }
+        assert_eq!(cache.entry_count(), 2);
+
+        // Eviction removes both the current and the superseded entry.
+        assert!(cache.evict(&link));
+        assert_eq!(cache.entry_count(), 0);
     }
 
     /// Check that our `FileCache` deduplicates symbolic link targets

--- a/src/file_cache.rs
+++ b/src/file_cache.rs
@@ -261,8 +261,6 @@ impl<T> FileCache<T> {
     /// the last referencing path has been evicted.
     ///
     /// Returns `true` if any data was evicted.
-    // TODO: Remove this `allow` once the consumer landed.
-    #[allow(dead_code)]
     pub(crate) fn evict(&mut self, path: &Path) -> bool {
         let Some(path_entry) = self.cache.remove(path) else {
             return false

--- a/src/insert_map.rs
+++ b/src/insert_map.rs
@@ -93,6 +93,19 @@ impl<K, V> InsertMap<K, V> {
         }
     }
 
+    /// Remove the value mapping to a key, if any.
+    ///
+    /// Removal requires exclusive access to the map, which statically
+    /// guarantees that no references to values handed out earlier are
+    /// still alive.
+    pub(crate) fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Eq + Hash + Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        self.map.get_mut().remove(key).map(|boxed| *boxed)
+    }
+
     /// Retrieve the number of elements in the map.
     #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
@@ -121,6 +134,22 @@ mod tests {
     use crate::Error;
     use crate::ErrorKind;
 
+
+    /// Check that value removal works as it should.
+    #[tag(miri)]
+    #[test]
+    fn removal() {
+        let mut map = InsertMap::<usize, &'static str>::new();
+        assert_eq!(map.remove(&42), None);
+
+        let _s = map.get_or_insert(42, || "you win the price");
+        let _s = map.get_or_insert(43, || "you win nothing");
+        assert_eq!(map.len(), 2);
+
+        assert_eq!(map.remove(&42), Some("you win the price"));
+        assert_eq!(map.get(&42), None);
+        assert_eq!(map.len(), 1);
+    }
 
     /// Check that value insertion works as it should.
     #[tag(miri)]

--- a/src/insert_map.rs
+++ b/src/insert_map.rs
@@ -106,6 +106,18 @@ impl<K, V> InsertMap<K, V> {
         self.map.get_mut().remove(key).map(|boxed| *boxed)
     }
 
+    /// Retain only the entries for which `f` returns `true`.
+    ///
+    /// Removal requires exclusive access to the map, which statically
+    /// guarantees that no references to values handed out earlier are
+    /// still alive.
+    pub(crate) fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&K, &V) -> bool,
+    {
+        self.map.get_mut().retain(|key, value| f(key, &**value))
+    }
+
     /// Retrieve the number of elements in the map.
     #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
@@ -149,6 +161,20 @@ mod tests {
         assert_eq!(map.remove(&42), Some("you win the price"));
         assert_eq!(map.get(&42), None);
         assert_eq!(map.len(), 1);
+    }
+
+    /// Check that selective retention of values works as it should.
+    #[tag(miri)]
+    #[test]
+    fn retention() {
+        let mut map = InsertMap::<usize, &'static str>::new();
+        let _s = map.get_or_insert(42, || "you win the price");
+        let _s = map.get_or_insert(43, || "you win nothing");
+
+        let () = map.retain(|_key, value| *value != "you win nothing");
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(&43), None);
+        assert_eq!(map.get(&42), Some(&"you win the price"));
     }
 
     /// Check that value insertion works as it should.

--- a/src/symbolize/evict.rs
+++ b/src/symbolize/evict.rs
@@ -1,0 +1,133 @@
+//! Definitions of symbolization eviction targets.
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
+use std::path::PathBuf;
+
+use crate::Pid;
+
+
+/// Configuration for eviction of ELF related data.
+#[derive(Clone)]
+pub struct Elf {
+    /// The path to an ELF file.
+    pub path: PathBuf,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
+}
+
+impl Elf {
+    /// Create a new [`Elf`] object, referencing the provided path.
+    #[inline]
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<Elf> for Evict {
+    #[inline]
+    fn from(elf: Elf) -> Self {
+        Self::Elf(elf)
+    }
+}
+
+impl Debug for Elf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let Self {
+            path,
+            _non_exhaustive: (),
+        } = self;
+
+        f.debug_tuple(stringify!(Elf)).field(path).finish()
+    }
+}
+
+
+/// Configuration for eviction of process-level data.
+#[derive(Clone)]
+pub struct Process {
+    /// The referenced process' ID.
+    pub pid: Pid,
+    /// The struct is non-exhaustive and open to extension.
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
+}
+
+impl Process {
+    /// Create a new [`Process`] object using the provided `pid`.
+    #[inline]
+    pub fn new(pid: Pid) -> Self {
+        Self {
+            pid,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl Debug for Process {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let Self {
+            pid,
+            _non_exhaustive: (),
+        } = self;
+
+        f.debug_tuple(stringify!(Process))
+            .field(&format_args!("{pid}"))
+            .finish()
+    }
+}
+
+impl From<Process> for Evict {
+    #[inline]
+    fn from(process: Process) -> Self {
+        Self::Process(process)
+    }
+}
+
+
+/// A description of what previously cached data to evict.
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum Evict {
+    /// Data cached for an ELF file.
+    Elf(Elf),
+    /// Data cached for a process.
+    Process(Process),
+}
+
+impl Debug for Evict {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Elf(elf) => Debug::fmt(elf, f),
+            Self::Process(process) => Debug::fmt(process, f),
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    /// Exercise the `Debug` representation of various types.
+    #[test]
+    fn debug_repr() {
+        let elf = Elf::new("/foobar/baz");
+        assert_eq!(format!("{elf:?}"), "Elf(\"/foobar/baz\")");
+        let evict = Evict::from(elf);
+        assert_eq!(format!("{evict:?}"), "Elf(\"/foobar/baz\")");
+
+        let process = Process::new(Pid::Slf);
+        assert_eq!(format!("{process:?}"), "Process(self)");
+        let process = Process::new(Pid::from(1234));
+        assert_eq!(format!("{process:?}"), "Process(1234)");
+        let evict = Evict::from(process);
+        assert_eq!(format!("{evict:?}"), "Process(1234)");
+    }
+}

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -92,6 +92,7 @@
 //! example, which illustrates the basic workflow.
 
 pub mod cache;
+pub mod evict;
 pub mod source;
 mod symbolizer;
 

--- a/src/symbolize/symbolizer.rs
+++ b/src/symbolize/symbolizer.rs
@@ -63,6 +63,8 @@ use crate::Result;
 
 use super::cache;
 use super::cache::Cache;
+use super::evict;
+use super::evict::Evict;
 #[cfg(feature = "apk")]
 use super::source::Apk;
 #[cfg(feature = "breakpad")]
@@ -1092,6 +1094,50 @@ impl Symbolizer {
                     let parsed = maps::parse_filtered(*pid)?.collect::<Result<Box<_>>>()?;
                     let _prev = self.process_vma_cache.borrow_mut().insert(*pid, parsed);
                 }
+            }
+        }
+        Ok(())
+    }
+
+    /// Evict data cached for a symbolization source.
+    ///
+    /// This method is the counterpart of [`Symbolizer::cache`]. Data is
+    /// generally cached for the lifetime of the `Symbolizer` instance.
+    /// Long-lived instances symbolizing across a churning set of files
+    /// or processes may want to release data (as well as the file
+    /// descriptor associated with each cached file) once no longer
+    /// needed, which is what this method provides.
+    ///
+    /// This method operates on a best-effort basis, meaning that not
+    /// all data associated with a request may be released, if book
+    /// keeping/discovery is expensive.
+    ///
+    /// Evicted data will be re-created transparently should a future
+    /// symbolization request require it. It is not an error if no
+    /// cached data exists for the given target.
+    #[cfg_attr(feature = "tracing", crate::log::instrument(skip_all, fields(evict = ?evict), err))]
+    pub fn evict(&mut self, evict: &Evict) -> Result<()> {
+        match evict {
+            Evict::Elf(evict::Elf {
+                path,
+                _non_exhaustive: (),
+            }) => {
+                let _evicted = self.elf_cache.evict(path);
+                let () = self.process_cache.retain(|path_name, _resolver| {
+                    !matches!(
+                        path_name,
+                        PathName::Path(entry_path)
+                            if entry_path.maps_file == *path
+                                || entry_path.symbolic_path == *path
+                    )
+                });
+            }
+            Evict::Process(evict::Process {
+                pid,
+                _non_exhaustive: (),
+            }) => {
+                let _prev = self.process_vma_cache.get_mut().remove(pid);
+                let _evicted = self.perf_map_cache.evict(&PerfMap::path(*pid));
             }
         }
         Ok(())

--- a/tests/suite/symbolize.rs
+++ b/tests/suite/symbolize.rs
@@ -26,6 +26,7 @@ use blazesym::helper::ElfResolver;
 use blazesym::inspect;
 use blazesym::normalize;
 use blazesym::symbolize::cache;
+use blazesym::symbolize::evict;
 use blazesym::symbolize::source::Breakpad;
 use blazesym::symbolize::source::Elf;
 use blazesym::symbolize::source::GsymData;
@@ -1363,6 +1364,94 @@ fn symbolize_process_exited_cached_vmas() {
 
     // And yet, we should still be able to symbolize.
     let () = test_symbolize();
+}
+
+/// Check that we can evict cached process data.
+#[cfg(linux)]
+#[test]
+fn symbolize_process_evicted_vmas() {
+    let test_so = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("libtest-so.so");
+    let wait = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-wait.bin");
+
+    let mut symbolizer = Symbolizer::new();
+
+    let (pid, addr) = RemoteProcess::default()
+        .arg(&test_so)
+        .exec(&wait, |pid, addr| {
+            // Cache VMA information about the process while it is alive.
+            let () = symbolizer
+                .cache(&cache::Cache::from(cache::Process::new(pid)))
+                .unwrap();
+            (pid, addr)
+        });
+
+    // By now the process is guaranteed to be dead (modulo PID reuse...).
+    let mut process = Process::new(pid);
+    // We need to opt out of map file usage, because those files will no
+    // longer be present with the process having exited.
+    process.map_files = false;
+
+    let src = Source::Process(process);
+
+    // Symbolization works based on the cached VMAs, even though the
+    // process has exited.
+    let result = symbolizer
+        .symbolize_single(&src, Input::AbsAddr(addr))
+        .unwrap()
+        .into_sym()
+        .unwrap();
+    assert_eq!(result.name, "await_input");
+
+    // Evict the cached process data.
+    let () = symbolizer
+        .evict(&evict::Evict::from(evict::Process::new(pid)))
+        .unwrap();
+
+    // With the cached VMAs evicted and the process gone, symbolization
+    // can no longer succeed.
+    let err = symbolizer
+        .symbolize_single(&src, Input::AbsAddr(addr))
+        .unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+}
+
+/// Check that cached ELF data is actually released on eviction.
+#[tag(other_os)]
+#[test]
+fn symbolize_elf_evicted() {
+    let path = Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .join("data")
+        .join("test-stable-addrs-no-dwarf.bin");
+    let dir = tempdir().unwrap();
+    let elf = dir.path().join("test-stable-addrs-no-dwarf.bin");
+    let _count = copy(&path, &elf).unwrap();
+
+    let mut symbolizer = Symbolizer::new();
+    let src = Source::Elf(Elf::new(&elf));
+    let sym = symbolizer
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
+        .unwrap()
+        .into_sym()
+        .unwrap();
+    assert_eq!(sym.name, "factorial");
+
+    // Evict the cached data and remove the file. A subsequent
+    // symbolization request has nothing to work with, which would not
+    // be the case had eviction kept data (and the open file
+    // descriptor) around.
+    let () = symbolizer
+        .evict(&evict::Evict::from(evict::Elf::new(&elf)))
+        .unwrap();
+    let () = remove_file(&elf).unwrap();
+
+    let err = symbolizer
+        .symbolize_single(&src, Input::VirtOffset(0x2000200))
+        .unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::NotFound);
 }
 
 /// Check that we can symbolize an address residing in a zip archive.


### PR DESCRIPTION
Implements the eviction support discussed in #1611, following the direction from that conversation:

- new `symbolize::evict::Evict` enum (mirroring the `cache` module's structure rather than reusing `cache::Cache`, which carries caching-only metadata), consumed by a new `Symbolizer::evict(&mut self, &Evict) -> Result<()>`
- `Evict::Elf`: releases data cached for an ELF file — including stale entries left behind by `auto_reload` when the file changed — and any custom-process-dispatcher results for members backed by that file. Entries reachable through multiple paths (symbolic links resolving to the same file) are only dropped once the last referencing path is evicted.
- `Evict::Process`: releases the process' cached VMAs and perf map data.
- no `evict_all()` for now, additions on an as-needed basis
- eviction of a target with nothing cached is `Ok(())`, not an error
- C API left for a separate follow-up

`&mut self` keeps the read paths untouched (no synchronization, no accounting): symbolization results borrow the `Symbolizer`, so exclusive access statically ensures no references into cached data remain when eviction runs.

Tests: `FileCache` eviction unit tests (basic, stale generations, symlink-shared entries), `InsertMap` removal, and two integration tests — cached-VMA symbolization of an exited process failing cleanly after `Evict::Process`, and ELF symbolization transparently re-creating data after `Evict::Elf`.
