### PR TITLE
Fix Go CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -522,7 +522,6 @@ jobs:
           go-version: stable
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6
           working-directory: go
         env:
           CGO_CFLAGS: "-I${{ github.workspace }}/capi/include"


### PR DESCRIPTION
Our Go CI tests of failing due to some version mismatch between action and system, because one is pinned while the other effectively a moving target.
Make both moving targets and then hope for the best.